### PR TITLE
fix(docs): use btn-md instead of empty string

### DIFF
--- a/.changeset/plenty-jars-approve.md
+++ b/.changeset/plenty-jars-approve.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed an issue with the button group story that lead to a bug for all following stories where controls did not show up and navigation was janky.

--- a/packages/documentation/src/stories/components/button-group/button-group.stories.tsx
+++ b/packages/documentation/src/stories/components/button-group/button-group.stories.tsx
@@ -27,11 +27,11 @@ export default {
         labels: {
           ' btn-sm': 'Small',
           ' btn-rg': 'Regular',
-          '': 'Medium',
+          ' btn-md': 'Medium',
           ' btn-lg': 'Large',
         },
       },
-      options: [' btn-sm', ' btn-rg', '', ' btn-lg'],
+      options: [' btn-sm', ' btn-rg', ' btn-md', ' btn-lg'],
       table: {
         category: 'General'
       }


### PR DESCRIPTION
Empty key values break storybook control rendering and lead to navigation hiccups. Using a default here is better because it's the correct class. The field is initially empty, so the default state without explicit class is still documented, only when size: md is explicitly chosen, the class will show up in the code block.