### PR TITLE
fix(styles): Safari display issue with floating labels

### DIFF
--- a/.changeset/young-brooms-push.md
+++ b/.changeset/young-brooms-push.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed an issue in Safari where the input value of a floating label input field was hidden by the floating label.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "snapshots": "start-server-and-test 'pnpm docs:headless' 9300 'pnpm --filter design-system-documentation snapshots'",
     "demo:start": "pnpm --filter design-system-demo... --parallel --stream start",
     "docs:start": "pnpm --filter design-system-documentation... --parallel --stream start",
+    "docs:build": "pnpm --filter design-system-documentation build",
     "docs:headless": "pnpm --filter design-system-documentation start:headless",
     "docs:test": "pnpm --filter design-system-documentation test",
     "docs:e2e": "start-server-and-test docs:headless 9300 'pnpm --filter design-system-documentation e2e'",

--- a/packages/styles/src/components/floating-label.scss
+++ b/packages/styles/src/components/floating-label.scss
@@ -24,7 +24,6 @@
         type.$line-height-copy * 0.5}
     );
     padding-bottom: 0;
-    height: forms.$form-floating-label-height;
     border: 0;
     color: forms.$form-floating-label-color;
     font-size: forms.$form-floating-label-font-size;

--- a/packages/styles/src/components/floating-label.scss
+++ b/packages/styles/src/components/floating-label.scss
@@ -19,15 +19,17 @@
     left: forms.$input-border-width;
     margin: 0;
     padding-inline: forms.$form-floating-padding-x;
-    padding-block: calc(
+    padding-top: calc(
       #{forms.$input-border-width} + #{forms.$form-floating-label-height * 0.5} - #{forms.$form-floating-label-font-size *
         type.$line-height-copy * 0.5}
     );
+    padding-bottom: 0;
     height: forms.$form-floating-label-height;
     border: 0;
     color: forms.$form-floating-label-color;
     font-size: forms.$form-floating-label-font-size;
     width: auto;
+    height: auto;
     max-width: calc(100% - (forms.$input-border-width * 2));
     white-space: nowrap;
     overflow: hidden;


### PR DESCRIPTION
A rendering issue in Safari clipped text input in a floating label input field where the floating label intersected with the current value of the input. Even having a transparent background, the input was invisible below the floating label. Setting the height of the floating label correctly fixes the rendering issue because now the label does no longer cover the value.