### PR TITLE
fix(intranet-header): close dropdown on link click

### DIFF
--- a/.changeset/proud-owls-beg.md
+++ b/.changeset/proud-owls-beg.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-intranet-header': patch
+---
+
+Fixed the auto-close behavior of optional dropdown content. Clicking links or routerLinks (<a> tags) now closes the dropdown as expected.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  // Fixes tsconfig not found error in nested .eslintrc.json files with relative paths
+  "eslint.workingDirectories": ["packages/components-angular"]
+}

--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "clean": "rimraf dist",
-    "dev": "ng serve --port 9001",
+    "start": "ng serve --port 9001",
     "build": "ng build intranet-header",
     "lint": "ng lint"
   },

--- a/packages/components-angular/projects/intranet-header-showcase/src/app/app.component.html
+++ b/packages/components-angular/projects/intranet-header-showcase/src/app/app.component.html
@@ -1,52 +1,95 @@
 <section class="preview">
   <sp-intranet-header [showIntranetSearch]="true" siteTitle="PostWeb" searchUrl="/">
     <li class="nav-item"><a href="/postweb" class="col-auto py-3 px-5 nav-link">Home</a></li>
-    <li class="nav-item"><a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">Post Informatik</a></li>
+    <li class="nav-item">
+      <a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">
+        Post Informatik
+      </a>
+    </li>
     <li class="nav-item"><a class="col-auto py-3 px-5 nav-link">HR-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a></li>
+    <li class="nav-item">
+      <a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a>
+    </li>
+    <li class="nav-item">
+      <a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a>
+    </li>
   </sp-intranet-header>
 </section>
 
 <section class="preview">
   <sp-intranet-header siteTitle="PostWeb" [optionDropdownContent]="myCustomOptions">
     <li class="nav-item"><a href="/postweb" class="col-auto py-3 px-5 nav-link">Home</a></li>
-    <li class="nav-item"><a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">Post Informatik</a></li>
+    <li class="nav-item">
+      <a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">
+        Post Informatik
+      </a>
+    </li>
     <li class="nav-item"><a class="col-auto py-3 px-5 nav-link">HR-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a></li>
+    <li class="nav-item">
+      <a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a>
+    </li>
+    <li class="nav-item">
+      <a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a>
+    </li>
   </sp-intranet-header>
 </section>
 
 <section class="preview">
-  <sp-intranet-header siteTitle="PostWeb" searchUrl="/" [showIntranetSearch]="true" [optionHeaderContent]="headerOptions" [optionDropdownContent]="myCustomOptions">
+  <sp-intranet-header
+    siteTitle="PostWeb"
+    searchUrl="/"
+    [showIntranetSearch]="true"
+    [optionHeaderContent]="headerOptions"
+    [optionDropdownContent]="myCustomOptions"
+  >
     <li class="nav-item"><a href="/postweb" class="col-auto py-3 px-5 nav-link">Home</a></li>
-    <li class="nav-item"><a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">Post Informatik</a></li>
+    <li class="nav-item">
+      <a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">
+        Post Informatik
+      </a>
+    </li>
     <li class="nav-item"><a class="col-auto py-3 px-5 nav-link">HR-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a></li>
+    <li class="nav-item">
+      <a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a>
+    </li>
+    <li class="nav-item">
+      <a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a>
+    </li>
   </sp-intranet-header>
 </section>
 
 <section class="preview">
-  <sp-intranet-header siteTitle="PostWeb" [optionHeaderContent]="headerOptions" [optionDropdownContent]="myCustomOptions">
+  <sp-intranet-header
+    siteTitle="PostWeb"
+    [optionHeaderContent]="headerOptions"
+    [optionDropdownContent]="myCustomOptions"
+  >
     <li class="nav-item"><a href="/postweb" class="col-auto py-3 px-5 nav-link">Home</a></li>
-    <li class="nav-item"><a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">Post Informatik</a></li>
+    <li class="nav-item">
+      <a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">
+        Post Informatik
+      </a>
+    </li>
     <li class="nav-item"><a class="col-auto py-3 px-5 nav-link">HR-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a></li>
-    <li class="nav-item"><a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a></li>
+    <li class="nav-item">
+      <a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a>
+    </li>
+    <li class="nav-item">
+      <a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a>
+    </li>
   </sp-intranet-header>
 </section>
 
 <ng-template #myCustomOptions let-dropdown="dropdownRef">
