### PR TITLE
fix(styles): unwrap complex :is selector

### DIFF
--- a/.changeset/light-hairs-turn.md
+++ b/.changeset/light-hairs-turn.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Unwrapped complex :is selector. When integrating in another project, the `not-disabled-focus-hover` mixin causes sass to silently fail and generate an empty output.

--- a/packages/styles/src/mixins/_utilities.scss
+++ b/packages/styles/src/mixins/_utilities.scss
@@ -73,7 +73,9 @@
 }
 
 @mixin not-disabled-focus-hover {
-  &:is(:focus, :not(:disabled):hover, .pretend-hover) {
+  &:focus,
+  &:not(:disabled):hover,
+  &.pretend-hover {
     @content;
   }
 }


### PR DESCRIPTION
Sass seems not entirely ready for :is. When integrating in another project, this mixin causes sass to silently fail and generate an empty output. The bug is not recreatable in a different environment and therefore we could not raise an issue with sass (yet).