### PR TITLE
feat(form-control-lg, form-floating)!: make form-controls even height

### DIFF
--- a/.changeset/young-mayflies-smoke.md
+++ b/.changeset/young-mayflies-smoke.md
@@ -1,0 +1,7 @@
+---
+'@swisspost/design-system-styles': major
+'@swisspost/design-system-demo': patch
+---
+
+Fixes form-control-lg and form-floating form-control heights.
+Removed some DesignSystem only SCSS variables.

--- a/packages/demo/src/app/bootstrap/components/form-control/form-control-demo/form-control-demo.component.html
+++ b/packages/demo/src/app/bootstrap/components/form-control/form-control-demo/form-control-demo.component.html
@@ -1,12 +1,32 @@
 <div class="form-floating">
-  <input class="form-control form-control-lg" id="floatingInput" placeholder=" " type="email">
+  <input class="form-control form-control-lg" id="floatingInput" placeholder=" " type="email" />
   <label class="form-label" for="floatingInput">.form-control-lg</label>
 </div>
 
-<input aria-label="default input example" class="form-control" placeholder="Default input" type="text">
+<input
+  aria-label="Required for accessibility on inputs that do not have an associated <label>"
+  class="form-control form-control-lg"
+  placeholder=".form-control-lg"
+  type="text"
+/>
 
-<input aria-label="Required for accessibility on inputs that do not have an associated <label>"
-       class="form-control form-control-rg" placeholder=".form-control-rg" type="text">
+<input
+  aria-label="default input example"
+  class="form-control"
+  placeholder="Default input"
+  type="text"
+/>
 
-<input aria-label="Required for accessibility on inputs that do not have an associated <label>"
-       class="form-control form-control-sm" placeholder=".form-control-sm" type="text">
+<input
+  aria-label="Required for accessibility on inputs that do not have an associated <label>"
+  class="form-control form-control-rg"
+  placeholder=".form-control-rg"
+  type="text"
+/>
+
+<input
+  aria-label="Required for accessibility on inputs that do not have an associated <label>"
+  class="form-control form-control-sm"
+  placeholder=".form-control-sm"
+  type="text"
+/>

