### PR TITLE
chore: exclude bootstrap from minor patch glob

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     },
     {
       "matchPackagePatterns": ["*"],
-      "excludePackageNames": ["typescript"],
+      "excludePackageNames": ["typescript", "bootstrap"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
Bootstrap keeps introducing breaking changes to their minor versions, this time a bunch of additional variables that are not defined when trying to build.