### PR TITLE
fix: converted environment to lowercase on initialization

### DIFF
--- a/.changeset/cold-mails-shout.md
+++ b/.changeset/cold-mails-shout.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fixed an issue with uppercase environment strings. Uppercase environment strings caused issues with mapping to datasets throughout the header. Now the property is being converted to lowercase internally.

--- a/packages/internet-header/cypress/e2e/environment.cy.ts
+++ b/packages/internet-header/cypress/e2e/environment.cy.ts
@@ -1,0 +1,16 @@
+import testConfiguration from '../fixtures/internet-header/test-configuration.json';
+import mockAuth from '../fixtures/internet-header/auth.json';
+
+describe('header attributes', { baseUrl: null }, () => {
+  beforeEach(() => {
+    cy.intercept('**/v1/session/subscribe', mockAuth).as('auth');
+    cy.intercept('**/api/headerjs/Json?serviceid=*', testConfiguration).as('getConfig');
+  });
+
+  it('should lowercase the environment attribute', () => {
+    cy.visit('./cypress/fixtures/pages/uppercase-environment.html');
+    cy.wait('@getConfig').then(interception => {
+      expect(interception.request.query['environment']).to.eq('int01');
+    });
+  });
+});

--- a/packages/internet-header/cypress/fixtures/pages/uppercase-environment.html
+++ b/packages/internet-header/cypress/fixtures/pages/uppercase-environment.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+    <script
+      src="../../../dist/swisspost-internet-header/swisspost-internet-header.esm.js"
+      type="module"
+    ></script>
+  </head>
+  <body>
+    <swisspost-internet-header project="ekp" environment="INT01"></swisspost-internet-header>
+    <h1>Fixtures - uppercase environment</h1>
+  </body>
+</html>

--- a/packages/internet-header/src/assets/js/klp-login-widget.js
+++ b/packages/internet-header/src/assets/js/klp-login-widget.js
@@ -1192,6 +1192,10 @@ const vertx = window.vertx || {};
 
       if (sessionData.userType === 'B2C') {
         const settingEnvLinks = {
+          dev01: 'https://serviceint1.post.ch/kvm/app/ui',
+          dev02: 'https://serviceint1.post.ch/kvm/app/ui',
+          devs1: 'https://serviceint1.post.ch/kvm/app/ui',
+          test: 'https://serviceint1.post.ch/kvm/app/ui',
           int01: 'https://serviceint1.post.ch/kvm/app/ui',
           int02: 'https://serviceint2.post.ch/kvm/app/ui',
           prod: 'https://service.post.ch/kvm/app/ui',

--- a/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
+++ b/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
@@ -167,7 +167,7 @@ export class PostInternetHeader {
     // Wait for the config to arrive, then render the header
     try {
       state.projectId = this.project;
-      state.environment = this.environment;
+      state.environment = this.environment.toLocaleLowerCase() as Environment;
       if (this.language !== undefined) state.currentLanguage = this.language;
       state.languageSwitchOverrides =
         typeof this.languageSwitchOverrides === 'string'
@@ -187,7 +187,7 @@ export class PostInternetHeader {
 
       state.localizedConfig = await getLocalizedConfig({
         projectId: this.project,
-        environment: this.environment,
+        environment: state.environment,
         language: this.language,
         cookieKey: this.languageCookieKey,
         localStorageKey: this.languageLocalStorageKey,

--- a/packages/internet-header/src/services/config.service.ts
+++ b/packages/internet-header/src/services/config.service.ts
@@ -199,13 +199,14 @@ export const fetchConfig = async (
 export const generateConfigUrl = (projectId: string, environment: Environment): string => {
   if (projectId === 'test') return 'assets/config/test-configuration.json';
 
-  const isProd = environment === 'prod';
+  const parsedEnvironment = environment.toLowerCase();
+  const isProd = parsedEnvironment === 'prod';
   const host = `https://${isProd ? 'www' : 'int'}.post.ch`;
   try {
     // Use URL to validate the generated URL
     return new URL(
       `${host}/api/headerjs/Json?serviceid=${encodeURIComponent(projectId)}${
-        !isProd ? '&environment=' + environment : ''
+        !isProd ? '&environment=' + parsedEnvironment : ''
       }`,
     ).toString();
   } catch (error) {

--- a/packages/internet-header/src/services/config.service.ts
+++ b/packages/internet-header/src/services/config.service.ts
@@ -199,14 +199,13 @@ export const fetchConfig = async (
 export const generateConfigUrl = (projectId: string, environment: Environment): string => {
   if (projectId === 'test') return 'assets/config/test-configuration.json';
 
-  const parsedEnvironment = environment.toLowerCase();
-  const isProd = parsedEnvironment === 'prod';
+  const isProd = environment === 'prod';
   const host = `https://${isProd ? 'www' : 'int'}.post.ch`;
   try {
     // Use URL to validate the generated URL
     return new URL(
       `${host}/api/headerjs/Json?serviceid=${encodeURIComponent(projectId)}${
-        !isProd ? '&environment=' + parsedEnvironment : ''
+        !isProd ? '&environment=' + environment : ''
       }`,
     ).toString();
   } catch (error) {


### PR DESCRIPTION
When the environment parameter is not set in lowercase, mapping to internal sets fails. This causes errors in the Login Widget for the Settings URL as well as for coveo token mapping.