### PR TITLE
feat(colors)!: prefix all color variables with --post-

### DIFF
--- a/.changeset/rude-buses-shave.md
+++ b/.changeset/rude-buses-shave.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': major
+---
+
+Removed inverted class for the subnavigation which is no longer necessary when using any bg-\* class

--- a/.changeset/short-lions-deny.md
+++ b/.changeset/short-lions-deny.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': major
+---
+
+Css variables originating from the Design System are now prefixed with --post-_. Css variables from bootstrap are prefixed with --bs-_

--- a/packages/demo/src/app/bootstrap/components/background/background-demo/background-demo.component.html
+++ b/packages/demo/src/app/bootstrap/components/background/background-demo/background-demo.component.html
@@ -1,4 +1,4 @@
-<div *ngFor="let color of colorArray" class="bg-{{color}} p-2 my-1" [style]="'--bg-opacity:' + (dropOpacity ? 0.8 : 1) + ';'">
+<div *ngFor="let color of colorArray" class="bg-{{color}} p-2 my-1" [style]="'--post-bg-opacity:' + (dropOpacity ? 0.8 : 1) + ';'">
   <div class="d-flex justify-content-between align-items-center">
     <strong class="text-capitalize">{{ color }}</strong>
     <small><code>.bg-{{color}}</code></small>

--- a/packages/demo/src/app/post-sample/components/subnavigation/subnavigation-demo/subnavigation-demo.component.html
+++ b/packages/demo/src/app/post-sample/components/subnavigation/subnavigation-demo/subnavigation-demo.component.html
@@ -36,8 +36,8 @@
 
 <span class="spacer"></span>
 
-<!-- Inverted -->
-<div class="subnavigation subnavigation-inverted bg-petrol">
+<!-- Colored background -->
+<div class="subnavigation bg-petrol">
   <div class="container container-fluid-xs container-fluid-sm">
     <ul class="subnavigation-list">
       <li class="subnavigation-item">

--- a/packages/migrations/src/migrations/backgrounds/index.ts
+++ b/packages/migrations/src/migrations/backgrounds/index.ts
@@ -13,4 +13,4 @@ class TextAutoClassesUpdate extends CssClassesUpdate {
     replaceValue = '';
 }
 
-// TODO: Replace .bg-[themeColor]-opacity-80 by style="--bg-opacity: 0.8"
+// TODO: Replace .bg-[themeColor]-opacity-80 by style="--post-bg-opacity: 0.8"

--- a/packages/styles/.stylelintrc
+++ b/packages/styles/.stylelintrc
@@ -6,6 +6,7 @@
   ],
   "rules": {
     "order/properties-alphabetical-order": null,
+    "order/order": null,
     "max-nesting-depth": 5,
     "selector-max-compound-selectors": 5,
     "selector-max-id": 1,

--- a/packages/styles/src/components/accordion.scss
+++ b/packages/styles/src/components/accordion.scss
@@ -42,7 +42,6 @@
   }
 
   // style to improve hcm mode
