### PR TITLE
fix: use local version for dependency-links

### DIFF
--- a/packages/demo/src/app/common/dependency-link/dependency-link.component.ts
+++ b/packages/demo/src/app/common/dependency-link/dependency-link.component.ts
@@ -18,7 +18,6 @@ export class DependencyLinkComponent implements OnDestroy {
   dependencyVersion: string;
   documentationBaseUrl: string;
   urlChangeSubscription: Subscription;
-  currentVersion$: Subscription;
 
   constructor(private route: ActivatedRoute, private versionService: VersionService) {
     this.urlChangeSubscription = this.route.url.subscribe(() => {
@@ -43,6 +42,5 @@ export class DependencyLinkComponent implements OnDestroy {
 
   ngOnDestroy() {
     this.urlChangeSubscription.unsubscribe();
-    this.currentVersion$.unsubscribe();
   }
 }

--- a/packages/demo/src/app/common/dependency-link/dependency-link.component.ts
+++ b/packages/demo/src/app/common/dependency-link/dependency-link.component.ts
@@ -22,23 +22,22 @@ export class DependencyLinkComponent implements OnDestroy {
 
   constructor(private route: ActivatedRoute, private versionService: VersionService) {
     this.urlChangeSubscription = this.route.url.subscribe(() => {
-      this.currentVersion$ = this.versionService.currentVersion.subscribe(({ dependencies }) => {
-        if (route.parent.snapshot.url[0].path === 'ng-bootstrap-samples') {
-          this.dependency = 'ng-bootstrap';
-          this.dependencyVersion = dependencies.get('@ng-bootstrap/ng-bootstrap').format('x');
-          this.documentationBaseUrl = `https://ng-bootstrap.github.io${
-            this.dependencyVersion === '14' ? '' : `/releases/${this.dependencyVersion}.x`
-          }/#/`;
-        } else {
-          this.dependency = 'Bootstrap';
-          this.dependencyVersion = dependencies.get('bootstrap').format('x.x');
-          this.documentationBaseUrl = `https://getbootstrap.com/docs/${this.dependencyVersion}/`;
-        }
+      const { dependencies } = this.versionService.localVersion;
+      if (route.parent.snapshot.url[0].path === 'ng-bootstrap-samples') {
+        this.dependency = 'ng-bootstrap';
+        this.dependencyVersion = dependencies.get('@ng-bootstrap/ng-bootstrap').format('x');
+        this.documentationBaseUrl = `https://ng-bootstrap.github.io${
+          this.dependencyVersion === '14' ? '' : `/releases/${this.dependencyVersion}.x`
+        }/#/`;
+      } else {
+        this.dependency = 'Bootstrap';
+        this.dependencyVersion = dependencies.get('bootstrap').format('x.x');
+        this.documentationBaseUrl = `https://getbootstrap.com/docs/${this.dependencyVersion}/`;
+      }
 
-        if (!this.documentationPath) {
-          this.documentationPath = `components/${route.snapshot.url[0].path}`;
-        }
-      });
+      if (!this.documentationPath) {
+        this.documentationPath = `components/${route.snapshot.url[0].path}`;
+      }
     });
   }
 

--- a/packages/demo/src/app/common/version.service.ts
+++ b/packages/demo/src/app/common/version.service.ts
@@ -73,5 +73,9 @@ export class VersionService {
       );
   }
 
+  public get localVersion() {
+    return new PackageVersion({ ...packageJSON, url: '/', title: 'Local version' });
+  }
+
   constructor(private http: HttpClient) {}
 }


### PR DESCRIPTION
While refactoring the versions.json, the remote versions were used in the DependencyLink component by mistake. Refactored the component to use the local package.json information instead of the remote versions.json information.