### PR TITLE
build(release): check if package version updated for docs deploys

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,9 +45,18 @@ jobs:
           publish: pnpm changeset:publish
           version: pnpm changeset:version
 
+      # Check if demo version changed
+      - name: Demo version check
+        id: demoCheck
+        uses: MontyD/package-json-updated-action
+        with:
+          path: ./packages/demo/package.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Publish demo only if changesets published any packages
       - name: Publish demo
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.demoCheck.outputs.has-updated
         id: netlify
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
@@ -56,8 +65,17 @@ jobs:
           netlify link --id $NETLIFY_SITE_ID
           netlify deploy --build false --dir packages/demo/dist/demo --prod
 
+      # Check if main storybook changed
+      - name: Main Storybook version check
+        id: sbCheck
+        uses: MontyD/package-json-updated-action
+        with:
+          path: ./packages/documentation/package.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Publish storybook
       - name: Publish storybooks
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.sbCheck.outputs.has-updated
         id: storybook
         run: pnpm --filter design-system-documentation run chromatic --project-token=${{ secrets.CHROMATIC_STORYBOOK_TOKEN }}


### PR DESCRIPTION
The old check only checked if any package got released to npm, which is not the case if the only the documentation got updated. This did not trigger a deploy of the documentations. The intended behaviour was to check if the demo package.json version has changed and do a release then.