### PR TITLE
chore(demo): switched to styles version number

### DIFF
--- a/.changeset/unlucky-insects-do.md
+++ b/.changeset/unlucky-insects-do.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-demo': patch
+---
+
+Switched to displaying the styles package version number instead of the demo app version number. The styles version is more important to developers than thenow disconnected demo version number

--- a/packages/demo/src/app/home/home.component.html
+++ b/packages/demo/src/app/home/home.component.html
@@ -14,7 +14,7 @@
     <h2 class="font-curve-large">Design System</h2>
     <p class="font-monospace small">
       <button class="btn btn-tertiary version-button" placement="right" [ngbPopover]="versions">
-        v{{ version }}
+        v{{ getVersion(stylesVersion) }}
       </button>
     </p>
     <p>


### PR DESCRIPTION
Switched to displaying the styles package version number instead of the demo app version number. The styles version is more important to developers than thenow disconnected demo version number