### PR TITLE
fix(header): deprecate stickyness full

### DIFF
--- a/.changeset/spotty-pants-count.md
+++ b/.changeset/spotty-pants-count.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/internet-header': patch
+'@swisspost/design-system-documentation': patch
+---
+
+Deprecated the stickyness option "full". It should not be used anymore as this mode takes up too much screen space

--- a/packages/documentation/src/stories/internet-header/components/header/post-internet-header.stories.tsx
+++ b/packages/documentation/src/stories/internet-header/components/header/post-internet-header.stories.tsx
@@ -51,12 +51,6 @@ export default {
       name: 'Language',
       control: {
         type: 'select',
-        lables: {
-          de: 'German',
-          fr: 'French',
-          it: 'Italien',
-          en: 'English',
-        },
       },
       options: ['de', 'fr', 'it', 'en'],
       description:
@@ -119,6 +113,7 @@ export default {
       name: 'Stickyness',
       control: {
         type: 'select',
+        labels: { none: 'none', minimal: 'minimal', main: 'main', full: 'full (deprecated)' },
       },
       options: ['none', 'minimal', 'main', 'full'],
       description:

--- a/packages/internet-header/cypress/e2e/stickyness.cy.ts
+++ b/packages/internet-header/cypress/e2e/stickyness.cy.ts
@@ -15,12 +15,13 @@ describe('stickyness', () => {
 
   it('should not show header when scrolling down with stickyness minimal, should show header without meta when scrolling up a little', () => {
     cy.changeArg('stickyness', 'minimal');
-    cy.get('swisspost-internet-header').should('be.inViewport');
+    cy.get('post-meta-navigation').should('be.inViewport');
     cy.scrollTo('bottom');
+    cy.get('swisspost-internet-footer').should('be.inViewport');
     cy.get('swisspost-internet-header').should('not.be.inViewport');
     cy.get('post-meta-navigation').should('not.be.inViewport');
     cy.scrollTo('center');
-    cy.get('swisspost-internet-header').should('be.inViewport');
+    cy.get('post-main-navigation').should('be.inViewport');
     cy.get('post-meta-navigation').should('not.be.inViewport');
     cy.scrollTo('top');
     cy.get('swisspost-internet-header').should('be.inViewport');

--- a/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
+++ b/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
@@ -206,6 +206,9 @@ export class PostInternetHeader {
       this.headerLoaded.emit();
       this.host.classList.add('header-loaded');
     });
+
+    if (this.stickyness === 'full')
+      console.warn('Internet Header: The stickyness="full" option is deprecated.');
   }
 
   @Watch('language')


### PR DESCRIPTION
The stickyness setting "full" should no longer be used because it uses up too much screen space.