### PR TITLE
chore: add pnpm peerDependencyRules to get rid of unmet- and missing peer warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,19 @@
   "engines": {
     "node": ">=16",
     "pnpm": ">=7.13"
+  },
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": [
+        "eslint",
+        "@typescript-eslint/eslint-plugin",
+        "@typescript-eslint/parser"
+      ],
+      "allowedVersions": {
+        "react": ">=18",
+        "react-dom": ">=18",
+        "stylelint": ">=15"
+      }
+    }
   }
 }


### PR DESCRIPTION
In a pnpm monorepo, these rules must be added to the root `package.json` file and nowhere else.