### PR TITLE
fix(header): uniform focus styles across browsers

### DIFF
--- a/.changeset/tall-rats-flash.md
+++ b/.changeset/tall-rats-flash.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fixed focus styles for links and buttons inside the navigation. Focus styles are now defined and uniform across browsers.

--- a/packages/internet-header/src/components/post-internet-breadcrumbs/post-internet-breadcrumbs.scss
+++ b/packages/internet-header/src/components/post-internet-breadcrumbs/post-internet-breadcrumbs.scss
@@ -129,6 +129,9 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
+  width: 1.5em;
+  height: 1.5em;
+  min-height: 0;
   font-size: inherit;
   color: inherit;
 

--- a/packages/internet-header/src/components/post-internet-breadcrumbs/post-internet-breadcrumbs.scss
+++ b/packages/internet-header/src/components/post-internet-breadcrumbs/post-internet-breadcrumbs.scss
@@ -50,12 +50,7 @@
       min-width: 0;
       overflow: hidden;
       text-overflow: ellipsis;
-
-      a {
-        // Make sure the focus highlight is visible even if overflow on the li is hidden
-        border: 2px solid transparent;
-        outline-offset: 0;
-      }
+      padding: 4px; // Allow space for the focus outline
     }
   }
 

--- a/packages/internet-header/src/components/post-klp-login-widget/widget-styles.scss
+++ b/packages/internet-header/src/components/post-klp-login-widget/widget-styles.scss
@@ -99,7 +99,6 @@
 
 .klp-widget-anonymous {
   height: 100%;
-  overflow: hidden;
   color: rgba(0, 0, 0, 0.6);
 }
 
@@ -118,7 +117,6 @@
   font-size: 1rem;
   text-decoration: none;
   background-color: white;