-  <div class="dropdown-item" (click)="dropdown.close()">
-    Close Dropdown
-  </div>
-  <div class="dropdown-item" (click)="count = (count ? count + 1 : 1)">
-    Click-counter {{ count }}
-  </div>
+  <div class="dropdown-item" (click)="dropdown.close()">Close Dropdown</div>
+  <a href="#" ngbDropdownItem ngbDropdownToggle class="dropdown-item">hash</a>
+  <a [routerLink]="">home routerlink</a>
+  <div class="dropdown-item" (click)="count = count ? count + 1 : 1">Click-counter {{ count }}</div>
 </ng-template>
 
 <ng-template #headerOptions>
-  <a style="text-decoration: none" routerLink="ui/login"><em class="pi pi-2064"></em> Login</a>
+  <a style="text-decoration: none" routerLink="ui/login">
+    <em class="pi pi-2064"></em>
+    Login
+  </a>
 </ng-template>

--- a/packages/components-angular/projects/intranet-header-showcase/src/app/app.module.ts
+++ b/packages/components-angular/projects/intranet-header-showcase/src/app/app.module.ts
@@ -6,15 +6,9 @@ import { SwissPostIntranetHeaderModule } from '../../../intranet-header/src/lib/
 import { AppComponent } from './app.component';
 
 @NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [
-    BrowserModule,
-    RouterModule.forRoot([]),
-    SwissPostIntranetHeaderModule
-  ],
+  declarations: [AppComponent],
+  imports: [BrowserModule, RouterModule.forRoot([]), SwissPostIntranetHeaderModule],
   providers: [],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
-export class AppModule { }
+export class AppModule {}

--- a/packages/components-angular/projects/intranet-header/.eslintrc.json
+++ b/packages/components-angular/projects/intranet-header/.eslintrc.json
@@ -1,18 +1,13 @@
 {
   "extends": "../../.eslintrc.json",
-  "ignorePatterns": [
-    "!**/*",
-    "node_modules"
-  ],
+  "ignorePatterns": ["!**/*", "node_modules"],
   "overrides": [
     {
-      "files": [
-        "*.ts"
-      ],
+      "files": ["*.ts"],
       "parserOptions": {
         "project": [
-          "projects/intranet-header/tsconfig.lib.json",
-          "projects/intranet-header/tsconfig.spec.json"
+          "packages/components-angular/projects/intranet-header/tsconfig.lib.json",
+          "packages/components-angular/projects/intranet-header/tsconfig.spec.json"
         ],
         "createDefaultProgram": true
       },
@@ -36,9 +31,7 @@
       }
     },
     {
-      "files": [
-        "*.html"
-      ],
+      "files": ["*.html"],
       "rules": {}
     }
   ]

--- a/packages/components-angular/projects/intranet-header/.eslintrc.json
+++ b/packages/components-angular/projects/intranet-header/.eslintrc.json
@@ -6,8 +6,8 @@
       "files": ["*.ts"],
       "parserOptions": {
         "project": [
-          "packages/components-angular/projects/intranet-header/tsconfig.lib.json",
-          "packages/components-angular/projects/intranet-header/tsconfig.spec.json"
+          "projects/intranet-header/tsconfig.lib.json",
+          "projects/intranet-header/tsconfig.spec.json"
         ],
         "createDefaultProgram": true
       },

--- a/packages/components-angular/projects/intranet-header/src/lib/swisspost-intranet-header.component.html
+++ b/packages/components-angular/projects/intranet-header/src/lib/swisspost-intranet-header.component.html
@@ -81,7 +81,7 @@
                     </div>
                   </ng-container>
                 </div>
-                <div class="other-items">
+                <div class="other-items" (click)="optionDropdownClick($event)">
                   <div class="dropdown-item" *ngIf="currentUserId">
                     {{ currentUserId }}
                   </div>
@@ -103,14 +103,7 @@
             *ngIf="hasNavbar === true"
             (click)="toggleMenu()"
             id="nav-toggler"
-            class="
-              navbar-toggler
-              px-3
-              d-md-none
-              align-self-stretch
-              d-inline-flex
-              align-items-center
-            "
+            class="navbar-toggler px-3 d-md-none align-self-stretch d-inline-flex align-items-center"
           >
             <em class="pi pi-2070"></em>
           </div>

