### PR TITLE
fix: use parens for attributions

### DIFF
--- a/.changeset/three-apricots-cheat.md
+++ b/.changeset/three-apricots-cheat.md
@@ -1,0 +1,9 @@
+---
+'@swisspost/design-system-changelog-github': patch
+---
+
+The <sup> construct does not work as intended in most contexts, adding unnecessary and confusing spacing into changelogs. New intended format:
+
+- This is a contribution. (by username with #111)
+- This is a multiline contribution that needs
+  a lot of text (by username with #111)

--- a/packages/changelog-github/src/index.ts
+++ b/packages/changelog-github/src/index.ts
@@ -64,9 +64,9 @@ const changelogFunctions: ChangelogFunctions = {
       '\n\n- ',
       firstLine,
       futureLines.map(l => `  ${l}`).join('\n'),
-      hasUserOrPull ? '\n<br><sup>' : '',
+      hasUserOrPull ? ' (' : '',
       [userString, pullString].join(' '),
-      hasUserOrPull ? '</sup>' : '',
+      hasUserOrPull ? ')' : '',
     ];
 
     return entry.join('');


### PR DESCRIPTION
The <sup> construct does not work as intended in most contexts, adding unnecessary and confusing spacing into changelogs. New intended format:
- This is a contribution. (by username with [#111](https://github.com/swisspost/design-system/issues/111))
- This is a multiline contribution that needs
a lot of text (by username with [#111](https://github.com/swisspost/design-system/issues/111))