### PR TITLE
feat(header): added isCustomSuggestionHidden switch

### DIFF
--- a/.changeset/short-crabs-clap.md
+++ b/.changeset/short-crabs-clap.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': minor
+---
+
+Implemented kill-switch for coveo suggestions based on the `isCustomSuggestionHidden` option in the search configuration.

--- a/packages/internet-header/cypress/e2e/search.cy.ts
+++ b/packages/internet-header/cypress/e2e/search.cy.ts
@@ -1,7 +1,7 @@
 import mockCoveoSuggestions from '../fixtures/internet-header/coveo-suggestions.json';
 import mockStaoCache from '../fixtures/internet-header/places-suggestions.json';
 import mockStaoCacheTypes from '../fixtures/internet-header/staocache-types.json';
-import { prepare } from '../support/prepare-story';
+import { copyConfig, prepare } from '../support/prepare-story';
 
 describe('search', () => {
   const searchButton = '#post-internet-header-search-button';
@@ -16,12 +16,12 @@ describe('search', () => {
     cy.intercept('**/StandortSuche/StaoCacheService/Types**', mockStaoCacheTypes).as(
       'StaoCacheTypes',
     );
-    prepare('Internet Header/Components/Header', 'Default');
   });
 
   describe('config', () => {
     describe('default', () => {
       it('Search button should not be displayed if the config does not provide a search config', () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.changeArg('search', false);
         cy.get('swisspost-internet-header').should('exist');
         cy.get('post-search').should('not.exist');
@@ -32,12 +32,14 @@ describe('search', () => {
   describe('args', () => {
     describe('search: true', () => {
       it(`adds search control`, () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.get('post-search').should('exist').and('be.visible');
       });
     });
 
     describe('search: false', () => {
       it(`removes search control`, () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.changeArg('search', false);
         cy.get('post-search').should('not.exist');
       });
@@ -45,6 +47,7 @@ describe('search', () => {
 
     describe('Search button should be hidden if header.search = false is set during runtime', () => {
       it(`change during runtime`, () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.changeArg('search', false);
         cy.get('post-search').should('not.exist');
         cy.changeArg('search', true);
@@ -56,20 +59,35 @@ describe('search', () => {
   describe('open & close', () => {
     describe('open search', () => {
       it('search should open on search button click', () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.changeArg('search', true);
         cy.get(searchButton).click({ force: true });
         cy.get('.flyout').should('exist').should('have.class', 'open');
       });
 
       it('Coveo suggestions should be loaded when search is opened', () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.changeArg('search', true);
         cy.get(searchButton).click();
+        cy.get('#searchBox').type('s');
         cy.get('.suggestions').should('exist');
+        cy.get('.suggestions li use[href="#pi-search"]').should('have.length', 3);
+      });
+
+      it('Coveo suggestions should be turned off with isCustomSuggestionHidden', () => {
+        const config = copyConfig();
+        config.de!.header.search.isCustomSuggestionHidden = true;
+        prepare('Internet Header/Components/Header', 'Default', config);
+        cy.get(searchButton).click();
+        cy.get('#searchBox').type('s');
+        cy.get('.suggestions').should('exist');
+        cy.get('.suggestions li use[href="#pi-search"]').should('have.length', 0);
       });
     });
 
     describe('close search', () => {
       it('Search should close on esc key click', () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.changeArg('search', true);
         cy.get(searchButton).click();
         cy.get('#searchBox')
@@ -80,6 +98,7 @@ describe('search', () => {
       });
 
       it('Search should close on search button click', () => {
+        prepare('Internet Header/Components/Header', 'Default');
         cy.changeArg('search', true);
         cy.get(searchButton).click({ force: true });
         cy.get('.flyout').should('exist');
@@ -97,6 +116,7 @@ describe('search', () => {
       );
     });
     it('Search should redirect to search page on enter if search input has a value', () => {
+      prepare('Internet Header/Components/Header', 'Default');
       cy.changeArg('search', true);
       cy.get(searchButton).click({ force: true });
       // workaround type error disabled with this https://github.com/cypress-io/cypress/issues/5827
@@ -108,6 +128,7 @@ describe('search', () => {
     });
 
     it('With suggestions and focus on the search input, pressing arrow down should focus the first suggestion', () => {
+      prepare('Internet Header/Components/Header', 'Default');
       let value: string;
       cy.changeArg('search', true);
       cy.get(searchButton).click();
@@ -122,6 +143,7 @@ describe('search', () => {
     });
 
     it('Should render geolocation results', () => {
+      prepare('Internet Header/Components/Header', 'Default');
       cy.changeArg('search', true);
       cy.get(searchButton).click();
       cy.get('#searchBox').click();
@@ -131,6 +153,7 @@ describe('search', () => {
     });
 
     it('redirects to the correct search page', () => {
+      prepare('Internet Header/Components/Header', 'Default');
       cy.changeArg('search', true);
       cy.get(searchButton).click();
       cy.get('#searchBox').click().type('{downArrow}', { force: true });

--- a/packages/internet-header/cypress/support/prepare-story.ts
+++ b/packages/internet-header/cypress/support/prepare-story.ts
@@ -1,5 +1,6 @@
 import testConfiguration from '../fixtures/internet-header/test-configuration.json';
 import mockAuth from '../fixtures/internet-header/auth.json';
+import { IPortalConfig } from '../../src/models/general.model';
 
 export const installInterceptors = (config: Object = testConfiguration) => {
   cy.intercept('**/api/headerjs/Json?serviceid=*', config).as('getConfig');
@@ -22,4 +23,8 @@ export const prepare = (
     },
   });
   cy.loadStory(storyTitle, storyName);
+};
+
+export const copyConfig = (): IPortalConfig => {
+  return JSON.parse(JSON.stringify(testConfiguration));
 };

--- a/packages/internet-header/src/models/header.model.ts
+++ b/packages/internet-header/src/models/header.model.ts
@@ -74,6 +74,7 @@ export interface ISearchConfig {
   searchHubName: string;
   searchPipelineName: string;
   searchRecommendations: ISearchRecommendationContainer;
+  isCustomSuggestionHidden?: boolean;
 }
 
 export interface ISearchRecommendationContainer {

--- a/packages/internet-header/src/services/search/coveo.service.ts
+++ b/packages/internet-header/src/services/search/coveo.service.ts
@@ -13,7 +13,11 @@ let suggestionsController: AbortController;
  * @returns
  */
 export const getCoveoSuggestions = async (query: string): Promise<CoveoCompletion[]> => {
-  if (state.localizedConfig?.header?.search === undefined) return [];
+  if (
+    state.localizedConfig?.header?.search === undefined ||
+    state.localizedConfig?.header?.search.isCustomSuggestionHidden === true
+  )
+    return [];
   const config = state.localizedConfig.header.search;
   const { token, organisation } = coveo.environment[state.environment];
   const url = `${coveo.url}?q=${query}&locale=${state.currentLanguage}&searchHub=${config.searchHubName}&pipeline=${config.searchPipelineName}&organizationId=${organisation}`;


### PR DESCRIPTION
For some pages (PostAuto), the coveo suggestions deliver inaccurate results. Until indices for these pages are added to coveo, turning off suggestions is the preferred way to go.