-  outline-offset: -2px; // Make outline visible
 }
 
 .klp-widget-anonymous a:hover {

--- a/packages/internet-header/src/components/post-language-switch/components/post-language-switch-list.tsx
+++ b/packages/internet-header/src/components/post-language-switch/components/post-language-switch-list.tsx
@@ -21,7 +21,7 @@ export const PostLanguageSwitchList = (props: {
         {props.navLang
           .filter(lang => !lang.isCurrent)
           .map(lang => {
-            const TagName = lang.url === null ? 'button' : 'a';
+            const TagName = lang.url ? 'a' : 'button';
             return (
               <li key={lang.lang}>
                 <TagName

--- a/packages/internet-header/src/components/post-main-navigation/post-main-navigation.scss
+++ b/packages/internet-header/src/components/post-main-navigation/post-main-navigation.scss
@@ -158,9 +158,7 @@
     background-color: transparent;
     opacity: 0;
     transform: scaleX(0.8);
-    height: 0px;
     transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-      height 0s 0.25s linear,
       transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 
     @media (prefers-reduced-motion: reduce) {
@@ -174,10 +172,7 @@
       background-color: color.$gray-20;
       opacity: 1;
       transform: scale(1);
-      visibility: visible;
-      height: 4px;
       transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1),
-        height 0s,
         transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     }
   }

--- a/packages/internet-header/src/components/post-main-navigation/post-main-navigation.scss
+++ b/packages/internet-header/src/components/post-main-navigation/post-main-navigation.scss
@@ -158,7 +158,9 @@
     background-color: transparent;
     opacity: 0;
     transform: scaleX(0.8);
+    height: 0px;
     transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+      height 0s 0.25s linear,
       transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 
     @media (prefers-reduced-motion: reduce) {
@@ -172,6 +174,11 @@
       background-color: color.$gray-20;
       opacity: 1;
       transform: scale(1);
+      visibility: visible;
+      height: 4px;
+      transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+        height 0s,
+        transform 0.25s cubic-bezier(0.4, 0, 0.2, 1);
     }
   }
 

--- a/packages/internet-header/src/components/post-skiplinks/post-skiplinks.scss
+++ b/packages/internet-header/src/components/post-skiplinks/post-skiplinks.scss
@@ -16,6 +16,7 @@
     background: white;
 
     &:focus-visible {
+      position: absolute;
       clip: unset;
       width: auto;
     }

--- a/packages/internet-header/src/utils/_placeholders.scss
+++ b/packages/internet-header/src/utils/_placeholders.scss
@@ -1,0 +1,63 @@
+@use '@swisspost/design-system-styles/mixins/forms' as forms-mx;
+@use '@swisspost/design-system-styles/variables/color';
+
+%visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  border: 0;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+%blank-button {
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+}
+
+%nav-link {
+  @include forms-mx.focus-outline();
+
+  text-decoration: none;
+  color: rgba(color.$black, 0.8);
+  transition: color 200ms;
+  background-color: transparent;
+  box-shadow: none;
+  border: 0;
+  margin: 0; // Buttons in safari have a default margin of 2px
+
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  &:hover,
+  &:focus {
+    color: black;
+  }
+
+  &:focus-visible {
+    z-index: 1;
+    position: relative;
+  }
+
+  > svg {
+    width: 1.4em;
+    height: 1.4em;
+    flex-shrink: 0;
+  }
+
+  > span {
+    flex-shrink: 1;
+  }
+}
+
+%no-list {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/packages/internet-header/src/utils/utils.scss
+++ b/packages/internet-header/src/utils/utils.scss
@@ -1,7 +1,9 @@
 @use '@swisspost/design-system-styles/components/fonts';
 @use '@swisspost/design-system-styles/variables/color';
 @use '@swisspost/design-system-styles/variables/breakpoints';
+@use '@swisspost/design-system-styles/variables/components/button';
 @use '@swisspost/design-system-styles/variables/type';
+@use '@swisspost/design-system-styles/mixins/forms' as forms-mx;
 @use './mixins.scss';
 
 *,
@@ -18,6 +20,17 @@
 button {
   font: inherit;
   padding: 0;
+}
+
+a,
+button {
+  border-radius: button.$btn-border-radius;
+
+  @include forms-mx.focus-outline() {
+    border-radius: button.$btn-border-radius;
+    position: relative;
+    z-index: 1;
+  }
 }
 
 img,

--- a/packages/internet-header/src/utils/utils.scss
+++ b/packages/internet-header/src/utils/utils.scss
@@ -4,6 +4,7 @@
 @use '@swisspost/design-system-styles/variables/components/button';
 @use '@swisspost/design-system-styles/variables/type';
 @use '@swisspost/design-system-styles/mixins/forms' as forms-mx;
+@use './placeholders.scss';
 @use './mixins.scss';
 
 *,
@@ -42,50 +43,6 @@ svg {
 svg {
   @media (forced-colors: active) {
     color: white;
-  }
-}
-
-%no-list {
-  list-style: none;
-  padding-left: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-%blank-button {
-  background-color: transparent;
-  border: none;
-  border-radius: 0;
-  padding: 0;
-}
-
-%nav-link {
-  text-decoration: none;
-  color: rgba(color.$black, 0.8);
-  transition: color 200ms;
-  background-color: transparent;
-  border-radius: 0;
-  box-shadow: none;
-  border: 0;
-  margin: 0; // Buttons in safari have a default margin of 2px
-
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-
-  &:hover,
-  &:focus {
-    color: black;
-  }
-
-  > svg {
-    width: 1.4em;
-    height: 1.4em;
-    flex-shrink: 0;
-  }
-
-  > span {
-    flex-shrink: 1;
   }
 }
 
@@ -148,17 +105,6 @@ svg {
 
 .container {
   @include mixins.container-padding();
-}
-
-%visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  border: 0;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
 }
 
 .visually-hidden {

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -107,5 +107,6 @@
   /* Compatibility with button-group */
   &:is(:focus-visible, :focus-within, .pretend-focus) {
     outline: forms.$input-focus-outline-thickness solid var(--post-contrast-color);
+    @content;
   }
 }


### PR DESCRIPTION
Fixed focus styles for links and buttons inside the navigation. Focus styles are now defined and uniform across browsers.

@josemanosalvas, please refer to https://github.com/swisspost/design-system/issues/1447#issuecomment-1573314555 for enabling tab navigation on Mac, it's not enabled by default. You can find links to the preview environment further down in the comments of this PR if you'd like to have a look at the fix before it's being merged. Feedback is welcome.