### PR TITLE
fix: update installation instructions for v5

### DIFF
--- a/.changeset/fast-carrots-turn.md
+++ b/.changeset/fast-carrots-turn.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-demo': patch
+---
+
+Update migration guide for v5 with precise installation instructions

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        uses: ./.github/actions/setup-pnpm.yml
+        uses: ../actions/setup-pnpm.yml
 
       - name: Bootstrap & Build Design System
         run: |

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       - name: Bootstrap & Build Design System
         run: |
@@ -38,7 +38,7 @@ jobs:
           pnpm --filter design-system-demo... build
 
       - name: Upload build artifacts
-        uses: ../actions/artifact-upload.yml
+        uses: swisspost/design-system/.github/actions/artifact-upload@main
         with:
           name: design-system-demo
           folder: packages/demo/dist/demo

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: ./.github/actions/setup-pnpm.yml
 
       - name: Bootstrap & Build Design System
         run: |

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
 
       - name: Bootstrap & Build Design System
         run: |
@@ -38,7 +38,7 @@ jobs:
           pnpm --filter design-system-demo... build
 
       - name: Upload build artifacts
-        uses: swisspost/design-system/.github/actions/artifact-upload@main
+        uses: swisspost/design-system/.github/actions/artifact-upload@${{ github.ref_name }}
         with:
           name: design-system-demo
           folder: packages/demo/dist/demo

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       - name: Bootstrap & Build Design System
         run: |
@@ -38,7 +38,7 @@ jobs:
           pnpm --filter design-system-demo... build
 
       - name: Upload build artifacts
-        uses: swisspost/design-system/.github/actions/artifact-upload@${{ github.ref_name }}
+        uses: swisspost/design-system/.github/actions/artifact-upload@main
         with:
           name: design-system-demo
           folder: packages/demo/dist/demo

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: ../actions/setup-pnpm.yml
 
       - name: Bootstrap & Build Design System
         run: |
@@ -38,7 +38,7 @@ jobs:
           pnpm --filter design-system-demo... build
 
       - name: Upload build artifacts
-        uses: swisspost/design-system/.github/actions/artifact-upload@main
+        uses: ../actions/artifact-upload.yml
         with:
           name: design-system-demo
           folder: packages/demo/dist/demo

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Setup
         uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        with:
+          pnpm_version: 7
 
       - name: Bootstrap & Build Design System
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: ../actions/setup-pnpm.yml
 
       - name: Install dependencies of changed packages
         run: pnpm install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ./.github/actions/setup-pnpm.yml
+        uses: ../actions/setup-pnpm.yml
 
       - name: Install dependencies of changed packages
         run: pnpm install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       - name: Install dependencies of changed packages
         run: pnpm install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
 
       - name: Install dependencies of changed packages
         run: pnpm install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: ./.github/actions/setup-pnpm.yml
 
       - name: Install dependencies of changed packages
         run: pnpm install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       - name: Install dependencies of changed packages
         run: pnpm install

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Setup
         uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        with:
+          pnpm_version: 7
 
       - name: Install dependencies of changed packages
         run: pnpm install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup
         uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        with:
+          pnpm_version: 7
 
       # Install changesets locally
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
 
       # Install changesets locally
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       # Install changesets locally
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -28,8 +29,16 @@ jobs:
       - name: Build changelog formatter
         run: pnpm --filter design-system-changelog-github build
 
+      # Set changeset base branch, only run on release/vX branches
+      - name: Set changeset base branch
+        if: github.ref != 'refs/heads/main'
+        run: echo "`jq '.baseBranch="${{ gituhb.ref_name}}"' .changeset/config.json`" > .changeset/config.json
+
+      - name: Log changeset config
+        run: echo $(cat .changeset/config.json)
+
       # The changeset action will behave differently based on whether there are
-      # new changesets on the main branch:
+      # new changesets on the base branch:
       #
       #  - new changesets: create a preview PR with the new version bumps and changelogs
       #  - no new changesets (the preview PR got merged into main): publish packages
@@ -40,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
-          title: 'chore(changesets): 🦋📦 publish packages'
-          commit: 'chore(changesets): publish packages'
+          title: 'chore(changesets): 🦋📦 publish packages (${{ github.ref_name }})'
+          commit: 'chore(changesets): publish packages (${{ github.ref_name }})'
           publish: pnpm changeset:publish
           version: pnpm changeset:version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       # Install changesets locally
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ./.github/actions/setup-pnpm.yml
+        uses: ../actions/setup-pnpm.yml
 
       # Install changesets locally
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: ../actions/setup-pnpm.yml
 
       # Install changesets locally
       - name: Install dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: ./.github/actions/setup-pnpm.yml
 
       # Install changesets locally
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup
         uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        with:
+          pnpm_version: 7
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: ../actions/setup-pnpm.yml
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: ./.github/actions/setup-pnpm.yml
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ../actions/setup-pnpm.yml
+        uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: swisspost/design-system/.github/actions/setup-pnpm@main
+        uses: swisspost/design-system/.github/actions/setup-pnpm@${{ github.ref_name }}
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup
-        uses: ./.github/actions/setup-pnpm.yml
+        uses: ../actions/setup-pnpm.yml
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies

--- a/packages/demo/src/app/home/home.component.html
+++ b/packages/demo/src/app/home/home.component.html
@@ -156,8 +156,8 @@
           class="d-block p-3"
           [languages]="['bash']"
           [highlight]="
-            'npm install @swisspost/design-system-styles' +
-            (isMigratingIntranet ? ' @swisspost/design-system-intranet-header' : '')
+            'npm install @swisspost/design-system-styles@5' +
+            (isMigratingIntranet ? ' @swisspost/design-system-intranet-header@3' : '')
           "
         ></code>
       </li>


### PR DESCRIPTION
This is a fix for an older release. Upon successfully merging into release/v5, a new, separate publish PR should be created by the release action, targeting the release/v5 branch.

TODO (after testing if the release PR is created): Deploy old documentation