### PR TITLE
chore(documentation): migrate changelog page to v7

### DIFF
--- a/packages/documentation-v7/src/stories/misc/changelog.stories.mdx
+++ b/packages/documentation-v7/src/stories/misc/changelog.stories.mdx
@@ -1,0 +1,16 @@
+import { Markdown, Meta, Source } from '@storybook/blocks';
+import changelog from '../../../../styles/CHANGELOG.md?raw';
+
+<Meta
+  title="Misc/ChangeLog"
+  parameters={{
+    previewTabs: {
+      canvas: {
+        hidden: true,
+      },
+    },
+    viewMode: 'docs',
+  }}
+/>
+
+<Markdown>{changelog}</Markdown>

--- a/packages/documentation-v7/src/stories/misc/changelog.stories.mdx
+++ b/packages/documentation-v7/src/stories/misc/changelog.stories.mdx
@@ -3,14 +3,6 @@ import changelog from '../../../../styles/CHANGELOG.md?raw';
 
 <Meta
   title="Misc/ChangeLog"
-  parameters={{
-    previewTabs: {
-      canvas: {
-        hidden: true,
-      },
-    },
-    viewMode: 'docs',
-  }}
 />
 
 <Markdown>{changelog}</Markdown>

--- a/packages/documentation-v7/src/stories/misc/changelog.stories.mdx
+++ b/packages/documentation-v7/src/stories/misc/changelog.stories.mdx
@@ -1,4 +1,4 @@
-import { Markdown, Meta, Source } from '@storybook/blocks';
+import { Markdown, Meta } from '@storybook/blocks';
 import changelog from '../../../../styles/CHANGELOG.md?raw';
 
 <Meta


### PR DESCRIPTION
* Replace react-markdown with ["native" markdown from Storybook.](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#importing-plain-markdown-files-with-transcludemarkdown-has-changed)

What's missing from the version 6 is the style "dark" (dark background color) on code elements. But this should be handled through style so that the color adapt to the current theme. Currently, the background stays dark when we switch the theme.

```mdx
<ReactMarkdown
  rehypePlugins={[rehypeRaw]}
  components={{
    code({ node, inline, className, children, ...props }) {
      const match = /language-(\w+)/.exec(className || '');
      return !inline && match ? (
        <Source language={match[1]} dark code={String(children).replace(/\n$/, '')} />
      ) : (
        <code className={className} {...props}>
          {children}
        </code>
      );
    },
  }}
  children={changelog}
/>
```