### PR TITLE
chore: mark components as public

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/post-components/post-components.esm.js",
-  "private": true,
+  "private": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/swisspost/design-system"


### PR DESCRIPTION
This will enable the changeset publish workflow to publish the components package to npm.