### PR TITLE
fix(sidebar): inherit width for fixed sidebar

### DIFF
--- a/.changeset/wise-news-raise.md
+++ b/.changeset/wise-news-raise.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-styles': patch
+'@swisspost/design-system-intranet-header': patch
+---
+
+Fixed an issue with the sidebar width. The fixed sidebar no longer spans the whole page and no longer hides the main page content beneath.

--- a/packages/styles/src/components/intranet-header/_sidebar.scss
+++ b/packages/styles/src/components/intranet-header/_sidebar.scss
@@ -73,7 +73,7 @@
     top: auto;
     top: 0;
     bottom: 0;
-    width: 100%;
+    width: inherit;
     max-width: inherit;
     margin-left: spacing.$spacer * -1;
     padding: spacing.$spacer 0;


### PR DESCRIPTION
Fixed an issue with the sidebar width. The fixed sidebar no longer spans the whole page and no longer hides the main page content beneath.