### PR TITLE
feat(documentation): Hide icons stories and rename docs pages

### DIFF
--- a/packages/documentation-v7/src/stories/icons/components/icon.demo.stories.ts
+++ b/packages/documentation-v7/src/stories/icons/components/icon.demo.stories.ts
@@ -6,7 +6,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { BADGE } from '../../../../.storybook/constants';
 
 const meta: Meta = {
-  title: 'Icons/Components/Icon',
+  title: 'Hidden/components/Icon',
   component: 'post-icon',
   parameters: {
     badges: [BADGE.NEEDS_REVISION],

--- a/packages/documentation-v7/src/stories/icons/components/icon.demo.stories.ts
+++ b/packages/documentation-v7/src/stories/icons/components/icon.demo.stories.ts
@@ -3,14 +3,10 @@ import { Args, Meta, StoryObj } from '@storybook/web-components';
 import { Components } from '@swisspost/design-system-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { BADGE } from '../../../../.storybook/constants';
 
 const meta: Meta = {
   title: 'Hidden/components/Icon',
   component: 'post-icon',
-  parameters: {
-    badges: [BADGE.NEEDS_REVISION],
-  },
   args: {
     'name': '1022',
     'base': '',
@@ -102,7 +98,7 @@ const renderVariants = (
 
 const generateDecorators = (story: any, className?: string) => {
   return html`
-    <div class=${ifDefined(className)} style="font-size: 32px">${story()}</div>
+    <div class="${ifDefined(className)}" style="font-size: 32px">${story()}</div>
   `;
 };
 

--- a/packages/documentation-v7/src/stories/icons/components/icon.docs.mdx
+++ b/packages/documentation-v7/src/stories/icons/components/icon.docs.mdx
@@ -1,9 +1,9 @@
 import LinkTo from '@storybook/addon-links/react';
 import { Meta, Canvas, Controls } from '@storybook/blocks';
 
-import * as IconStories from './icon.stories';
+import * as IconStories from './icon.demo.stories';
 
-<Meta of={IconStories} />
+<Meta title="Icons/Icon Component" />
 
 # Icon
 
@@ -13,7 +13,7 @@ import * as IconStories from './icon.stories';
 </div>
 
 <Canvas of={IconStories.Default} />
-<Controls />
+<Controls of={IconStories.Default} />
 
 ### Color
 

--- a/packages/documentation-v7/src/stories/icons/components/icon.docs.mdx
+++ b/packages/documentation-v7/src/stories/icons/components/icon.docs.mdx
@@ -1,9 +1,10 @@
 import LinkTo from '@storybook/addon-links/react';
-import { Meta, Canvas, Controls } from '@storybook/blocks';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { BADGE } from '../../../../.storybook/constants';
 
 import * as IconStories from './icon.demo.stories';
 
-<Meta title="Icons/Icon Component" />
+<Meta title="Icons/Icon Component" parameters={{ badges: [BADGE.NEEDS_REVISION] }} />
 
 # Icon
 

--- a/packages/documentation-v7/src/stories/icons/search-icons/search-icons.blocks.tsx
+++ b/packages/documentation-v7/src/stories/icons/search-icons/search-icons.blocks.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import report from '@swisspost/design-system-icons/public/report.json';
+import React from 'react';
 import './search-icons.styles.scss';
 
 const ICONS = report.icons.map(icon =>
@@ -48,12 +48,11 @@ export class Search extends React.Component {
               id="IconSearchFilter_Freetext"
               type="text"
               className="form-control"
-              placeholder="Search Icons"
               value={this.state.freetext}
               onChange={this.searchFreetext.bind(this)}
               ref={this.freetextRef}
             />
-            <label htmlFor="IconSearchFilter_Freetext">Search Icons</label>
+            <label htmlFor="IconSearchFilter_Freetext">Search for icons by name or id</label>
             {this.state.freetext ? (
               <button className="form-control-reset" onClick={this.resetFreetext.bind(this)}>
                 <post-icon name="2043" />

--- a/packages/documentation-v7/src/stories/icons/search-icons/search-icons.docs.mdx
+++ b/packages/documentation-v7/src/stories/icons/search-icons/search-icons.docs.mdx
@@ -1,9 +1,9 @@
 import { Meta } from '@storybook/blocks';
 import { Search } from './search-icons.blocks';
 
-<Meta title="Icons/Search Icons" />
+<Meta title="Icons/Search for Icons" />
 
-# Icons
+# Search for icons
 
 <div className="lead">
   The official Swiss Post Icon Library for the web with over 800 high-quality scalable vector


### PR DESCRIPTION
| Before  | After   |
|---|---|
|  ![Screenshot 2023-07-27 at 17-12-54 Icons _ Components _ Icon - Default ⋅ Storybook](https://github.com/swisspost/design-system/assets/12294151/23268d5a-a53f-4339-b1d9-d6d0dfeb59b5) |  ![Screenshot 2023-07-27 at 17-12-14 Icons _ Icon Component - Docs ⋅ Storybook](https://github.com/swisspost/design-system/assets/12294151/6e9bf3d0-48e2-4e78-b66d-e0acd56a8e8c) |

