### PR TITLE
fix(intranet-header): remove unnecessary pseudo-element

### DIFF
--- a/.changeset/tidy-tomatoes-help.md
+++ b/.changeset/tidy-tomatoes-help.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Removes unnecessary pseudo-element on open sidebar menu-icon.

--- a/packages/styles/src/components/intranet-header/_sidebar.scss
+++ b/packages/styles/src/components/intranet-header/_sidebar.scss
@@ -53,10 +53,6 @@
 
     &:not(.closed) > div > ul > li:first-child {
       margin-bottom: spacing.$spacer;
-
-      i.pi::before {
-        content: '\EA14';
-      }
     }
 
     &.closed > div > ul > * {


### PR DESCRIPTION
On mobile devices the sidebar showed an unnecessary pseudo-element (when the menu was opened).
This pseudo-element has been removed.