### PR TITLE
chore: group non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "labels": ["{{{parentDir}}}"],
   "packageRules": [
     {
@@ -12,13 +10,15 @@
         "monorepo:angular-eslint",
         "monorepo:jasmine"
       ],
-      "matchUpdateTypes": [
-        "digest",
-        "patch",
-        "minor",
-        "major"
-      ],
+      "matchUpdateTypes": ["digest", "patch", "minor", "major"],
       "groupName": "Angular"
+    },
+    {
+      "comment": "Grouping all non-major dependencies: https://docs.renovatebot.com/presets-group/#groupallnonmajor",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
     }
   ],
   "timezone": "Europe/Zurich",


### PR DESCRIPTION
In an effort to reduce the amount of PRs created by renovate, I'd like to test the group all non-major updates policy. This should create just one PR for all minor and patch updates which is much easier to merge on Monday.