### PR TITLE
feat(documentation): add import instruction to intranet header documentation

### DIFF
--- a/.changeset/slow-tables-kick.md
+++ b/.changeset/slow-tables-kick.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-demo': patch
+---
+
+Adds import instructions to intranet-header documentation

--- a/.changeset/slow-tables-kick.md
+++ b/.changeset/slow-tables-kick.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-demo': patch
 ---
 
-Adds import instructions to intranet-header documentation
+Added import instructions to the intranet-header documentation

--- a/packages/demo/src/app/intranet-layout/intranet-layout.component.html
+++ b/packages/demo/src/app/intranet-layout/intranet-layout.component.html
@@ -14,6 +14,10 @@
   <h2 class="bold mt-5">Usage</h2>
   <section class="light font-curve-regular">
     <p>
+        In your <code>app.module.ts</code>, add the header to your imports:
+    </p>
+    <code class="block" [highlight]="codeModule" [languages]="['typescript']"></code>
+    <p>
       On your layout page; create a container (e.g. <code>&lt;div&gt;</code> or
       <code>&lt;section&gt;</code> - or use the <code>body</code> container) and
       apply the following css classes:

--- a/packages/demo/src/app/intranet-layout/intranet-layout.component.ts
+++ b/packages/demo/src/app/intranet-layout/intranet-layout.component.ts
@@ -10,6 +10,20 @@ const codeTemplateBig =
   styleUrls: ['intranet-layout.component.css'],
 })
 export class IntranetLayoutComponent {
+  codeModule = `// Other imports ....
+  import { SwissPostIntranetHeaderModule } from '@swisspost/design-system-intranet-header';
+
+  @NgModule({
+    declarations: [
+      // ...
+    ],
+    imports: [
+      // ...
+      SwissPostIntranetHeaderModule,
+    ],
+    // ...
+  })
+  export class AppModule {}`;
   codeTemplateSmall = codeTemplateSmall;
   codeTemplateBig = codeTemplateBig;
   codeTemplateReg = `<sp-intranet-header siteTitle="SiteTitle" isPreview="true" languages="de,fr,it">


### PR DESCRIPTION
Adds import instructions for the intranet-header component because I stumbled upon it myself earlier.
![image](https://user-images.githubusercontent.com/5127581/203996345-10cbfcd6-582c-41b9-9766-4ede86d89c1b.png)
