### PR TITLE
chore: allow patch and minor pnpm updates

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -30,7 +30,7 @@ inputs:
     type: string
   pnpm_version:
     description: Specify the pnpm version to install
-    default: 7.27.0
+    default: 7
     type: string
   use_cache:
     description: Specify wether to use the pnpm cache or not

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "engines": {
     "node": ">=16",
-    "pnpm": "7.27.0"
+    "pnpm": "7"
   },
   "pnpm": {
     "peerDependencyRules": {


### PR DESCRIPTION
Allow pnpm to update minor and patch versions, but not major. Updating major versions breaks things as well as specifying a fixed version.