### PR TITLE
chore: deprecate alert-error and alert-notification

### DIFF
--- a/.changeset/clever-fans-remember.md
+++ b/.changeset/clever-fans-remember.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Deprecated the `alert-error` and the `alert-notification` variants of the alert component. These variants will be removed in the next major version.

--- a/packages/demo/src/app/bootstrap/components/alert/alert-demo-page/alert-demo-page.component.html
+++ b/packages/demo/src/app/bootstrap/components/alert/alert-demo-page/alert-demo-page.component.html
@@ -46,8 +46,10 @@
 </p>
 <section>
   <div class="alert alert-warning">
-    The following two color variants are deprecated and will be removed in the next major version of
-    the styles package:
+    <p>
+      The following two color variants are deprecated and will be removed in the next major version
+      of the styles package:
+    </p>
     <ul>
       <li>
         <code>alert-error</code>

--- a/packages/demo/src/app/bootstrap/components/alert/alert-demo-page/alert-demo-page.component.html
+++ b/packages/demo/src/app/bootstrap/components/alert/alert-demo-page/alert-demo-page.component.html
@@ -1,78 +1,125 @@
 <div class="heading py-5">
   <h1 id="alerts" class="bold font-curve-large">Alerts / Notifications</h1>
   <h2 class="font-curve-medium">Using Bootstrap v5.0</h2>
-  <a href="https://getbootstrap.com/docs/5.0/components/alerts/" target="_blank" rel="noopener"
-     class="btn btn-primary btn-sm btn-animated"><span>Bootstrap Documentation</span></a>
+  <a
+    href="https://getbootstrap.com/docs/5.0/components/alerts/"
+    target="_blank"
+    rel="noopener"
+    class="btn btn-primary btn-sm btn-animated"
+  >
+    <span>Bootstrap Documentation</span>
+  </a>
 </div>
 
 <section class="continous-text">
   <h3>Usage</h3>
   <div class="alert-container mt-5">
     <div class="alert alert-info">
-      <p class="alert-heading">The markup for alerts differs from the basic bootstrap implementation, to secure cross-browser compatibility!</p>
+      <p class="alert-heading">
+        The markup for alerts differs from the basic bootstrap implementation, to secure
+        cross-browser compatibility!
+      </p>
       <p>
-        While all bootstrap classes related to alerts are still available and functional, there are some changes to their HTMs-Markup.
+        While all bootstrap classes related to alerts are still available and functional, there are
+        some changes to their HTMs-Markup.
       </p>
       <ul>
         <li>The close button for dismissible alerts needs to be the first tag inside the alert.</li>
         <li>Alerts have an alert-container around them.</li>
-        <li>All alert-content needs to be wrapped in their own tag, for example a &lt;p&gt;-tag.</li>
-        <li>For thematic colors, only the alerts shown on this page are available. (No "alert-light" or "alert-dark" available.)</li>
+        <li>
+          All alert-content needs to be wrapped in their own tag, for example a &lt;p&gt;-tag.
+        </li>
+        <li>
+          For thematic colors, only the alerts shown on this page are available. (No "alert-light"
+          or "alert-dark" available.)
+        </li>
       </ul>
       <p class="bold pt-3">For Toasts, the bootstrap classes are not yet available!</p>
     </div>
   </div>
 </section>
 
-
 <h1>Toast / Small notification bar</h1>
-<p>These are not meant to be put on a page directly, they should only be used overlaying the site content. It should always close the toast when you click on it.</p>
+<p>
+  These are not meant to be put on a page directly, they should only be used overlaying the site
+  content. It should always close the toast when you click on it.
+</p>
 <section>
+  <div class="alert alert-warning">
+    The following two color variants are deprecated and will be removed in the next major version of
+    the styles package:
+    <ul>
+      <li>
+        <code>alert-error</code>
+        becomes
+        <code>alert-danger</code>
+      </li>
+      <li>
+        <code>alert-notification</code>
+        becomes
+        <code>alert-primary</code>
+      </li>
+    </ul>
+  </div>
   <app-toast-demo></app-toast-demo>
 </section>
-<code class="block" [highlight]="codeTemplateToast" [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"></code>
+<code
+  class="block"
+  [highlight]="codeTemplateToast"
+  [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+></code>
 
 <h1>Alert / Notification bar</h1>
-<p class="continous-text">
-
-</p>
+<p class="continous-text"></p>
 <section>
   <app-alert-demo></app-alert-demo>
 </section>
-<code class="block" [highlight]="codeTemplateAlert" [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"></code>
+<code
+  class="block"
+  [highlight]="codeTemplateAlert"
+  [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+></code>
 
 <h1>Alert / Notification bar with action</h1>
-<p class="continous-text">
-
-</p>
+<p class="continous-text"></p>
 <section>
   <app-action-alert-demo></app-action-alert-demo>
 </section>
-<code class="block" [highlight]="codeTemplateAction" [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"></code>
+<code
+  class="block"
+  [highlight]="codeTemplateAction"
+  [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+></code>
 
 <h1>Button notification</h1>
-<p class="continous-text">
-
-</p>
+<p class="continous-text"></p>
 <section>
   <app-button-notification-demo></app-button-notification-demo>
 </section>
-<code class="block" [highlight]="codeTemplateButton" [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"></code>
+<code
+  class="block"
+  [highlight]="codeTemplateButton"
+  [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+></code>
 
 <h1>Overlay Notification</h1>
-<p class="continous-text">
-
-</p>
+<p class="continous-text"></p>
 <section>
   <app-overlay-notification-demo></app-overlay-notification-demo>
 </section>
-<code class="block" [highlight]="codeTemplateOverlay" [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"></code>
+<code
+  class="block"
+  [highlight]="codeTemplateOverlay"
+  [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+></code>
 
 <h1>Notification dot</h1>
-<p class="continous-text">
-
-</p>
+<p class="continous-text"></p>
 <section>
-    <app-dot-notification-demo></app-dot-notification-demo>
+  <app-dot-notification-demo></app-dot-notification-demo>
 </section>
-<code class="block" [highlight]="codeTemplateDot" [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"></code>
+<code
+  class="block"
+  [highlight]="codeTemplateDot"
+  [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+></code>


### PR DESCRIPTION
Deprecated the `alert-error` and the `alert-notification` variants of the alert component. These variants will be removed in the next major version.