### PR TITLE
fix(demo): add auto as default placement setting

### DIFF
--- a/.changeset/blue-geese-pretend.md
+++ b/.changeset/blue-geese-pretend.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-demo': patch
+---
+
+Updated the documentation for tooltips regarding the "auto" placement option which can be used to place the tooltip where it fits if there is not enough space for the initial placement.

--- a/packages/demo/src/app/ng-bootstrap/components/tooltip/tooltip-demo-page/tooltip-demo-page.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/tooltip/tooltip-demo-page/tooltip-demo-page.component.html
@@ -5,5 +5,15 @@
 
 <section>
   <app-ngb-tooltip-demo></app-ngb-tooltip-demo>
+  <p class="mt-3">
+    Using
+    <code>placement="[position] auto"</code>
+    allows the tooltip to be displayed in another location if there is no room for the initial
+    placement location.
+  </p>
 </section>
-<code class="block" [highlight]="codeTemplate" [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"></code>
+<code
+  class="block"
+  [highlight]="codeTemplate"
+  [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+></code>

--- a/packages/demo/src/app/ng-bootstrap/components/tooltip/tooltip-demo/tooltip-demo.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/tooltip/tooltip-demo/tooltip-demo.component.html
@@ -1,11 +1,16 @@
 <div class="d-flex gap-3 flex-wrap">
-  <button type="button" class="btn btn-secondary me-2" placement="top" ngbTooltip="Tooltip on top">
+  <button
+    type="button"
+    class="btn btn-secondary me-2"
+    placement="top auto"
+    ngbTooltip="Tooltip on top"
+  >
     Tooltip on top
   </button>
   <button
     type="button"
     class="btn btn-secondary me-2"
-    placement="right"
+    placement="right auto"
     ngbTooltip="Tooltip on right"
   >
     Tooltip on right
@@ -13,7 +18,7 @@
   <button
     type="button"
     class="btn btn-secondary me-2"
-    placement="bottom"
+    placement="bottom auto"
     ngbTooltip="Tooltip on bottom"
   >
     Tooltip on bottom
@@ -21,7 +26,7 @@
   <button
     type="button"
     class="btn btn-secondary me-2"
-    placement="left"
+    placement="left auto"
     ngbTooltip="Tooltip on left"
   >
     Tooltip on left
@@ -41,7 +46,7 @@
   <button
     type="button"
     class="btn btn-secondary me-2"
-    placement="top"
+    placement="top auto"
     [ngbTooltip]="tooltipContent"
   >
     Custom HTML Tooltip on top


### PR DESCRIPTION
Updated the documentation for tooltips regarding the "auto" placement option which can be used to place the tooltip where it fits if there is not enough space for the initial placement.