### PR TITLE
fix(header): shipment info in search suggestions not reset

### DIFF
--- a/.changeset/twenty-apples-allow.md
+++ b/.changeset/twenty-apples-allow.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fixed a bug where a shipment information in the search suggestions was not reset after the search query changed.

--- a/packages/internet-header/src/components/post-search/post-search.tsx
+++ b/packages/internet-header/src/components/post-search/post-search.tsx
@@ -168,9 +168,10 @@ export class PostSearch implements HasDropdown, IsFocusable {
       getParcelSuggestion(query, state.localizedConfig.header.search),
     ]);
 
+    this.parcelSuggestion = trackAndTraceInfo;
+
     // Parcel suggestion is more important than any other
     if (trackAndTraceInfo) {
-      this.parcelSuggestion = trackAndTraceInfo;
       this.placeSuggestions = [];
       this.coveoSuggestions = [];
     } else {


### PR DESCRIPTION
Fixed a bug where a shipment information in the search suggestions was not reset after the search query changed.