### PR TITLE
chore: exclude bootstrap and typescript

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
     },
     {
       "matchPackagePatterns": ["*"],
+      "excludePackageNames": ["bootstrap", "typescript"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
Excludes bootstrap and typescript from the minor or patch group of updates. Bootstrap seems not to adhere to semantic versioning and includes breaking changes into minor versions and typescript usually is defined as peer dependency of angular in a specific version.