### PR TITLE
chore: add a github codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# these users will be requested for
+# review when someone opens a pull request.
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @gfellerph @oliverschuerch @alizedebray

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CODEOWNERS


### PR DESCRIPTION
Adds maintainers as codeowners so they will be requested for review on every pull request. This is something we have to do manually at the moment.