### PR TITLE
build(actions): fix deprecated set_output

### DIFF
--- a/.github/actions/artifact-download/action.yaml
+++ b/.github/actions/artifact-download/action.yaml
@@ -52,5 +52,5 @@ runs:
       id: build
       shell: bash
       run: |
-        echo "::set-output name=id::$(cat ${{ inputs.folder }}/GHA-EVENT-ID)"
-        echo "::set-output name=action::$(cat ${{ inputs.folder }}/GHA-EVENT-ACTION)"
+        echo "id=$(cat ${{ inputs.folder }}/GHA-EVENT-ID)" >> $GITHUB_OUTPUT
+        echo "action=$(cat ${{ inputs.folder }}/GHA-EVENT-ACTION)" >> $GITHUB_OUTPUT

--- a/.github/actions/deploy-to-netlify/action.yaml
+++ b/.github/actions/deploy-to-netlify/action.yaml
@@ -85,13 +85,13 @@ runs:
         url_alias=`echo "preview-${{ inputs.id }}" | iconv -t ascii//TRANSLIT | sed -E 's/[~\^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+\|-+$//g' | sed -E 's/^-+//g' | sed -E 's/-+$//g' | tr A-Z a-z`
         netlify link --id ${{ inputs.netlify_site_id }}
         netlify deploy --alias $url_alias --build false --dir ${{ inputs.folder }}
-        echo "::set-output name=url_alias::$url_alias"
+        echo "url_alias=$url_alias" >> $GITHUB_OUTPUT
 
     - name: Prepare Comment Message
       id: comment
       shell: bash
       run: |
-        echo "::set-output name=message::Preview environment ready: https://${{ steps.netlify_deploy.outputs.url_alias }}--${{ inputs.netlify_site_url }}"
+        echo "message=Preview environment ready: https://${{ steps.netlify_deploy.outputs.url_alias }}--${{ inputs.netlify_site_url }}" >> $GITHUB_OUTPUT
 
     - name: Replace Preview Comment
       uses: peter-evans/create-or-update-comment@v2

--- a/packages/demo/src/app/common/highlight.provider.ts
+++ b/packages/demo/src/app/common/highlight.provider.ts
@@ -7,7 +7,6 @@ export class HighlightProvider {
         provide: HIGHLIGHT_OPTIONS,
         useValue: {
           fullLibraryLoader: () => import('highlight.js').then(lib => {
-            console.log(lib);
             return lib;
           }).catch(e => console.log(e)),
         }


### PR DESCRIPTION
According to this post https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/, the set_output can be replaced by the newer env file approach.