-  /* stylelint-disable-next-line order/order */
   @include utilities.high-contrast-mode() {
     &:disabled {
       opacity: 1 !important;

--- a/packages/styles/src/components/alert.scss
+++ b/packages/styles/src/components/alert.scss
@@ -68,7 +68,7 @@
 
 @each $name, $color, $icon in alert.$alert-list {
   .alert-#{$name} {
-    --bg-rgb: #{color-fn.rgb-values($color)};
+    --post-bg-rgb: #{color-fn.rgb-values($color)};
     @extend %notification-#{$name};
 
     @if (color-fn.get-contrast-color($color) != #000) {

--- a/packages/styles/src/components/badge.scss
+++ b/packages/styles/src/components/badge.scss
@@ -51,7 +51,7 @@ button {
 
   &-input:focus-visible + &-label {
     outline-offset: forms.$input-focus-outline-thickness;
-    outline: forms.$input-focus-outline-thickness solid var(--text-color);
+    outline: forms.$input-focus-outline-thickness solid var(--post-text-color);
   }
 
   &-input:not(:checked) + &-label:hover {

--- a/packages/styles/src/components/badge.scss
+++ b/packages/styles/src/components/badge.scss
@@ -51,7 +51,7 @@ button {
 
   &-input:focus-visible + &-label {
     outline-offset: forms.$input-focus-outline-thickness;
-    outline: forms.$input-focus-outline-thickness solid var(--post-text-color);
+    outline: forms.$input-focus-outline-thickness solid var(--post-contrast-color);
   }
 
   &-input:not(:checked) + &-label:hover {

--- a/packages/styles/src/components/button-group.scss
+++ b/packages/styles/src/components/button-group.scss
@@ -21,7 +21,7 @@
     cursor: pointer;
 
     @include utilities.not-disabled-focus-hover() {
-      box-shadow: 0 0 0 0.125rem var(--contrast-color);
+      box-shadow: 0 0 0 0.125rem var(--post-contrast-color);
     }
 
     &:focus,

--- a/packages/styles/src/components/button-group.scss
+++ b/packages/styles/src/components/button-group.scss
@@ -53,7 +53,6 @@
       }
     }
 
-    /* stylelint-disable-next-line order/order */
     @include utilities.high-contrast-mode() {
       &:focus,
       &:focus-within,

--- a/packages/styles/src/components/button.scss
+++ b/packages/styles/src/components/button.scss
@@ -60,7 +60,6 @@
     }
   }
 
-  // stylelint-disable-next-line order/order
   @include color-mx.on-dark-background() {
     .pi {
       filter: invert(0);
@@ -120,7 +119,6 @@
   }
 
   // Styles  to improve accessibility in high contrast mode
-  /* stylelint-disable-next-line order/order */
   @include utilities.high-contrast-mode() {
     color: linktext;
     text-decoration: underline !important;

--- a/packages/styles/src/components/button.scss
+++ b/packages/styles/src/components/button.scss
@@ -33,7 +33,7 @@
   border-radius: button.$btn-border-radius;
   background-color: transparent;
   box-shadow: none;
-  color: var(--contrast-color);
+  color: var(--post-contrast-color);
   font-family: inherit;
   font-weight: button.$btn-font-weight;
   line-height: inherit;
@@ -44,19 +44,19 @@
 // Primary
 .btn-primary {
   border-color: transparent;
-  background-color: rgba(var(--contrast-color-rgb), 0.8);
-  color: var(--contrast-color-inverted);
+  background-color: rgba(var(--post-contrast-color-rgb), 0.8);
+  color: var(--post-contrast-color-inverted);
 
   @include utilities.not-disabled-focus-hover() {
-    background-color: var(--contrast-color);
-    color: var(--contrast-color-inverted); // Override <a> color
+    background-color: var(--post-contrast-color);
+    color: var(--post-contrast-color-inverted); // Override <a> color
   }
 
   @include color-mx.on-dark-background {
-    background-color: var(--contrast-color);
+    background-color: var(--post-contrast-color);
 
     @include utilities.not-disabled-focus-hover() {
-      background-color: rgba(var(--contrast-color-rgb), 0.8);
+      background-color: rgba(var(--post-contrast-color-rgb), 0.8);
     }
   }
 
@@ -69,7 +69,7 @@
 
   // Styles  to improve accessibility in high contrast mode
   @include utilities.high-contrast-mode() {
-    border-color: var(--contrast-color);
+    border-color: var(--post-contrast-color);
     background-color: ButtonFace;
 
     &:hover {
@@ -82,7 +82,7 @@
   }
 
   &:disabled {
-    background-color: rgba(var(--contrast-color-rgb), 0.4);
+    background-color: rgba(var(--post-contrast-color-rgb), 0.4);
   }
 
   .pi {
@@ -112,11 +112,11 @@
   padding-left: 0.375rem;
 
   @include utilities.not-disabled-focus-hover() {
-    color: rgba(var(--contrast-color-rgb), 0.8);
+    color: rgba(var(--post-contrast-color-rgb), 0.8);
   }
 
   &:disabled {
-    color: rgba(var(--contrast-color-rgb), 0.6);
+    color: rgba(var(--post-contrast-color-rgb), 0.6);
   }
 
   // Styles  to improve accessibility in high contrast mode

--- a/packages/styles/src/components/carousel.scss
+++ b/packages/styles/src/components/carousel.scss
@@ -17,7 +17,6 @@
     box-shadow: 0 0 0 2px #fff, 0 0 0 4px #000, 0 0 12px 5px rgba(0, 0, 0, 0.24);
   }
 
-  /* stylelint-disable-next-line order/order */
   @include utilities.high-contrast-mode() {
     &:focus-visible {
       border-radius: commons.$border-radius;

--- a/packages/styles/src/components/close.scss
+++ b/packages/styles/src/components/close.scss
@@ -17,7 +17,7 @@
   }
 
   &:focus {
-    outline: 2px solid var(--contrast-color);
+    outline: 2px solid var(--post-contrast-color);
     box-shadow: none;
 
     &:not(:focus-visible) {

--- a/packages/styles/src/components/datepicker.scss
+++ b/packages/styles/src/components/datepicker.scss
@@ -7,7 +7,7 @@
 
 ngb-datepicker {
   // Conversion for compatibility
-  --bs-light: var(--light);
+  --bs-light: var(--post-light);
 }
 
 ngb-datepicker.dropdown-menu {
@@ -15,7 +15,7 @@ ngb-datepicker.dropdown-menu {
 }
 
 .ngb-dp-weekday {
-  color: rgba(var(--black-rgb), 0.6) !important;
+  color: rgba(var(--post-contrast-color-rgb), 0.6) !important;
   font-size: 1rem;
   font-style: normal !important;
   line-height: 1.47 !important;

--- a/packages/styles/src/components/floating-label.scss
+++ b/packages/styles/src/components/floating-label.scss
@@ -48,7 +48,6 @@
     }
   }
 
-  /* stylelint-disable-next-line order/order */
   @include utilities-mx.high-contrast-mode() {
     > input {
       @include forms-mx.placeholder() {

--- a/packages/styles/src/components/form-check.scss
+++ b/packages/styles/src/components/form-check.scss
@@ -161,7 +161,7 @@
       background-image: escape-svg(form-switch.$form-switch-bg-image),
         form-switch.$form-switch-linear-gradient;
       box-shadow: none;
-      outline: button.$input-btn-focus-width solid var(--contrast-color, color.$black);
+      outline: button.$input-btn-focus-width solid var(--post-contrast-color, color.$black);
     }
 
     @supports selector(:focus-visible) {
@@ -170,7 +170,7 @@
       }
 
       &:focus-visible {
-        outline: button.$input-btn-focus-width solid var(--contrast-color, color.$black);
+        outline: button.$input-btn-focus-width solid var(--post-contrast-color, color.$black);
       }
     }
 
@@ -190,7 +190,7 @@
     }
 
     @include utilities.high-contrast-mode() {
-      --success: ActiveText;
+      --post-success: ActiveText;
 
       // linear-gradients or statements which contains linear-gradients are disabled in firefox
       // so we have to repeat background-image statements here without linear-gradients
@@ -214,16 +214,16 @@
       }
 
       &:checked {
-        background-color: var(--success);
+        background-color: var(--post-success);
         background-image: escape-svg(form-switch.$form-switch-checked-bg-image);
 
         &:focus {
-          background-color: var(--success);
+          background-color: var(--post-success);
           background-image: escape-svg(form-switch.$form-switch-checked-bg-image);
         }
 
         &:hover:not(:disabled) {
-          background-color: var(--success);
+          background-color: var(--post-success);
           border-color: Highlight;
         }
       }

--- a/packages/styles/src/components/form-check.scss
+++ b/packages/styles/src/components/form-check.scss
@@ -85,7 +85,6 @@
   }
 
   // Styles  to improve accessibility in high contrast mode
-  // stylelint-disable order/order
   @include utilities.high-contrast-mode() {
     &-input {
       &[type='checkbox']:checked {

--- a/packages/styles/src/components/form-range.scss
+++ b/packages/styles/src/components/form-range.scss
@@ -12,9 +12,9 @@
 
 .form-range {
   // https://codepen.io/thebabydino/pen/goYYrN
-  --range: calc(var(--max) - var(--min));
-  --ratio: calc((var(--val) - var(--min)) / var(--range));
-  --sx: calc(0.5 * 1.5em + var(--ratio) * (100% - 1.5em));
+  --post-range: calc(var(--post-max) - var(--post-min));
+  --post-ratio: calc((var(--post-val) - var(--post-min)) / var(--post-range));
+  --post-sx: calc(0.5 * 1.5em + var(--post-ratio) * (100% - 1.5em));
 
   &::-moz-range-thumb {
     border-radius: 50%;
@@ -24,7 +24,7 @@
 
   &:not(:disabled, .disabled) {
     &::-webkit-slider-runnable-track {
-      background: linear-gradient(color.$black, color.$black) 0 / var(--sx) 100%;
+      background: linear-gradient(color.$black, color.$black) 0 / var(--post-sx) 100%;
       background-repeat: no-repeat;
       background-color: color.$gray-20;
     }
@@ -59,7 +59,7 @@
 
     &:not(:disabled, .disabled) {
       &::-webkit-slider-runnable-track {
-        background: linear-gradient(Highlight, Highlight) 0 / var(--sx) 100%;
+        background: linear-gradient(Highlight, Highlight) 0 / var(--post-sx) 100%;
         background-repeat: no-repeat;
         background-color: ButtonBorder;
       }

--- a/packages/styles/src/components/grid.scss
+++ b/packages/styles/src/components/grid.scss
@@ -96,6 +96,5 @@ $container-cache: 0;
     }
   }
 
-  //stylelint-disable-next-line order/order
   $container-cache: $container-padding;
 }

--- a/packages/styles/src/components/intranet-header/_nav-overflow.scss
+++ b/packages/styles/src/components/intranet-header/_nav-overflow.scss
@@ -33,7 +33,7 @@
       right: 0;
       margin-top: commons.$border-width;
       padding-bottom: commons.$border-width;
-      border-left: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+      border-left: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
       background-color: color.$white;
 
       &.dropup.show,
@@ -43,7 +43,7 @@
 
       &.last-nav-overflow {
         padding-bottom: 0;
-        border-bottom: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+        border-bottom: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
       }
     }
 

--- a/packages/styles/src/components/intranet-header/_scaffolding.scss
+++ b/packages/styles/src/components/intranet-header/_scaffolding.scss
@@ -19,7 +19,7 @@
   top: 0;
   left: 0;
   width: 100%;
-  border-bottom: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+  border-bottom: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
   background-color: color.$white;
 
   .nav-down {

--- a/packages/styles/src/components/intranet-header/_searchbox.scss
+++ b/packages/styles/src/components/intranet-header/_searchbox.scss
@@ -9,16 +9,16 @@
 header.navbar {
   .search-textbox {
     @include media-breakpoint-down(rg) {
-      border-top: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+      border-top: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
     }
     @include media-breakpoint-up(md) {
-      border-left: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+      border-left: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
     }
 
     input {
       height: intranet-header.$header-content-size;
       border: 0;
-      background-color: rgba(var(--black-rgb), 0.1);
+      background-color: rgba(var(--post-contrast-color-rgb), 0.1);
       font-size: 1.2em;
       font-weight: type.$font-weight-light;
     }

--- a/packages/styles/src/components/intranet-header/_settings.scss
+++ b/packages/styles/src/components/intranet-header/_settings.scss
@@ -4,10 +4,10 @@
 @use '../../variables/components/intranet-header';
 
 .settings {
-  border-left: 1px solid rgba(var(--black-rgb), 0.2);
+  border-left: 1px solid rgba(var(--post-contrast-color-rgb), 0.2);
 
   &:hover {
-    background-color: rgba(var(--black-rgb), 0.1);
+    background-color: rgba(var(--post-contrast-color-rgb), 0.1);
     cursor: pointer;
   }
 

--- a/packages/styles/src/components/intranet-header/_sidebar.scss
+++ b/packages/styles/src/components/intranet-header/_sidebar.scss
@@ -35,12 +35,12 @@
       margin-bottom: 0;
       padding: spacing.$spacer;
       padding-top: spacing.$spacer;
-      border-bottom: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+      border-bottom: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
       background-color: color.$white;
 
       &:hover,
       &:focus {
-        background-color: get-solid-color(rgba(var(--black-rgb), 0.1), color.$white);
+        background-color: get-solid-color(rgba(var(--post-contrast-color-rgb), 0.1), color.$white);
         cursor: pointer;
       }
 

--- a/packages/styles/src/components/intranet-header/_top-navigation.scss
+++ b/packages/styles/src/components/intranet-header/_top-navigation.scss
@@ -14,14 +14,14 @@
   button.nav-link {
     @include button-mixins.reset-button();
     padding: nav.$nav-link-padding-y navbar.$navbar-nav-link-padding-x;
-    line-height: var(--body-line-height);
+    line-height: var(--post-body-line-height);
   }
 
   .nav-item > .nav-link {
     border-top: 4px solid transparent; // Border-Width according to PostWeb CSS
     border-bottom: 4px solid transparent; // Border-Width according to PostWeb CSS
     background-color: transparent;
-    color: rgba(var(--black-rgb), 0.6);
+    color: rgba(var(--post-contrast-color-rgb), 0.6);
 
     @include utilities.high-contrast-mode() {
       border-top: 4px solid canvas; // Border-Width according to PostWeb CSS
@@ -29,7 +29,7 @@
 
     &:hover,
     &:focus {
-      border-bottom-color: rgba(var(--black-rgb), 0.4);
+      border-bottom-color: rgba(var(--post-contrast-color-rgb), 0.4);
       background-color: color.$gray-10;
       text-decoration: none;
     }
@@ -69,13 +69,13 @@
 
 @include media-breakpoint-down(rg) {
   .top-navigation #navbarsDefault {
-    border-top: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+    border-top: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
   }
 }
 
 @include media-breakpoint-up(md) {
   .top-navigation {
-    border-top: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+    border-top: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
   }
 }
 
@@ -87,18 +87,18 @@
 @include media-breakpoint-down(rg) {
   #nav-toggler {
     border: 0;
-    border-left: commons.$border-width solid rgba(var(--black-rgb), 0.2);
+    border-left: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
     border-radius: 0;
 
     &:hover,
     &:focus {
-      background-color: rgba(var(--black-rgb), 0.1);
+      background-color: rgba(var(--post-contrast-color-rgb), 0.1);
     }
 
     i.pi {
       height: 100%;
       //width: 1.5rem;
-      color: rgba(var(--black-rgb), 0.2);
+      color: rgba(var(--post-contrast-color-rgb), 0.2);
 
       &::before {
         position: relative;

--- a/packages/styles/src/components/list-group.scss
+++ b/packages/styles/src/components/list-group.scss
@@ -142,7 +142,7 @@
 
     &:hover {
       background-color: transparent;
-      color: rgba(var(--white-rgb), 0.8);
+      color: rgba(var(--post-contrast-color-inverted-rgb), 0.8);
     }
   }
 }
@@ -160,6 +160,7 @@
 .list-group-white {
   .list-group-item {
     border: 0;
-    border-top: list-group.$list-group-border-width solid rgba(var(--white-rgb), 0.2);
+    border-top: list-group.$list-group-border-width solid
+      rgba(var(--post-contrast-color-inverted-rgb), 0.2);
   }
 }

--- a/packages/styles/src/components/progress.scss
+++ b/packages/styles/src/components/progress.scss
@@ -9,10 +9,6 @@
 @use '../variables/components/progress-bars';
 @use '../mixins/utilities';
 
-.progress-bar {
-  color: var(--post-contrast-color, progress-bars.$progress-bar-color);
-}
-
 @include utilities.high-contrast-mode() {
   .progress {
     border: commons.$border-width solid ButtonBorder;

--- a/packages/styles/src/components/progress.scss
+++ b/packages/styles/src/components/progress.scss
@@ -10,7 +10,7 @@
 @use '../mixins/utilities';
 
 .progress-bar {
-  color: var(--contrast-color, progress-bars.$progress-bar-color);
+  color: var(--post-contrast-color, progress-bars.$progress-bar-color);
 }
 
 @include utilities.high-contrast-mode() {

--- a/packages/styles/src/components/sizing.scss
+++ b/packages/styles/src/components/sizing.scss
@@ -88,7 +88,6 @@ $cache: ();
     }
 
     // Render the stack
-    //stylelint-disable-next-line order/order
     @include media-breakpoint-up($breakpoint-key) {
       @each $classname, $class-map in $stack {
         @each $curve-name, $curve-map in $class-map {

--- a/packages/styles/src/components/subnavigation.scss
+++ b/packages/styles/src/components/subnavigation.scss
@@ -37,19 +37,8 @@ $module-name: 'subnavigation';
     }
 
     .#{$module-name}-link {
-      color: subnavigation.$subnavigation-link-color-inverted;
-
-      &:hover,
-      &:focus {
-        color: subnavigation.$subnavigation-link-color-hover-inverted;
-      }
-
       &:not(.active)::after {
         background-color: subnavigation.$subnavigation-link-underscore-color-hover-inverted;
-      }
-
-      &.active {
-        color: subnavigation.$subnavigation-link-color-hover-inverted;
       }
     }
   }

--- a/packages/styles/src/components/subnavigation.scss
+++ b/packages/styles/src/components/subnavigation.scss
@@ -29,20 +29,6 @@ $module-name: 'subnavigation';
     background-color: subnavigation.$subnavigation-background-color-alternate;
   }
 
-  &-inverted {
-    background-color: subnavigation.$subnavigation-background-color-inverted;
-
-    &::after {
-      background-color: subnavigation.$subnavigation-border-bottom-color-inverted;
-    }
-
-    .#{$module-name}-link {
-      &:not(.active)::after {
-        background-color: subnavigation.$subnavigation-link-underscore-color-hover-inverted;
-      }
-    }
-  }
-
   &-list {
     display: flex;
     width: calc(100% + 2rem);

--- a/packages/styles/src/components/tabs.scss
+++ b/packages/styles/src/components/tabs.scss
@@ -66,18 +66,18 @@
     border-left: 1px solid transparent;
     outline-color: currentColor;
     opacity: 0.7;
-    color: var(--contrast-color);
+    color: var(--post-contrast-color);
 
     &:focus {
       opacity: 0.7;
       background-color: unset;
-      color: var(--contrast-color);
+      color: var(--post-contrast-color);
     }
 
     &:hover {
       opacity: 1;
       background-color: nav.$nav-tabs-link-active-bg;
-      color: var(--contrast-color);
+      color: var(--post-contrast-color);
     }
 
     // same styles as focus, can't use placeholder here because focus-visible can't be described outside of the support condition
@@ -85,7 +85,7 @@
       outline: transparent;
       opacity: 1;
       background-color: nav.$nav-tabs-link-active-bg;
-      color: var(--contrast-color);
+      color: var(--post-contrast-color);
 
       &::after {
         content: '';
@@ -105,7 +105,7 @@
       border-left-color: nav.$nav-tabs-border-color;
       opacity: 1;
       background-color: nav.$nav-tabs-link-active-bg;
-      color: var(--contrast-color);
+      color: var(--post-contrast-color);
       font-weight: 700;
 
       // Create a line that does not suffer from border corner mitering

--- a/packages/styles/src/components/tabs.scss
+++ b/packages/styles/src/components/tabs.scss
@@ -32,7 +32,6 @@
     background-color: transparent !important;
   }
 
-  /* stylelint-disable-next-line order/order */
   @include utilities.high-contrast-mode() {
     &::after {
       background-color: ButtonBorder;
@@ -121,7 +120,6 @@
       }
     }
 
-    /* stylelint-disable-next-line order/order */
     @include utilities.high-contrast-mode() {
       opacity: 1;
       border-left-color: Canvas;
@@ -149,7 +147,6 @@
   }
 
   // Tabs with dark backgrounds
-  /* stylelint-disable-next-line order/order */
   @include color-mx.on-dark-background(true) {
     .tab-title {
       &:hover {

--- a/packages/styles/src/components/toast.scss
+++ b/packages/styles/src/components/toast.scss
@@ -153,7 +153,7 @@
 
 @each $name, $color, $icon in alert.$alert-list {
   .toast-#{$name} {
-    --bg-rgb: #{color-fn.rgb-values($color)};
+    --post-bg-rgb: #{color-fn.rgb-values($color)};
     @extend %notification-#{$name};
 
     @if (color-fn.get-contrast-color($color) != #000) {

--- a/packages/styles/src/components/topic-teaser.scss
+++ b/packages/styles/src/components/topic-teaser.scss
@@ -122,7 +122,7 @@
 
   @include media-breakpoint-up(rg) {
     flex-direction: row;
-    gap: var(--gutter-x);
+    gap: var(--post-gutter-x);
   }
 }
 
@@ -163,7 +163,7 @@
   padding: 0.75rem 2rem 0.75rem 1rem;
   transition: opacity 200ms, background-position 200ms;
   border: 0;
-  border-top: 1px solid rgba(var(--white-rgb), 0.2);
+  border-top: 1px solid rgba(var(--post-contrast-color-rgb), 0.2);
   background-image: url(icons.get-colored-svg-url('2050', color.$white));
   background-repeat: no-repeat;
   background-position: right 0.75rem center;

--- a/packages/styles/src/components/topic-teaser.scss
+++ b/packages/styles/src/components/topic-teaser.scss
@@ -174,7 +174,6 @@
     background-position: right 0.5rem center;
   }
 
-  /* stylelint-disable-next-line order/order */
   @include media-breakpoint-up(lg) {
     padding-top: 1.25rem;
     padding-bottom: 1.25rem;

--- a/packages/styles/src/components/utilities.scss
+++ b/packages/styles/src/components/utilities.scss
@@ -65,7 +65,7 @@ span.spacer {
 // Background Utility
 @each $name, $color in color.$background-colors {
   .bg-#{$name} {
-    --bg-rgb: #{color-fn.rgb-values($color)};
+    --post-bg-rgb: #{color-fn.rgb-values($color)};
     @extend %color-background-rgba;
 
     @if (color-fn.get-contrast-color($color) != #000) {
@@ -89,10 +89,10 @@ span.spacer {
 }
 
 a {
-  color: var(--contrast-color);
+  color: var(--post-contrast-color);
 
   &:focus,
   &:hover {
-    color: rgba(var(--contrast-color-rgb), 0.8);
+    color: rgba(var(--post-contrast-color-rgb), 0.8);
   }
 }

--- a/packages/styles/src/functions/_color.scss
+++ b/packages/styles/src/functions/_color.scss
@@ -4,7 +4,6 @@
 @use 'sass:string';
 
 // Source: http://thesassway.com/intermediate/mixins-for-semi-transparent-colors
-// stylelint-disable order/order
 @function get-solid-color($color, $background: white) {
   @if (meta.type-of($color) != color or meta.type-of($background) != color) {
     @error "Please provide a color for this function. Supplied: '#{$color}' and '#{$background}'.";

--- a/packages/styles/src/functions/_icons.scss
+++ b/packages/styles/src/functions/_icons.scss
@@ -4,8 +4,6 @@
 @use './utilities';
 @use '../functions/color';
 
-// stylelint-disable order/order
-
 @function add-fill-color($svg, $color) {
   $opacity: alpha($color);
   $color: color.get-hex-string($color);

--- a/packages/styles/src/functions/_sizing.scss
+++ b/packages/styles/src/functions/_sizing.scss
@@ -3,8 +3,6 @@
 @use './utilities';
 @use './list';
 
-// stylelint-disable order/order
-
 @function strip-unit($value) {
   @return math.div($value, $value * 0 + 1);
 }

--- a/packages/styles/src/mixins/_button.scss
+++ b/packages/styles/src/mixins/_button.scss
@@ -42,7 +42,7 @@
 }
 
 @mixin button-color-variant($name, $color) {
-  .btn-#{$name} {
+  .btn-#{'' + $name} {
     border-color: transparent;
     background-color: $color;
 

--- a/packages/styles/src/mixins/_button.scss
+++ b/packages/styles/src/mixins/_button.scss
@@ -42,7 +42,7 @@
 }
 
 @mixin button-color-variant($name, $color) {
-  .btn-#{'' + $name} {
+  .btn-#{$name} {
     border-color: transparent;
     background-color: $color;
 

--- a/packages/styles/src/mixins/_form-checks.scss
+++ b/packages/styles/src/mixins/_form-checks.scss
@@ -52,7 +52,7 @@
   border-color: $color;
 
   ~ .form-check-label {
-    color: var(--contrast-color);
+    color: var(--post-contrast-color);
   }
 }
 

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -106,6 +106,6 @@
 
   /* Compatibility with button-group */
   &:is(:focus-visible, :focus-within) {
-    outline: forms.$input-focus-outline-thickness solid var(--contrast-color);
+    outline: forms.$input-focus-outline-thickness solid var(--post-contrast-color);
   }
 }

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -46,7 +46,6 @@
     line-height: type.$line-height-base;
 
     /* Keeping borders gray while maintaining a green background on tooltips */
-    //stylelint-disable-next-line order/order
     @if ($state == 'valid') {
       background-color: rgba(form-feedback.$form-feedback-valid-bg, tooltips.$tooltip-opacity);
     } @else {

--- a/packages/styles/src/mixins/_size.scss
+++ b/packages/styles/src/mixins/_size.scss
@@ -57,7 +57,6 @@
           }
         }
       }
-      //stylelint-disable-next-line order/order
       $cache: $value;
     }
   } @else {

--- a/packages/styles/src/placeholders/_button.scss
+++ b/packages/styles/src/placeholders/_button.scss
@@ -5,7 +5,6 @@
 %btn-default {
   border: button.$btn-border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
 
-  /* stylelint-disable-next-line order/order */
   @include utilities.not-disabled-focus-hover() {
     border-color: var(--post-contrast-color);
     color: var(--post-contrast-color); // Override <a> color

--- a/packages/styles/src/placeholders/_button.scss
+++ b/packages/styles/src/placeholders/_button.scss
@@ -3,24 +3,24 @@
 @use '../variables/components/button';
 
 %btn-default {
-  border: button.$btn-border-width solid rgba(var(--contrast-color-rgb), 0.2);
+  border: button.$btn-border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
 
   /* stylelint-disable-next-line order/order */
   @include utilities.not-disabled-focus-hover() {
-    border-color: var(--contrast-color);
-    color: var(--contrast-color); // Override <a> color
+    border-color: var(--post-contrast-color);
+    color: var(--post-contrast-color); // Override <a> color
   }
 
   @include color-mx.on-dark-background() {
-    border-color: var(--contrast-color);
+    border-color: var(--post-contrast-color);
 
     @include utilities.not-disabled-focus-hover() {
-      border-color: rgba(var(--contrast-color-rgb), 0.4);
+      border-color: rgba(var(--post-contrast-color-rgb), 0.4);
     }
   }
 
   &:disabled {
-    border-color: rgba(var(--contrast-color-rgb), 0.4);
-    color: rgba(var(--contrast-color-rgb), 0.6);
+    border-color: rgba(var(--post-contrast-color-rgb), 0.4);
+    color: rgba(var(--post-contrast-color-rgb), 0.6);
   }
 }

--- a/packages/styles/src/placeholders/_color.scss
+++ b/packages/styles/src/placeholders/_color.scss
@@ -46,6 +46,8 @@
 %color-background-dark-variables {
   --post-contrast-color: #{color.$white};
   --post-contrast-color-inverted: #{color.$black};
+  --post-dark: #{color.$light};
+  --post-light: #{color.$dark};
 
   // Invert grays
   $l: list.length(color.$post-grays);
@@ -58,6 +60,10 @@
 
   --post-contrast-color-rgb: #{color-fn.rgb-values(color.$white)};
   --post-contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$black)};
+  --post-dark-rgb: #{color-fn.rgb-values(color.$light)};
+  --post-light-rgb: #{color-fn.rgb-values(color.$dark)};
+
+  // Invert grays rgb
   @for $i from 1 through $l {
     $color-name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
     $color-value: list.nth(list.nth(color.$post-grays, $i), 2);

--- a/packages/styles/src/placeholders/_color.scss
+++ b/packages/styles/src/placeholders/_color.scss
@@ -22,7 +22,7 @@
   --post-contrast-color-inverted: #{color.$white};
 
   @each $color-name, $color-value in color.$post-grays {
-    --post-gray-#{$color-name}: #{$color-value};
+    --post-#{$color-name}: #{$color-value};
   }
 
   @each $name, $color in color.$background-colors {
@@ -34,7 +34,7 @@
   --post-contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$white)};
 
   @each $color-name, $color-value in color.$post-grays {
-    --post-gray-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
+    --post-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
   }
 
   @each $name, $color in color.$background-colors {
@@ -53,7 +53,7 @@
     $color-name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
     $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
     // stylelint-disable-next-line order/order
-    --post-gray-#{$color-name}: #{$color-value};
+    --post-#{$color-name}: #{$color-value};
   }
 
   --post-contrast-color-rgb: #{color-fn.rgb-values(color.$white)};
@@ -62,6 +62,6 @@
     $color-name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
     $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
     // stylelint-disable-next-line order/order
-    --post-gray-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
+    --post-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
   }
 }

--- a/packages/styles/src/placeholders/_color.scss
+++ b/packages/styles/src/placeholders/_color.scss
@@ -5,42 +5,56 @@
 
 // background rgb properties
 %color-background-rgb {
-  background-color: rgb(var(--bg-rgb)) !important;
-  color: var(--contrast-color) !important;
+  background-color: rgb(var(--post-bg-rgb)) !important;
+  color: var(--post-contrast-color) !important;
 }
 
 // background rgba properties
 %color-background-rgba {
-  --bg-opacity: 1;
-  background-color: rgba(var(--bg-rgb), var(--bg-opacity)) !important;
-  color: var(--contrast-color) !important;
+  --post-bg-opacity: 1;
+  background-color: rgba(var(--post-bg-rgb), var(--post-bg-opacity)) !important;
+  color: var(--post-contrast-color) !important;
 }
 
 // light background variables
 %color-background-light-variables {
-  --contrast-color: #{color.$black};
-  --contrast-color-rgb: #{color-fn.rgb-values(color.$black)};
-  --contrast-color-inverted: #{color.$white};
-  --contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$white)};
+  --post-contrast-color: #{color.$black};
+  --post-contrast-color-inverted: #{color.$white};
 
-  @each $color-name, $color-value in color.$grays {
-    --gray-#{$color-name}: #{$color-value};
+  @each $color-name, $color-value in color.$post-grays {
+    --post-gray-#{$color-name}: #{$color-value};
+  }
+
+  @each $name, $color in color.$background-colors {
+    --post-#{$name}: #{$color};
+  }
+
+  // RGB variants of the above, moved down here for better overview in the dev tools
+  --post-contrast-color-rgb: #{color-fn.rgb-values(color.$black)};
+  --post-contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$white)};
+
+  @each $color-name, $color-value in color.$post-grays {
+    --post-gray-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
+  }
+
+  @each $name, $color in color.$background-colors {
+    --post-#{$name}-rgb: #{color-fn.rgb-values($color)};
   }
 }
 
 // dark background variables
 %color-background-dark-variables {
-  --contrast-color: #{color.$white};
-  --contrast-color-rgb: #{color-fn.rgb-values(color.$white)};
-  --contrast-color-inverted: #{color.$black};
-  --contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$black)};
+  --post-contrast-color: #{color.$white};
+  --post-contrast-color-rgb: #{color-fn.rgb-values(color.$white)};
+  --post-contrast-color-inverted: #{color.$black};
+  --post-contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$black)};
 
   // Invert grays
-  $l: list.length(color.$grays);
+  $l: list.length(color.$post-grays);
   @for $i from 1 through $l {
-    $color-name: list.nth(list.nth(color.$grays, $l + 1 - $i), 1);
-    $color-value: list.nth(list.nth(color.$grays, $i), 2);
+    $color-name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
+    $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
     // stylelint-disable-next-line order/order
-    --gray-#{$color-name}: #{$color-value};
+    --post-gray-#{$color-name}: #{$color-value};
   }
 }

--- a/packages/styles/src/placeholders/_color.scss
+++ b/packages/styles/src/placeholders/_color.scss
@@ -45,9 +45,7 @@
 // dark background variables
 %color-background-dark-variables {
   --post-contrast-color: #{color.$white};
-  --post-contrast-color-rgb: #{color-fn.rgb-values(color.$white)};
   --post-contrast-color-inverted: #{color.$black};
-  --post-contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$black)};
 
   // Invert grays
   $l: list.length(color.$post-grays);
@@ -56,6 +54,14 @@
     $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
     // stylelint-disable-next-line order/order
     --post-gray-#{$color-name}: #{$color-value};
+  }
+
+  --post-contrast-color-rgb: #{color-fn.rgb-values(color.$white)};
+  --post-contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$black)};
+  @for $i from 1 through $l {
+    $color-name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
+    $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
+    // stylelint-disable-next-line order/order
     --post-gray-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
   }
 }

--- a/packages/styles/src/placeholders/_color.scss
+++ b/packages/styles/src/placeholders/_color.scss
@@ -21,8 +21,8 @@
   --post-contrast-color: #{color.$black};
   --post-contrast-color-inverted: #{color.$white};
 
-  @each $color-name, $color-value in color.$post-grays {
-    --post-#{$color-name}: #{$color-value};
+  @each $name, $color in color.$post-grays {
+    --post-#{$name}: #{$color};
   }
 
   @each $name, $color in color.$background-colors {
@@ -33,8 +33,8 @@
   --post-contrast-color-rgb: #{color-fn.rgb-values(color.$black)};
   --post-contrast-color-inverted-rgb: #{color-fn.rgb-values(color.$white)};
 
-  @each $color-name, $color-value in color.$post-grays {
-    --post-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
+  @each $name, $color in color.$post-grays {
+    --post-#{$name}-rgb: #{color-fn.rgb-values($color)};
   }
 
   @each $name, $color in color.$background-colors {
@@ -52,10 +52,10 @@
   // Invert grays
   $l: list.length(color.$post-grays);
   @for $i from 1 through $l {
-    $color-name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
-    $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
+    $name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
+    $color: list.nth(list.nth(color.$post-grays, $i), 2);
     // stylelint-disable-next-line order/order
-    --post-#{$color-name}: #{$color-value};
+    --post-#{$name}: #{$color};
   }
 
   --post-contrast-color-rgb: #{color-fn.rgb-values(color.$white)};
@@ -65,9 +65,9 @@
 
   // Invert grays rgb
   @for $i from 1 through $l {
-    $color-name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
-    $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
+    $name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
+    $color: list.nth(list.nth(color.$post-grays, $i), 2);
     // stylelint-disable-next-line order/order
-    --post-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
+    --post-#{$name}-rgb: #{color-fn.rgb-values($color)};
   }
 }

--- a/packages/styles/src/placeholders/_color.scss
+++ b/packages/styles/src/placeholders/_color.scss
@@ -54,7 +54,6 @@
   @for $i from 1 through $l {
     $name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
     $color: list.nth(list.nth(color.$post-grays, $i), 2);
-    // stylelint-disable-next-line order/order
     --post-#{$name}: #{$color};
   }
 
@@ -67,7 +66,6 @@
   @for $i from 1 through $l {
     $name: list.nth(list.nth(color.$post-grays, $l + 1 - $i), 1);
     $color: list.nth(list.nth(color.$post-grays, $i), 2);
-    // stylelint-disable-next-line order/order
     --post-#{$name}-rgb: #{color-fn.rgb-values($color)};
   }
 }

--- a/packages/styles/src/placeholders/_color.scss
+++ b/packages/styles/src/placeholders/_color.scss
@@ -56,5 +56,6 @@
     $color-value: list.nth(list.nth(color.$post-grays, $i), 2);
     // stylelint-disable-next-line order/order
     --post-gray-#{$color-name}: #{$color-value};
+    --post-gray-#{$color-name}-rgb: #{color-fn.rgb-values($color-value)};
   }
 }

--- a/packages/styles/src/themes/bootstrap/_overrides-color.scss
+++ b/packages/styles/src/themes/bootstrap/_overrides-color.scss
@@ -20,8 +20,6 @@ $secondary: color.$gray-60;
 $info: color.$yellow;
 // $warning: color.$warning; // Is already defined as $warning in post-colors
 $danger: color.$error;
-$light: color.$gray-background-light;
-$dark: $primary;
 
 // Colors that can be used as a background
 $colors: () !default;
@@ -31,8 +29,8 @@ $colors: map.merge(
     'primary': $primary,
     'secondary': $secondary,
     'white': color.$white,
-    'light': $light,
-    'dark': $dark,
+    'light': color.$light,
+    'dark': color.$dark,
   )
 );
 $colors: map.merge($colors, color.$contextual-colors);

--- a/packages/styles/src/themes/bootstrap/_overrides-color.scss
+++ b/packages/styles/src/themes/bootstrap/_overrides-color.scss
@@ -24,8 +24,21 @@ $light: color.$gray-background-light;
 $dark: $primary;
 
 // Colors that can be used as a background
-$theme-colors: () !default;
 $colors: () !default;
+$colors: map.merge(
+  $colors,
+  (
+    'primary': $primary,
+    'secondary': $secondary,
+    'white': color.$white,
+    'light': $light,
+    'dark': $dark,
+  )
+);
+$colors: map.merge($colors, color.$contextual-colors);
+
+$theme-colors: () !default;
+$theme-colors: map.merge($theme-colors, $colors);
 
 // Contrast colors are ok
 

--- a/packages/styles/src/themes/bootstrap/_overrides-color.scss
+++ b/packages/styles/src/themes/bootstrap/_overrides-color.scss
@@ -23,20 +23,18 @@ $danger: color.$error;
 
 // Colors that can be used as a background
 $colors: () !default;
-$colors: map.merge(
-  $colors,
+
+$theme-colors: () !default;
+$theme-colors: map.merge(
+  $theme-colors,
   (
     'primary': $primary,
     'secondary': $secondary,
-    'white': color.$white,
     'light': color.$light,
     'dark': color.$dark,
   )
 );
-$colors: map.merge($colors, color.$contextual-colors);
-
-$theme-colors: () !default;
-$theme-colors: map.merge($theme-colors, $colors);
+$theme-colors: map.merge($theme-colors, color.$contextual-colors);
 
 // Contrast colors are ok
 

--- a/packages/styles/src/themes/bootstrap/_overrides-color.scss
+++ b/packages/styles/src/themes/bootstrap/_overrides-color.scss
@@ -24,7 +24,8 @@ $light: color.$gray-background-light;
 $dark: $primary;
 
 // Colors that can be used as a background
-$theme-colors: color.$background-colors !default;
+$theme-colors: () !default;
+$colors: () !default;
 
 // Contrast colors are ok
 

--- a/packages/styles/src/themes/bootstrap/_overrides-features.scss
+++ b/packages/styles/src/themes/bootstrap/_overrides-features.scss
@@ -15,4 +15,4 @@ $enable-grid-classes: true;
 // Prefix for :root CSS variables
 // TODO: this variable will change from "$variable-prefix" to "$prefix" in bootstrap@5.2
 // https://getbootstrap.com/docs/5.2/customize/css-variables/#prefix
-$variable-prefix: '' !default;
+$variable-prefix: 'bs-' !default;

--- a/packages/styles/src/variables/_color.scss
+++ b/packages/styles/src/variables/_color.scss
@@ -48,7 +48,7 @@ $warning: #f49e00;
  */
 
 $grays: () !default;
-$grays: map.merge(
+$post-grays: map.merge(
   $grays,
   (
     '10': $gray-10,
@@ -106,16 +106,6 @@ $background-colors: map.merge(
 // Merge with the other lists
 $background-colors: map.merge($background-colors, $contextual-colors);
 $background-colors: map.merge($background-colors, $accent-colors);
-
-// One list to rule them all
-$colors: () !default;
-$colors: map.merge(
-  (
-    'black': $black,
-  ),
-  $grays
-);
-$colors: map.merge($background-colors, $colors);
 
 // Compile a list of dark backgrounds, used in the :is selector mixin at mixins/color
 $dark-backgrounds: () !default;

--- a/packages/styles/src/variables/_color.scss
+++ b/packages/styles/src/variables/_color.scss
@@ -47,15 +47,15 @@ $warning: #f49e00;
  * by always merging into a default empty map
  */
 
-$grays: () !default;
+$post-grays: () !default;
 $post-grays: map.merge(
-  $grays,
+  $post-grays,
   (
-    '10': $gray-10,
-    '20': $gray-20,
-    '40': $gray-40,
-    '60': $gray-60,
-    '80': $gray-80,
+    'gray-10': $gray-10,
+    'gray-20': $gray-20,
+    'gray-40': $gray-40,
+    'gray-60': $gray-60,
+    'gray-80': $gray-80,
   )
 );
 

--- a/packages/styles/src/variables/_color.scss
+++ b/packages/styles/src/variables/_color.scss
@@ -10,6 +10,9 @@
 $yellow: #fc0;
 
 // Grayscale
+$gray-background: #f4f3f1;
+$gray-background-light: #faf9f8;
+
 $white: #fff;
 $gray-10: hsl(0, 0%, 90%);
 $gray-20: hsl(0, 0%, 80%);
@@ -18,8 +21,8 @@ $gray-60: hsl(0, 0%, 40%);
 $gray-80: hsl(0, 0%, 20%);
 $black: #000;
 
-$gray-background: #f4f3f1;
-$gray-background-light: #faf9f8;
+$dark: $gray-80;
+$light: $gray-background-light;
 
 // Accent colors
 $nightblue-dark: #004976;
@@ -95,9 +98,9 @@ $background-colors: map.merge(
   $background-colors,
   (
     'yellow': $yellow,
-    'light': $gray-background-light,
+    'light': $light,
     'gray': $gray-background,
-    'dark': $gray-80,
+    'dark': $dark,
     'primary': $gray-80,
     'white': $white,
   )

--- a/packages/styles/src/variables/components/_alert.scss
+++ b/packages/styles/src/variables/components/_alert.scss
@@ -47,5 +47,5 @@ $alert-font-size-small: type.$font-size-small; // Design System only
 $alert-toast-width: 25rem; // Design System only
 $alert-toast-width-small-breakpoint: 21rem; // Design System only
 
-$alert-toast-box-shadow-hover: 0 0 1rem 0 rgba(var(--black-rgb), 0.4); // Design System only
+$alert-toast-box-shadow-hover: 0 0 1rem 0 rgba(var(--post-contrast-color-rgb), 0.4); // Design System only
 $alert-close-hover-opacity: 0.4; // Design System only

--- a/packages/styles/src/variables/components/_dropdowns.scss
+++ b/packages/styles/src/variables/components/_dropdowns.scss
@@ -12,7 +12,7 @@ $dropdown-bg: color.$white !default;
 $dropdown-border-color: rgba(color.$black, 0.15) !default;
 $dropdown-border-radius: commons.$border-radius !default;
 $dropdown-border-width: commons.$border-width !default;
-$dropdown-divider-bg: rgba(var(--white-rgb), 0.6) !default;
+$dropdown-divider-bg: rgba(var(--post-contrast-color-inverted-rgb), 0.6) !default;
 $dropdown-box-shadow: 0 0.5rem 1rem rgba(color.$black, 0.175) !default;
 
 $dropdown-link-color: color.$gray-60 !default;

--- a/packages/styles/src/variables/components/_form-switch.scss
+++ b/packages/styles/src/variables/components/_form-switch.scss
@@ -21,9 +21,9 @@ $form-switch-focus-bg-image: $form-switch-checked-bg-image;
 
 // Design System custom variables
 $form-switch-height: spacing.$size-big !default;
-$form-switch-bg: rgba(var(--contrast-color-rgb), 0.3) !default;
-$form-switch-hover-bg: rgba(var(--contrast-color-rgb), 0.1) !default;
-$form-switch-checked-bg: var(--success) !default;
+$form-switch-bg: rgba(var(--post-contrast-color-rgb), 0.3) !default;
+$form-switch-hover-bg: rgba(var(--post-contrast-color-rgb), 0.1) !default;
+$form-switch-checked-bg: var(--post-success) !default;
 $form-switch-checked-bg-image-size: $form-switch-height;
 $form-switch-linear-gradient: linear-gradient(
   to left,

--- a/packages/styles/src/variables/components/_forms.scss
+++ b/packages/styles/src/variables/components/_forms.scss
@@ -12,7 +12,7 @@
 // Forms
 
 $form-label-margin-bottom: 0.5rem !default;
-$form-label-color: rgba(var(--contrast-color-rgb), 0.8) !default;
+$form-label-color: rgba(var(--post-contrast-color-rgb), 0.8) !default;
 
 $input-padding-y: button.$input-btn-padding-y !default;
 $input-padding-x: button.$input-btn-padding-x !default;
@@ -31,7 +31,7 @@ $input-padding-x-lg: button.$input-btn-padding-x-lg !default;
 $input-line-height-lg: button.$input-btn-line-height-lg !default;
 
 $input-bg: color.$white !default;
-$input-disabled-bg: rgba(var(--white-rgb), 0.6) !default;
+$input-disabled-bg: rgba(var(--post-contrast-color-inverted-rgb), 0.6) !default;
 $input-disabled-color: color.$gray-60; // Design System only
 $input-disabled-border-color: color.$gray-20; // Design System only
 
@@ -53,7 +53,7 @@ $input-focus-box-shadow: button.$input-btn-focus-box-shadow !default;
 $input-focus-outline-thickness: spacing.$size-line;
 
 $input-placeholder-color: color.$gray-60 !default;
-$input-plaintext-color: var(--contrast-color) !default;
+$input-plaintext-color: var(--post-contrast-color) !default;
 
 $input-height-border: $input-border-width * 2 !default;
 
@@ -75,14 +75,14 @@ $input-height-lg: calc(#{$input-height-inner-lg} + #{$input-height-border}) !def
 
 $input-transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out !default;
 
-$form-text-color: var(--contrast-color);
+$form-text-color: var(--post-contrast-color);
 $form-text-font-size: type.$font-size-tiny;
 $form-text-margin-top: spacing.$size-micro !default;
 
 $form-group-margin-bottom: 1rem !default;
 
 $input-group-addon-color: $input-color !default;
-$input-group-addon-bg: rgba(var(--white-rgb), 0.6) !default;
+$input-group-addon-bg: rgba(var(--post-contrast-color-inverted-rgb), 0.6) !default;
 $input-group-addon-border-color: $input-border-color !default;
 
 $form-range-track-height: 0.2rem !default;

--- a/packages/styles/src/variables/components/_nav.scss
+++ b/packages/styles/src/variables/components/_nav.scss
@@ -36,9 +36,9 @@ $nav-tabs-link-active-font-weight: bold !default;
 $nav-tabs-focus-box-shadow: 0 0 0 1px color.$white, 0 0 0 2px color.$gray-80 !default;
 $nav-tabs-focus-box-shadow-width: 2px !default;
 
-$nav-tabs-i-border-color: rgba(var(--white-rgb), 0.4) !default;
-$nav-tabs-i-link-hover-bg: rgba(var(--black-rgb), 0.1) !default;
-$nav-tabs-i-link-hover-border-color: rgba(var(--white-rgb), 0.8) !default;
+$nav-tabs-i-border-color: rgba(var(--post-contrast-color-inverted-rgb), 0.4) !default;
+$nav-tabs-i-link-hover-bg: rgba(var(--post-contrast-color-rgb), 0.1) !default;
+$nav-tabs-i-link-hover-border-color: rgba(var(--post-contrast-color-inverted-rgb), 0.8) !default;
 $nav-tabs-i-link-text-color: color.$white !default;
 $nav-tabs-i-link-active-color: color.$white !default;
 

--- a/packages/styles/src/variables/components/_stepper.scss
+++ b/packages/styles/src/variables/components/_stepper.scss
@@ -18,7 +18,8 @@ $_stepper-indicator-check-icon: icon-fn.get-colored-svg-url('2105', $stepper-ind
 $stepper-indicator-check-icon: url($_stepper-indicator-check-icon);
 $stepper-indicator-hover-color: color.$white;
 $stepper-indicator-hover-bg: color.$black;
-$stepper-indicator-hover-outline: forms.$input-focus-outline-thickness solid var(--text-color);
+$stepper-indicator-hover-outline: forms.$input-focus-outline-thickness solid
+  var(--post-contrast-color);
 $_stepper-indicator-hover-check-icon: icon-fn.get-colored-svg-url(
   '2105',
   $stepper-indicator-hover-color

--- a/packages/styles/src/variables/components/_subnavigation.scss
+++ b/packages/styles/src/variables/components/_subnavigation.scss
@@ -12,23 +12,20 @@ $subnavigation-background-color-inverted: transparent;
 
 $subnavigation-border-bottom-width: commons.$border-width;
 $subnavigation-border-bottom-color: color.$gray-10;
-$subnavigation-border-bottom-color-inverted: rgba(var(--black-rgb), 0.2);
+$subnavigation-border-bottom-color-inverted: rgba(var(--post-contrast-color-rgb), 0.2);
 
 // These heights have to be synchronous to main navigation heights
 $subnavigation-height-xs: sizing.px-to-rem(56);
 $subnavigation-height-lg: sizing.px-to-rem(64);
 $subnavigation-height-xl: sizing.px-to-rem(72);
 
-$subnavigation-link-color: color.$gray-60;
-$subnavigation-link-color-hover: color.$black;
-
-$subnavigation-link-color-inverted: rgba(var(--white-rgb), 0.6);
-$subnavigation-link-color-hover-inverted: color.$white;
+$subnavigation-link-color: rgba(var(--post-contrast-color-rgb), 0.6);
+$subnavigation-link-color-hover: var(--post-contrast-color);
 
 $subnavigation-link-underscore-height: map.get(spacing.$post-sizes, 'micro');
 $subnavigation-link-underscore-color-active: color.$yellow;
-$subnavigation-link-underscore-color-hover: color.$gray-40;
-$subnavigation-link-underscore-color-hover-inverted: rgba(var(--white-rgb), 0.4);
+$subnavigation-link-underscore-color-hover: rgba(var(--post-contrast-color-rgb), 0.4);
+$subnavigation-link-underscore-color-hover-inverted: rgba(var(--post-contrast-color-rgb), 0.4);
 
 $subnavigation-link-padding-xs: map.get(spacing.$post-sizes, 'regular')
   map.get(spacing.$post-sizes, 'small-regular');

--- a/packages/styles/src/variables/components/_subnavigation.scss
+++ b/packages/styles/src/variables/components/_subnavigation.scss
@@ -8,11 +8,9 @@
 
 $subnavigation-background-color: color.$white;
 $subnavigation-background-color-alternate: color.$gray-background-light;
-$subnavigation-background-color-inverted: transparent;
 
 $subnavigation-border-bottom-width: commons.$border-width;
 $subnavigation-border-bottom-color: color.$gray-10;
-$subnavigation-border-bottom-color-inverted: rgba(var(--post-contrast-color-rgb), 0.2);
 
 // These heights have to be synchronous to main navigation heights
 $subnavigation-height-xs: sizing.px-to-rem(56);
@@ -25,7 +23,6 @@ $subnavigation-link-color-hover: var(--post-contrast-color);
 $subnavigation-link-underscore-height: map.get(spacing.$post-sizes, 'micro');
 $subnavigation-link-underscore-color-active: color.$yellow;
 $subnavigation-link-underscore-color-hover: rgba(var(--post-contrast-color-rgb), 0.4);
-$subnavigation-link-underscore-color-hover-inverted: rgba(var(--post-contrast-color-rgb), 0.4);
 
 $subnavigation-link-padding-xs: map.get(spacing.$post-sizes, 'regular')
   map.get(spacing.$post-sizes, 'small-regular');

--- a/packages/styles/src/variables/components/_tables.scss
+++ b/packages/styles/src/variables/components/_tables.scss
@@ -23,9 +23,9 @@ $table-hover-bg: rgba(color.$black, 0.075) !default;
 $table-active-bg: $table-hover-bg !default;
 
 $table-border-width: commons.$border-width !default;
-$table-border-color: rgba(var(--white-rgb), 0.4) !default;
+$table-border-color: rgba(var(--post-contrast-color-inverted-rgb), 0.4) !default;
 
-$table-head-bg: rgba(var(--white-rgb), 0.6) !default;
+$table-head-bg: rgba(var(--post-contrast-color-inverted-rgb), 0.6) !default;
 $table-head-color: color.$gray-40 !default;
 
 $table-dark-bg: color.$gray-80 !default;

--- a/packages/styles/tests/cwf.test.scss
+++ b/packages/styles/tests/cwf.test.scss
@@ -7,11 +7,11 @@
  * packages. Extend these tests at your convenience.
  */
 .test {
-  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$colors, 'coral')));
+  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$accent-colors, 'coral')));
   background-image: url(cwf.get-colored-svg-url('2063', #ff0080));
   background-image: url(cwf.get-colored-svg-url('2063', cwf.$white));
 
-  @include cwf.pi(2063, map.get(cwf.$colors, 'coral'));
+  @include cwf.pi(2063, map.get(cwf.$accent-colors, 'coral'));
   @include cwf.pi(2063, #ff0080);
   @include cwf.pi(2063, cwf.$white);
   @include cwf.pi(2063, midnightblue);

--- a/packages/styles/tests/cwf.test.scss
+++ b/packages/styles/tests/cwf.test.scss
@@ -7,11 +7,11 @@
  * packages. Extend these tests at your convenience.
  */
 .test {
-  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$accent-colors, 'coral')));
+  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$colors, 'coral')));
   background-image: url(cwf.get-colored-svg-url('2063', #ff0080));
   background-image: url(cwf.get-colored-svg-url('2063', cwf.$white));
 
-  @include cwf.pi(2063, map.get(cwf.$accent-colors, 'coral'));
+  @include cwf.pi(2063, map.get(cwf.$colors, 'coral'));
   @include cwf.pi(2063, #ff0080);
   @include cwf.pi(2063, cwf.$white);
   @include cwf.pi(2063, midnightblue);

--- a/packages/styles/tests/functions/icons.test.scss
+++ b/packages/styles/tests/functions/icons.test.scss
@@ -27,5 +27,5 @@ $expected-add-fill-color-output: "data:image/svg+xml,%3Csvg version='1.1' xmlns=
     }
   }
 
-  background-image: url(icons.get-colored-svg-url('1000', map.get(color.$colors, 'coral')));
+  background-image: url(icons.get-colored-svg-url('1000', map.get(color.$accent-colors, 'coral')));
 }

--- a/packages/styles/tests/functions/icons.test.scss
+++ b/packages/styles/tests/functions/icons.test.scss
@@ -27,5 +27,5 @@ $expected-add-fill-color-output: "data:image/svg+xml,%3Csvg version='1.1' xmlns=
     }
   }
 
-  background-image: url(icons.get-colored-svg-url('1000', map.get(color.$accent-colors, 'coral')));
+  background-image: url(icons.get-colored-svg-url('1000', map.get(color.$colors, 'coral')));
 }

--- a/packages/styles/tests/post-intranet.test.scss
+++ b/packages/styles/tests/post-intranet.test.scss
@@ -4,11 +4,11 @@
 @use './jest';
 
 .test {
-  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$accent-colors, 'coral')));
+  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$colors, 'coral')));
   background-image: url(cwf.get-colored-svg-url('2063', #ff0080));
   background-image: url(cwf.get-colored-svg-url('2063', cwf.$white));
 
-  @include cwf.pi(2063, map.get(cwf.$accent-colors, 'coral'));
+  @include cwf.pi(2063, map.get(cwf.$colors, 'coral'));
   @include cwf.pi(2063, #ff0080);
   @include cwf.pi(2063, cwf.$white);
   @include cwf.pi(2063, midnightblue);

--- a/packages/styles/tests/post-intranet.test.scss
+++ b/packages/styles/tests/post-intranet.test.scss
@@ -4,11 +4,11 @@
 @use './jest';
 
 .test {
-  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$colors, 'coral')));
+  background-image: url(cwf.get-colored-svg-url('2063', map.get(cwf.$accent-colors, 'coral')));
   background-image: url(cwf.get-colored-svg-url('2063', #ff0080));
   background-image: url(cwf.get-colored-svg-url('2063', cwf.$white));
 
-  @include cwf.pi(2063, map.get(cwf.$colors, 'coral'));
+  @include cwf.pi(2063, map.get(cwf.$accent-colors, 'coral'));
   @include cwf.pi(2063, #ff0080);
   @include cwf.pi(2063, cwf.$white);
   @include cwf.pi(2063, midnightblue);


### PR DESCRIPTION
This changes is an overhaul of colors and how they are presented to the developer. Colors defined by the Post now have the prefix --post, variables defined by bootstrap have the prefix --bs. The code has been generally updated to use post variables wherever variables were used already. Many components don't use variables and have yet to be migrated.

The idea of contrast colors is, that they always provide the best contrast on their current background - provided the bg-* classes were used to set said background.