### PR TITLE
fix(header): search button position

### DIFF
--- a/.changeset/weak-radios-switch.md
+++ b/.changeset/weak-radios-switch.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fixed an issue with the search button. Focusing or clicking the button will no longer change its position and search queries can be performed as usual.

--- a/packages/internet-header/src/assets/js/klp-login-widget.js
+++ b/packages/internet-header/src/assets/js/klp-login-widget.js
@@ -1014,9 +1014,7 @@ const vertx = window.vertx || {};
         .find('#' + id)
         .html(
           '<div class="klp-widget-anonymous"><div class="klp-widget-anonymous__wrapper">' +
-            '<a tabindex="' +
-            tabIndex('sign-in') +
-            '" ' +
+            '<a ' +
             accessKey('sign-in') +
             ' title="' +
             text('sign-in') +

--- a/packages/internet-header/src/components/post-language-switch/post-language-switch.scss
+++ b/packages/internet-header/src/components/post-language-switch/post-language-switch.scss
@@ -1,6 +1,6 @@
-@use "@swisspost/design-system-styles/variables/color";
-@use "@swisspost/design-system-styles/functions";
-@use "../../utils/utils.scss";
+@use '@swisspost/design-system-styles/variables/color';
+@use '@swisspost/design-system-styles/functions';
+@use '../../utils/utils.scss';
 
 :host {
   --separator-display: none;
@@ -33,6 +33,8 @@
   &:hover,
   &:focus {
     color: black;
+    position: relative;
+    z-index: 1;
   }
 
   svg {

--- a/packages/internet-header/src/components/post-search/post-search.scss
+++ b/packages/internet-header/src/components/post-search/post-search.scss
@@ -102,6 +102,9 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  background: none;
+  border: 0;
+  box-shadow: none;
 
   svg {
     width: 1.5rem;

--- a/packages/internet-header/src/components/post-search/post-search.tsx
+++ b/packages/internet-header/src/components/post-search/post-search.tsx
@@ -372,10 +372,7 @@ export class PostSearch implements HasDropdown, IsFocusable {
                         onKeyDown={e => this.handleKeyDown(e)}
                       />
                       <label htmlFor="searchBox">{translations.flyoutSearchBoxFloatingLabel}</label>
-                      <button
-                        onClick={() => void this.startSearch()}
-                        class="nav-link start-search-button"
-                      >
+                      <button onClick={() => void this.startSearch()} class="start-search-button">
                         <span class="visually-hidden">{translations.searchSubmit}</span>
                         <SvgIcon name="pi-search" />
                       </button>

--- a/packages/internet-header/src/utils/utils.scss
+++ b/packages/internet-header/src/utils/utils.scss
@@ -29,8 +29,6 @@ button {
 
   @include forms-mx.focus-outline() {
     border-radius: button.$btn-border-radius;
-    position: relative;
-    z-index: 1;
   }
 }
 


### PR DESCRIPTION
Removed the global relative styling for buttons and links that messed with the absolute positioning of the search button.