### PR TITLE
fix(datepicker): alignment of days when outside="hidden"

### DIFF
--- a/.changeset/stale-buses-lie.md
+++ b/.changeset/stale-buses-lie.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+When outside days get hidden, they collapse in their flex context and change the alignment of the first days of the month. Adding flex-grow 1 ensures the hidden days still keep their space so the day labels on top match correctly with the calendar days.

--- a/packages/styles/src/components/datepicker.scss
+++ b/packages/styles/src/components/datepicker.scss
@@ -89,6 +89,10 @@ span.ngb-dp-navigation-chevron {
 .ngb-dp-day {
   width: auto !important;
   height: auto !important;
+
+  &.hidden {
+    flex-grow: 1;
+  }
 }
 
 .ngb-dp-day > .btn-light {


### PR DESCRIPTION
When outside days get hidden, they collapse in their flex context and change the alignment of the first days of the month. Adding flex-grow 1 ensures the hidden days still keep their space so the day labels on top match correctly with the calendar days.