### PR TITLE
fix(demo): add href to make link focusable

### DIFF
--- a/.changeset/shaggy-students-shave.md
+++ b/.changeset/shaggy-students-shave.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-demo': patch
+---
+
+Fixed a regression for the stepper component. Completed items should be links with a href attribute (or a routerLink in Angular) so users can navigate back to previous steps.

--- a/packages/demo/src/app/post-sample/components/stepper/stepper-demo/stepper-demo.component.html
+++ b/packages/demo/src/app/post-sample/components/stepper/stepper-demo/stepper-demo.component.html
@@ -13,7 +13,7 @@
       [attr.aria-current]="isCurrent(step) ? 'step' : undefined"
       class="stepper-item"
     >
-      <a *ngIf="i < currentIndex" class="stepper-link" (click)="currentIndex = i">
+      <a *ngIf="i < currentIndex" class="stepper-link" (click)="currentIndex = i" href="#">
         <span class="visually-hidden">Complete:</span>
         {{ step }}
       </a>


### PR DESCRIPTION
Stepper links make no sense without being a link back to this step. A href or [routerLink] is needed anyways. Regression was added because of https://github.com/swisspost/design-system/pull/1317/files#r1153405992. A href attribute might be less missleading than an internal [routerLink].