### PR TITLE
fix(input-file): Fix display errors on safari

### DIFF
--- a/.changeset/hip-geese-push.md
+++ b/.changeset/hip-geese-push.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixes safari display error.

--- a/packages/styles/src/components/forms.scss
+++ b/packages/styles/src/components/forms.scss
@@ -30,15 +30,69 @@ select.form-control-rg:not([size]):not([multiple]) {
     background-color: forms.$input-bg;
   }
 
-  &::file-selector-button {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    margin-inline-start: forms.$input-padding-x;
-    margin-inline-end: 0;
-    border-inline-end-width: 0;
-    border-inline-start-width: forms.$input-border-width;
+  &[type='file'] {
+    min-height: calc(
+      (1rem * forms.$input-line-height) + (forms.$input-padding-y * 2) +
+        (forms.$input-border-width * 2)
+    );
+
+    &::file-selector-button {
+      margin-inline-start: 0;
+      margin-inline-end: 0;
+      padding-left: 0;
+      padding-right: 0;
+      width: 0;
+      border: 0 none;
+    }
+
+    &::after {
+      display: flex;
+      align-items: center;
+      content: 'Choose File';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      z-index: 2;
+      padding-left: inherit;
+      padding-right: inherit;
+      background-color: inherit;
+      border-left: inherit;
+      text-align: center;
+
+      [lang='de'] & {
+        content: 'Datei auswählen';
+      }
+
+      [lang='fr'] & {
+        content: 'Choisir un fichier';
+      }
+
+      [lang='it'] & {
+        content: 'Scegli file';
+      }
+    }
+
+    &.form-control-sm {
+      min-height: calc(
+        (1rem * forms.$input-line-height-sm) + (forms.$input-padding-y-sm * 2) +
+          (forms.$input-border-width * 2)
+      );
+    }
+
+    &.form-control-rg {
+      min-height: calc(
+        (1rem * forms.$input-line-height-rg) + (forms.$input-padding-y-rg * 2) +
+          (forms.$input-border-width * 2)
+      );
+    }
+
+    &.form-control-lg {
+      min-height: calc(
+        (1rem * forms.$input-line-height-lg) + (forms.$input-padding-y-lg * 2) +
+          (forms.$input-border-width * 2)
+      );
+    }
   }
 
   @include utilities.high-contrast-mode() {
@@ -46,8 +100,10 @@ select.form-control-rg:not([size]):not([multiple]) {
     &:focus {
       border-color: Highlight;
 
-      &::file-selector-button {
-        border-color: Highlight;
+      &[type='file'] {
+        &::after {
+          border-color: Highlight;
+        }
       }
     }
   }


### PR DESCRIPTION
I was able to eliminate almost all of the graphical errors.
Unfortunately this leads to the fact that you have to set the button translations via content CSS-property and these are dependent on the document-language.
The integrated languages are: en (default), de, fr, it