### PR TITLE
chore: build docs when internet header is updated

### DIFF
--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -17,6 +17,7 @@ on:
       - 'packages/documentation/**'
       - 'packages/styles/**'
       - 'packages/components/**'
+      - 'packages/internet-header/**'
 
 jobs:
   build:


### PR DESCRIPTION
This lets the documentation build workflow run when internet header files have changed, enabling PR previews for this package as well.