### PR TITLE
feat(styles): decouple fixed position and actions for alerts

### DIFF
--- a/.changeset/smooth-pants-argue.md
+++ b/.changeset/smooth-pants-argue.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-documentation': minor
+'@swisspost/design-system-styles': minor
+---
+
+Decoupled the fixed and the action button styles for the alert component. Alerts can now be fixed to bottom without having action buttons and can have action buttons without being fixed to the bottom of the page.

--- a/packages/documentation/src/stories/components/alert/alert.stories.tsx
+++ b/packages/documentation/src/stories/components/alert/alert.stories.tsx
@@ -139,7 +139,7 @@ const Template = (args: Args) => {
     args.noIcon ? 'no-icon' : '',
     args.dismissible ? 'alert-dismissible' : '',
     args.fixed ? 'alert-fixed-bottom' : '',
-    args.action ? 'alert-action alert-fixed-bottom' : '',
+    args.action ? 'alert-action' : '',
     args.show ? '' : 'd-none',
   ]
     .filter(c => c)
@@ -156,7 +156,7 @@ const Template = (args: Args) => {
   return (
     <div className={classes} role="alert">
       {/* Dismissible Button */}
-      {(args.dismissible || args.fixed) && !args.action ? (
+      {args.dismissible || args.fixed ? (
         <button
           className="btn-close"
           data-dismiss="alert"
@@ -193,7 +193,7 @@ export const Default: Story = Template.bind({});
 Default.decorators = [
   (Story: Story, { args }) => {
     const [_, updateArgs] = useArgs();
-    const showToggleButton = args.fixed || args.action;
+    const showToggleButton = args.fixed;
     const showResetButton = !showToggleButton && args.dismissible && !args.show;
 
     return (

--- a/packages/styles/src/components/alert.scss
+++ b/packages/styles/src/components/alert.scss
@@ -84,8 +84,7 @@
   }
 }
 
-.alert-fixed-bottom,
-%alert-fixed {
+.alert-fixed-bottom {
   position: fixed;
   z-index: commons.$zindex-alert;
   bottom: 0;
@@ -129,8 +128,6 @@
 }
 
 .alert-action {
-  @extend %alert-fixed;
-
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: center;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9888,7 +9888,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1_bluebird@3.7.2
+      promise-inflight: 1.0.1
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -19812,17 +19812,6 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
-    dev: true
-
-  /promise-inflight/1.0.1_bluebird@3.7.2:
-    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
-    peerDependencies:
-      bluebird: '*'
-    peerDependenciesMeta:
-      bluebird:
-        optional: true
-    dependencies:
-      bluebird: 3.7.2
     dev: true
 
   /promise-retry/2.0.1:


### PR DESCRIPTION
Decoupled the fixed and the action button styles for the alert component. Alerts can now be fixed to bottom without having action buttons and can have action buttons without being fixed to the bottom of the page.