--- a/packages/styles/src/components/floating-label.scss
+++ b/packages/styles/src/components/floating-label.scss
@@ -11,11 +11,13 @@
 
 .form-floating {
   > label {
+    display: flex;
+    align-items: center;
     top: forms.$input-border-width;
     left: forms.$input-border-width;
-    padding-top: forms.$form-floating-label-padding-t;
-    padding-bottom: forms.$form-floating-label-padding-b;
-    transform: translateY(forms.$form-floating-padding-y - forms.$form-floating-label-padding-t);
+    margin: 0;
+    padding: forms.$form-floating-padding-y forms.$form-floating-padding-x;
+    height: 100%;
     border: 0;
     color: forms.$form-floating-label-color;
     font-size: forms.$form-floating-label-font-size;
@@ -23,27 +25,97 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    transform-origin: forms.$form-floating-padding-x 0;
+    transition: forms.$form-floating-transition-out;
   }
 
-  > textarea.form-control {
-    line-height: forms.$form-floating-textarea-line-height;
+  > .form-control {
+    // disable styleint here, because the classes are coming from bs5
+    /* stylelint-disable */
+    @extend .form-control-lg;
+    /* stylelint-disable */
 
-    ~ label {
-      min-width: 0;
-      height: unset;
-      background: forms.$input-bg;
-      background: linear-gradient(forms.$input-bg 85%, rgba(forms.$input-bg, 0));
+    &[type='file']::file-selector-button {
+      padding-top: forms.$form-floating-input-padding-t +
+        ((forms.$form-floating-line-height - 1) * 0.5);
     }
 
     &:focus,
     &:not(:placeholder-shown) {
-      padding-top: forms.$form-floating-textarea-padding-t;
-      padding-bottom: forms.$form-floating-textarea-padding-b;
+      padding-top: forms.$form-floating-input-padding-t;
+      padding-bottom: forms.$form-floating-input-padding-b;
+
+      &[type='file']::file-selector-button {
+        padding-top: forms.$form-floating-input-padding-t +
+          ((forms.$form-floating-line-height - 1) * 0.5);
+      }
 
       ~ label {
-        min-width: calc(
-          (100% - #{2 * forms.$form-floating-padding-x}) / #{forms.$form-floating-label-scale}
+        padding-top: 0;
+        max-width: calc(
+          (100% * forms.$form-floating-label-upscale) -
+            (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
+            (forms.$input-border-width * forms.$form-floating-label-upscale * 2)
         );
+        transition: forms.$form-floating-transition-in;
+      }
+    }
+  }
+
+  > .form-select {
+    // disable styleint here, because the classes are coming from bs5
+    /* stylelint-disable */
+    @extend .form-control-lg;
+    /* stylelint-disable */
+
+    padding-top: forms.$form-floating-input-padding-t;
+    padding-bottom: forms.$form-floating-input-padding-b;
+
+    ~ label {
+      padding-top: 0;
+      max-width: calc(
+        (100% * forms.$form-floating-label-upscale) -
+          (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
+          (forms.$input-border-width * forms.$form-floating-label-upscale * 2)
+      );
+      transition: forms.$form-floating-transition-in;
+    }
+
+    &:empty {
+      padding-top: forms.$form-floating-input-padding-t;
+      padding-bottom: forms.$form-floating-input-padding-b;
+
+      ~ label {
+        padding-top: forms.$form-floating-padding-y;
+        max-width: calc(100% - (forms.$input-border-width * 2));
+        transform: none;
+      }
+    }
+  }
+
+  > textarea.form-control {
+    ~ label {
+      padding-bottom: 0;
+      width: calc(100% - (forms.$input-border-width * 2));
+      max-width: none;
+      height: unset;
+    }
+
+    &:focus,
+    &:not(:placeholder-shown) {
+      padding-top: forms.$input-padding-y-lg * 1.5;
+      padding-bottom: forms.$input-padding-y-lg;
+
+      ~ label {
+        padding-top: forms.$input-padding-y-lg * forms.$form-floating-label-scale;
+        width: calc(
+          (100% * forms.$form-floating-label-upscale) -
+            (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
+            (forms.$input-border-width * forms.$form-floating-label-upscale * 2) -
+            (forms.$form-floating-padding-x * forms.$form-floating-label-upscale)
+        );
+        max-width: none;
+        background: forms.$input-bg;
       }
     }
   }
@@ -56,23 +128,4 @@
       }
     }
   }
-
-  // disable styleint here, because the classes are coming from bs5
-  /* stylelint-disable */
-  > .form-control {
-    @extend .form-control-lg;
-  }
-
-  > .form-select {
-    @extend .form-select-lg;
-
-    &:empty {
-      ~ label {
-        transform: translateY(
-          forms.$form-floating-padding-y - forms.$form-floating-label-padding-t
-        );
-      }
-    }
-  }
-  /* stylelint-enable */
 }

--- a/packages/styles/src/components/floating-label.scss
+++ b/packages/styles/src/components/floating-label.scss
@@ -30,10 +30,8 @@
   }
 
   > .form-control {
-    // disable styleint here, because the classes are coming from bs5
-    /* stylelint-disable */
-    @extend .form-control-lg;
-    /* stylelint-disable */
+    // disable stylelint here, because the classes are coming from bs5
+    @extend .form-control-lg; /* stylelint-disable-line */
 
     &[type='file']::file-selector-button {
       padding-top: forms.$form-floating-input-padding-t +
@@ -63,10 +61,8 @@
   }
 
   > .form-select {
-    // disable styleint here, because the classes are coming from bs5
-    /* stylelint-disable */
-    @extend .form-control-lg;
-    /* stylelint-disable */
+    // disable stylelint here, because the classes are coming from bs5
+    @extend .form-control-lg; /* stylelint-disable-line */
 
     padding-top: forms.$form-floating-input-padding-t;
     padding-bottom: forms.$form-floating-input-padding-b;

--- a/packages/styles/src/variables/components/_forms.scss
+++ b/packages/styles/src/variables/components/_forms.scss
@@ -1,5 +1,6 @@
-@use 'sass:map';
 @use 'sass:math';
+@use 'sass:list';
+@use 'sass:map';
 
 @use './button';
 @use '../color';
@@ -16,19 +17,19 @@ $form-label-color: rgba(var(--post-contrast-color-rgb), 0.8) !default;
 
 $input-padding-y: button.$input-btn-padding-y !default;
 $input-padding-x: button.$input-btn-padding-x !default;
-$input-line-height: button.$input-btn-line-height !default;
+$input-line-height: type.$line-height-regular !default;
 
 $input-padding-y-sm: button.$input-btn-padding-y-sm !default;
 $input-padding-x-sm: button.$input-btn-padding-x-sm !default;
-$input-line-height-sm: button.$input-btn-line-height-sm !default;
+$input-line-height-sm: type.$line-height-regular !default;
 
 $input-padding-y-rg: button.$input-btn-padding-y-rg !default;
 $input-padding-x-rg: button.$input-btn-padding-x-rg !default;
-$input-line-height-rg: button.$input-btn-line-height-rg !default;
+$input-line-height-rg: type.$line-height-regular !default;
 
-$input-padding-y-lg: spacing.$size-large !default;
+$input-padding-y-lg: spacing.$size-small-large !default;
 $input-padding-x-lg: button.$input-btn-padding-x-lg !default;
-$input-line-height-lg: button.$input-btn-line-height-lg !default;
+$input-line-height-lg: type.$line-height-regular !default;
 
 $input-bg: color.$white !default;
 $input-disabled-bg: rgba(var(--post-contrast-color-inverted-rgb), 0.6) !default;
@@ -69,7 +70,7 @@ $input-height-content-rg: type.$font-size-regular * $input-line-height-rg !defau
 $input-height-inner-rg: $input-height-content-rg + ($input-padding-y-rg * 2) !default;
 $input-height-rg: calc(#{$input-height-inner-rg} + #{$input-height-border}) !default;
 
-$input-height-content-lg: type.$font-size-bigger-regular * $input-line-height-lg !default;
+$input-height-content-lg: type.$font-size-medium * $input-line-height-lg !default;
 $input-height-inner-lg: $input-height-content-lg + ($input-padding-y-lg * 2) !default; // Design System
 $input-height-lg: calc(#{$input-height-inner-lg} + #{$input-height-border}) !default;
 
@@ -109,7 +110,7 @@ $form-floating-padding-x: $input-padding-x-lg;
 $form-floating-padding-y: $input-padding-y-lg;
 $form-floating-input-padding-t: spacing.$size-large;
 $form-floating-input-padding-b: 0;
-$form-floating-line-height: $input-height-inner-lg - $form-floating-input-padding-t;
+$form-floating-line-height: type.$line-height-base;
 $form-floating-label-opacity: 1;
 $form-floating-label-color: $input-placeholder-color;
 $form-floating-label-font-size: type.$font-size-bigger-regular;
@@ -118,12 +119,10 @@ $form-floating-label-scale: math.div(
   $form-floating-label-font-size-small,
   $form-floating-label-font-size
 );
+$form-floating-label-upscale: math.div(1, $form-floating-label-scale);
 $form-floating-label-translate-x: $form-floating-padding-x * (1 - $form-floating-label-scale);
-$form-floating-label-transform: scale($form-floating-label-scale)
-  translateX($form-floating-label-translate-x);
+$form-floating-label-transform: scale($form-floating-label-scale);
 $form-floating-transition: animation.$transition-base;
-$form-floating-label-padding-t: math.div(spacing.$size-regular, $form-floating-label-scale);
-$form-floating-label-padding-b: math.div(spacing.$size-mini, $form-floating-label-scale);
-$form-floating-textarea-line-height: type.$line-height-base;
-$form-floating-textarea-padding-t: spacing.$size-bigger-big;
-$form-floating-textarea-padding-b: spacing.$size-regular;
+$form-floating-transition-in: $form-floating-transition,
+  width 0ms list.nth(animation.$transition-base, 2);
+$form-floating-transition-out: $form-floating-transition, width 0ms linear;


### PR DESCRIPTION
The following form controls have been adjusted:

- input
- select
- input[type="file"]
- textarea

In connection with the revision, the following superfluous scss variables were removed from the project:

- $form-floating-label-padding-t
- $form-floating-label-padding-b
- $form-floating-textarea-line-height
- $form-floating-textarea-padding-t
- $form-floating-textarea-padding-b