--- a/packages/components-angular/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
+++ b/packages/components-angular/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
@@ -18,7 +18,7 @@ import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { fromEvent, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { userImage } from './user';
-import { NgbDropdown, NgbDropdownMenu } from '@ng-bootstrap/ng-bootstrap';
+import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'sp-intranet-header',
@@ -113,7 +113,7 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
   ngOnInit() {
     this.appLangs = this.languages.split(',');
     this.setLang(this.lang);
-    const tempArr = location.href.match(/lang=([a-zA-Z]{2})/);
+    const tempArr = RegExp(/lang=([a-zA-Z]{2})/).exec(location.href);
     if (tempArr && tempArr.length > 1) {
       this.setLang(tempArr[1]);
     }
@@ -153,34 +153,36 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
       if (!MutationObserver) {
         return;
       }
-      this.navChanges = new MutationObserver(mutationList => {
-        if (mutationList.some(mutation => mutation.type === 'childList')) {
-          // Resize the navbar anytime an nav item is added or removed
-          const navItems = Array.from(
-            this.navElement.querySelectorAll<HTMLElement>('.nav-item:not(#more)'),
-          );
-          if (navItems.length !== this.navItems.length) {
-            this.navItems = navItems;
-            this.navigationResize();
-          }
-        } else {
-          // Resize the navbar anytime the text of a nav item changes
-          const textNodeType = 3;
-          if (
-            mutationList.some(
-              mutation =>
-                mutation.type === 'characterData' && mutation.target.nodeType === textNodeType,
-            )
-          ) {
-            this.navigationResize();
-          }
-        }
-      });
+      this.navChanges = new MutationObserver(m => this.navMutationCallback(m));
       this.navChanges.observe(this.navElement, {
         childList: true,
         characterData: true,
         subtree: true,
       });
+    }
+  }
+
+  public navMutationCallback(mutationList: MutationRecord[]) {
+    if (mutationList.some(mutation => mutation.type === 'childList')) {
+      // Resize the navbar anytime an nav item is added or removed
+      const navItems = Array.from(
+        this.navElement.querySelectorAll<HTMLElement>('.nav-item:not(#more)'),
+      );
+      if (navItems.length !== this.navItems.length) {
+        this.navItems = navItems;
+        this.navigationResize();
+      }
+    } else {
+      // Resize the navbar anytime the text of a nav item changes
+      const textNodeType = 3;
+      if (
+        mutationList.some(
+          mutation =>
+            mutation.type === 'characterData' && mutation.target.nodeType === textNodeType,
+        )
+      ) {
+        this.navigationResize();
+      }
     }
   }
 
@@ -194,7 +196,7 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
       }
 
       const currentLoc = sanitizedLocationUrl;
-      if (currentLoc.match(/lang=[a-zA-Z]+/)) {
+      if (RegExp(/lang=[a-zA-Z]+/).exec(currentLoc)) {
         // lang paramter is already present in url
         location.href = currentLoc.replace(/lang=[a-zA-Z]{2}/, `lang=${lang}`);
       } else {

--- a/packages/components-angular/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
+++ b/packages/components-angular/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
@@ -18,6 +18,7 @@ import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { fromEvent, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 import { userImage } from './user';
+import { NgbDropdown, NgbDropdownMenu } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'sp-intranet-header',
@@ -40,6 +41,7 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
 
   @ViewChild('domWrapper')
   dom!: ElementRef;
+  @ViewChild('optionDropdown') optionDropdown!: NgbDropdown;
 
   appLangs!: string[];
   avatarUrl = this.createSafeAvatarUrl();
@@ -239,6 +241,14 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
   public handleOverflowKeyEvent(e: KeyboardEvent) {
     if (e.code === 'Enter' || e.code === 'Space') {
       this.toggleMenuOverflow();
+    }
+  }
+
+  // Close dropdown on link clicks https://github.com/swisspost/design-system/issues/1300
+  public optionDropdownClick(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+    if (target.tagName.toLowerCase() === 'a') {
+      this.optionDropdown.close();
     }
   }
 


### PR DESCRIPTION
Fixed the auto-close behavior of optional dropdown content. Clicking links or routerLinks (<a> tags) now closes the dropdown as expected.