### PR TITLE
fix(docs): update paths in the icons getting started page

### DIFF
--- a/.changeset/empty-hats-mix.md
+++ b/.changeset/empty-hats-mix.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Updated the paths in the post-install script examples on the "Getting Started" Icons page.

--- a/packages/documentation/src/stories/icons/getting-started.stories.mdx
+++ b/packages/documentation/src/stories/icons/getting-started.stories.mdx
@@ -57,7 +57,7 @@ Just open your `anuglar.json` file and add the following to the `build.options.a
               {
                 "glob": "**/*.svg",
                 "input": "./node_modules/@swisspost/design-system-icons/public/post-icons",
-                "output": "/post-icons/"
+                "output": "post-icons"
               }
             ]
           }
@@ -79,7 +79,7 @@ If you want to know more about pre & post scripts and how they are handled, plea
 // package.json
 {
   "scripts": {
-    "postinstall": "node -e \"const fs = require('fs'); fs.cpSync('node_modules/@swisspost/design-system-icons/public/post-icons', 'public/post-icons', { recursive: true }, (err) => { if (err) throw err; });\""
+    "postinstall": "node -e \"const fs = require('fs'); fs.cpSync('node_modules/@swisspost/design-system-icons/public/post-icons', 'post-icons', { recursive: true }, (err) => { if (err) throw err; });\""
   }
 }
 ```
@@ -100,7 +100,7 @@ If you want to know more about pre & post scripts and how they are handled, plea
 const fse = require('fs-extra');
 
 const srcDir = 'node_modules/@swisspost/design-system-icons/public/post-icons';
-const destDir = 'public/post-icons';
+const destDir = 'post-icons';
 
 // To copy a folder or file, select overwrite accordingly
 try {
@@ -135,11 +135,11 @@ You can do this with two different solutions:
 <post-icon name="1000" base="/base-path/to/your/own/icon-folder"></post-icon>
 ```
 
-## Usage of the CDN approch
+## Usage of the CDN approach
 
 There is one last thing we want to tell you about.
 
-All icons are also available from a CDN, which is the default if you don't configure a base path for your icons and don't serve them locally. When using the CDN, please note that you need to configure your CORS policy to enable resource loading from unpkg.com. 
+All icons are also available from a CDN, which is the default if you don't configure a base path for your icons and don't serve them locally. When using the CDN, please note that you need to configure your CORS policy to enable resource loading from unpkg.com.
 
 <p class="alert alert-warning alert-md">
   Using the CDN is not recommended for production because of higher latency when loading from the CDN, use it for quickly testing something or for prototyping.


### PR DESCRIPTION
Since the snippet to set the meta for icons now uses the path `/post-icons` instead or `/public/post-icons` the postinstall script must be updated. 