### PR TITLE
feat(styles): update buttons padding, gap and border-radius

### DIFF
--- a/.changeset/polite-radios-train.md
+++ b/.changeset/polite-radios-train.md
@@ -1,0 +1,5 @@
+---
+"@swisspost/design-system-styles": patch
+---
+
+Update button styles: padding, gap and border-radius

--- a/.changeset/polite-radios-train.md
+++ b/.changeset/polite-radios-train.md
@@ -2,4 +2,4 @@
 "@swisspost/design-system-styles": patch
 ---
 
-Update button styles: padding, gap and border-radius
+Update button styles: padding, gap and border-radius.

--- a/packages/styles/src/mixins/_button.scss
+++ b/packages/styles/src/mixins/_button.scss
@@ -21,7 +21,7 @@
 @mixin button-size($size: md) {
   min-height: map.get(button.$btn-height-map, $size);
   font-size: map.get(button.$btn-font-size-map, $size);
-  gap: map.get(button.$btn-padding-x-map, $size) * 0.5;
+  gap: map.get(button.$btn-gap-x-map, $size);
 
   &:where(:not(.btn-link, .btn-tertiary)) {
     padding: 0 map.get(button.$btn-padding-x-map, $size);

--- a/packages/styles/src/variables/_commons.scss
+++ b/packages/styles/src/variables/_commons.scss
@@ -7,7 +7,7 @@ $border-width: 1px !default;
 $border-thick: 2px !default;
 $border-color: color.$gray-20 !default;
 
-$border-radius: 3px !default;
+$border-radius: 4px !default;
 $border-radius-sm: $border-radius !default;
 $border-radius-rg: $border-radius !default;
 $border-radius-lg: $border-radius !default;

--- a/packages/styles/src/variables/components/_button.scss
+++ b/packages/styles/src/variables/components/_button.scss
@@ -75,7 +75,7 @@ $btn-animation-distance-lg: spacing.$size-mini !default;
 // Design System only
 $btn-height-lg: 3.5rem;
 $btn-font-size-lg: type.$font-size-18 !default;
-$btn-icon-size-lg: spacing.$size-large !default;
+$btn-icon-size-lg: 1.375rem !default;
 
 // Available button sizes except the default, which is md
 $btn-non-default-sizes: sm, rg, lg !default;

--- a/packages/styles/src/variables/components/_button.scss
+++ b/packages/styles/src/variables/components/_button.scss
@@ -39,7 +39,8 @@ $btn-animation-distance-factor: 0.5 !default;
 
 // sm
 $btn-padding-y-sm: spacing.$size-mini !default;
-$btn-padding-x-sm: spacing.$size-regular !default;
+$btn-padding-x-sm: sizing.px-to-rem(12) !default;
+$btn-gap-x-sm: sizing.px-to-rem(6) !default;
 $btn-animation-distance-sm: spacing.$size-mini !default;
 // Design System only
 $btn-height-sm: 2rem;
@@ -48,7 +49,8 @@ $btn-icon-size-sm: spacing.$size-regular !default;
 
 // rg
 $btn-padding-y-rg: spacing.$size-small-regular !default;
-$btn-padding-x-rg: spacing.$size-large !default;
+$btn-padding-x-rg: sizing.px-to-rem(14) !default;
+$btn-gap-x-rg: sizing.px-to-rem(8) !default;
 $btn-animation-distance-rg: 0.625rem !default;
 // Design System only
 $btn-height-rg: 2.5rem;
@@ -57,7 +59,8 @@ $btn-icon-size-rg: 1.125rem !default;
 
 // md
 $btn-padding-y-md: spacing.$size-regular !default;
-$btn-padding-x-md: spacing.$size-big !default;
+$btn-padding-x-md: sizing.px-to-rem(16) !default;
+$btn-gap-x-md: sizing.px-to-rem(10) !default;
 $btn-animation-distance-md: spacing.$size-small-regular !default;
 // Design System only
 $btn-height-md: 3rem;
@@ -66,7 +69,8 @@ $btn-icon-size-md: spacing.$size-small-large !default;
 
 // lg
 $btn-padding-y-lg: spacing.$size-small-large !default;
-$btn-padding-x-lg: spacing.$size-bigger-big !default;
+$btn-padding-x-lg: sizing.px-to-rem(18) !default;
+$btn-gap-x-lg: sizing.px-to-rem(12) !default;
 $btn-animation-distance-lg: spacing.$size-regular !default;
 // Design System only
 $btn-height-lg: 3.5rem;
@@ -93,6 +97,12 @@ $btn-padding-x-map: (
   'rg': $btn-padding-x-rg,
   'md': $btn-padding-x-md,
   'lg': $btn-padding-x-lg,
+);
+$btn-gap-x-map: (
+  'sm': $btn-gap-x-sm,
+  'rg': $btn-gap-x-rg,
+  'md': $btn-gap-x-md,
+  'lg': $btn-gap-x-lg,
 );
 $btn-height-map: (
   'sm': $btn-height-sm,

--- a/packages/styles/src/variables/components/_button.scss
+++ b/packages/styles/src/variables/components/_button.scss
@@ -51,7 +51,7 @@ $btn-icon-size-sm: spacing.$size-regular !default;
 $btn-padding-y-rg: spacing.$size-small-regular !default;
 $btn-padding-x-rg: sizing.px-to-rem(14) !default;
 $btn-gap-x-rg: sizing.px-to-rem(8) !default;
-$btn-animation-distance-rg: 0.625rem !default;
+$btn-animation-distance-rg: spacing.$size-mini !default;
 // Design System only
 $btn-height-rg: 2.5rem;
 $btn-font-size-rg: type.$font-size-14 !default;
@@ -61,7 +61,7 @@ $btn-icon-size-rg: 1.125rem !default;
 $btn-padding-y-md: spacing.$size-regular !default;
 $btn-padding-x-md: sizing.px-to-rem(16) !default;
 $btn-gap-x-md: sizing.px-to-rem(10) !default;
-$btn-animation-distance-md: spacing.$size-small-regular !default;
+$btn-animation-distance-md: spacing.$size-mini !default;
 // Design System only
 $btn-height-md: 3rem;
 $btn-font-size-md: type.$font-size-16 !default;
@@ -71,7 +71,7 @@ $btn-icon-size-md: spacing.$size-small-large !default;
 $btn-padding-y-lg: spacing.$size-small-large !default;
 $btn-padding-x-lg: sizing.px-to-rem(18) !default;
 $btn-gap-x-lg: sizing.px-to-rem(12) !default;
-$btn-animation-distance-lg: spacing.$size-regular !default;
+$btn-animation-distance-lg: spacing.$size-mini !default;
 // Design System only
 $btn-height-lg: 3.5rem;
 $btn-font-size-lg: type.$font-size-18 !default;


### PR DESCRIPTION
Following https://github.com/swisspost/design-system/issues/1571#issuecomment-1641942510 and discussion from today.

Updated:
* Padding
* Internal gap
* Border-radius

Figma: https://www.figma.com/file/xZ0IW0MJO0vnFicmrHiKaY/Components-Post?node-id=9096%3A36684&mode=dev