### PR TITLE
fix(internet-header): patched relative URLs in search recommendations

### DIFF
--- a/.changeset/cool-colts-tell.md
+++ b/.changeset/cool-colts-tell.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Patched relative URLs for the "most searched services" feature of the search box. Relative URLs are always resolved to the base "https://post.ch"

--- a/packages/documentation/cypress/e2e/search.cy.ts
+++ b/packages/documentation/cypress/e2e/search.cy.ts
@@ -133,13 +133,12 @@ describe('search', () => {
     it('redirects to the correct search page', () => {
       cy.changeArg('search', true);
       cy.get(searchButton).click();
-      cy.get('#searchBox')
-        .click()
-        .type('{downArrow}', { force: true })
-        .type('{enter}', { force: true });
-      cy.location('pathname').should(
-        'eq',
-        '/de/kundencenter/onlinedienste/vgk/paketetiketten-inland/info',
+      cy.get('#searchBox').click().type('{downArrow}', { force: true });
+
+      cy.get('.search-recommendation.selected').should(
+        'have.attr',
+        'href',
+        'https://post.ch/de/kundencenter/onlinedienste/vgk/paketetiketten-inland/info',
       );
     });
   });

--- a/packages/internet-header/src/components/post-search/post-search.tsx
+++ b/packages/internet-header/src/components/post-search/post-search.tsx
@@ -364,7 +364,7 @@ export class PostSearch implements HasDropdown, IsFocusable {
                           <li key={recommendation.href}>
                             <a
                               class="nav-link search-recommendation"
-                              href={recommendation.href}
+                              href={new URL(recommendation.href, 'https://post.ch').href}
                               data-suggestion-text={recommendation.label}
                               onMouseEnter={e => this.handleMouseEnterSuggestion(e)}
                             >


### PR DESCRIPTION
Patched relative URLs for the "most searched services" feature of the search box. Relative URLs are always resolved to the base "https://post.ch"