### PR TITLE
test: update stickyness test

### DIFF
--- a/packages/internet-header/cypress/e2e/stickyness.cy.ts
+++ b/packages/internet-header/cypress/e2e/stickyness.cy.ts
@@ -15,12 +15,13 @@ describe('stickyness', () => {
 
   it('should not show header when scrolling down with stickyness minimal, should show header without meta when scrolling up a little', () => {
     cy.changeArg('stickyness', 'minimal');
-    cy.get('swisspost-internet-header').should('be.inViewport');
+    cy.get('post-meta-navigation').should('be.inViewport');
     cy.scrollTo('bottom');
+    cy.get('swisspost-internet-footer').should('be.inViewport');
     cy.get('swisspost-internet-header').should('not.be.inViewport');
     cy.get('post-meta-navigation').should('not.be.inViewport');
     cy.scrollTo('center');
-    cy.get('swisspost-internet-header').should('be.inViewport');
+    cy.get('post-main-navigation').should('be.inViewport');
     cy.get('post-meta-navigation').should('not.be.inViewport');
     cy.scrollTo('top');
     cy.get('swisspost-internet-header').should('be.inViewport');


### PR DESCRIPTION
After scrolling, wait for elements that should be in the viewoprt instead of just checking if some elements are not in the viewport. When just checking the latter, cypress runs the check during scroll and it's immediately successful so the next scroll is executed. If there is an element that should be there, cypress has to wait for the scroll to finish before the element appears.