### PR TITLE
chore: add renovate rule to fix angular for styles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchFiles": ["packages/styles/package.json"],
+      "matchPackagePatterns": ["^@angular"],
+      "allowedVersions": "<=15.0.4"
     }
   ],
   "timezone": "Europe/Zurich",


### PR DESCRIPTION
Angular schematics had a regression where utils are no longer exposed in versions newer than 15.0.4. Fixing Angular packages in the styles package does not have an impact on the supported version of Angular by the styles itself.