### PR TITLE
chore: remove IDE specific instructions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "[scss]": {
-    "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
-}


### PR DESCRIPTION
These instructions are not very useful at the moment and not everybody is using the same IDE. We already have a editorconfig in the root for the most basic settings, everything else would be up to the dev. Correct linting is enforced with the PR check.