### PR TITLE
fix(demo): update target Angular version to 14

### DIFF
--- a/.changeset/forty-pillows-cross.md
+++ b/.changeset/forty-pillows-cross.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-demo': patch
+---
+
+Updated the target Angular version to 14 in the migration instructions. The Intranet Header is not compatible with older versions.

--- a/packages/demo/src/app/home/home.component.html
+++ b/packages/demo/src/app/home/home.component.html
@@ -162,11 +162,11 @@
       <li>
         <h4 class="h5 bold">Update your packages 🩺</h4>
         <p>
-          If your angular version is lower than 13, use
+          If your angular version is lower than 14, use
           <a href="https://update.angular.io/" target="_blank" rel="noopener">
             https://update.angular.io/
           </a>
-          to update angular step by step to version 13.
+          to update angular step by step to version 14.
         </p>
         <p>Make sure, you have updated all your packages as far as possible.</p>
       </li>


### PR DESCRIPTION
Updated the target Angular version to 14 in the migration instructions. The Intranet Header is not compatible with older versions.