### PR TITLE
fix(links): add hcm styles

### DIFF
--- a/.changeset/poor-games-know.md
+++ b/.changeset/poor-games-know.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Adds high-contrast-mode/forced-color styles to links. Overrides all a, a:visited, a:focus and a:hover colors with LinkText !important, to avoid different styling for visited links in firefox.

--- a/packages/styles/src/components/utilities.scss
+++ b/packages/styles/src/components/utilities.scss
@@ -95,4 +95,13 @@ a {
   &:hover {
     color: rgba(var(--post-contrast-color-rgb), 0.8);
   }
+
+  @include utilities.high-contrast-mode() {
+    &,
+    &:visited,
+    &:focus,
+    &:hover {
+      color: LinkText !important;
+    }
+  }
 }


### PR DESCRIPTION
To avoid different stylings in different browsers, links and there pseudo classes (visited, focus, hover) have been overwritten with the css statment: `color: LinkText !important;`.