### PR TITLE
docs: use light mode per default

### DIFF
--- a/packages/documentation-v7/.storybook/blocks/footer.tsx
+++ b/packages/documentation-v7/.storybook/blocks/footer.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useDarkMode } from 'storybook-dark-mode';
 
 interface Developer {
   name: string;
@@ -32,42 +31,38 @@ const DEVELOPERS: Developer[] = [
 
 export default () => (
   <footer className="docs-footer mt-huge">
-    <div className={useDarkMode() ? 'bg-black' : 'bg-light'}>
-      <div className="container">
-        <div className="pt-big-r pb-big-r">
-          <h2 className="mt-0">Support</h2>
+    <div className="container">
+      <div className="pt-big-r pb-big-r">
+        <h2 className="mt-0">Support</h2>
 
-          <div className="d-flex flex-wrap mt-huge-r mb-huge-r profile-list">
-            {DEVELOPERS
-              .sort(() => (Math.random() > 0.5 ? 1 : -1))
-              .map((developer, index) => (
-                <article key={index} className="avatar">
-                  <img
-                    className="profile-picture"
-                    src={developer.avatar}
-                    alt={`Profile picture ${developer.name}`}
-                  />
-                  <div>
-                    <p>
-                      <strong>{developer.name}</strong>
-                    </p>
-                    <p>{developer.title}</p>
-                  </div>
-                </article>
-              ))}
-          </div>
+        <div className="d-flex flex-wrap mt-huge-r mb-huge-r profile-list">
+          {DEVELOPERS.sort(() => (Math.random() > 0.5 ? 1 : -1)).map((developer, index) => (
+            <article key={index} className="avatar">
+              <img
+                className="profile-picture"
+                src={developer.avatar}
+                alt={`Profile picture ${developer.name}`}
+              />
+              <div>
+                <p>
+                  <strong>{developer.name}</strong>
+                </p>
+                <p>{developer.title}</p>
+              </div>
+            </article>
+          ))}
+        </div>
 
-          <div className="row mt-regular-r">
-            <div className="col-12 col-rg-auto mt-regular-r">
-              <a
-                className="btn-primary btn btn-rg btn-animated"
-                href="https://github.com/swisspost/design-system/issues"
-                target="_blank"
-                rel="noopener"
-              >
-                <span>Submit an issue</span>
-              </a>
-            </div>
+        <div className="row mt-regular-r">
+          <div className="col-12 col-rg-auto mt-regular-r">
+            <a
+              className="btn-primary btn btn-rg btn-animated"
+              href="https://github.com/swisspost/design-system/issues"
+              target="_blank"
+              rel="noopener"
+            >
+              <span>Submit an issue</span>
+            </a>
           </div>
         </div>
       </div>

--- a/packages/documentation-v7/.storybook/main.ts
+++ b/packages/documentation-v7/.storybook/main.ts
@@ -13,7 +13,6 @@ const config: StorybookConfig = {
   addons: [
     '@storybook/addon-links',
     // '@storybook/addon-a11y',
-    'storybook-dark-mode',
     '@geometricpanda/storybook-addon-badges',
     '@pxtrn/storybook-addon-docs-stencil',
     {

--- a/packages/documentation-v7/.storybook/manager.ts
+++ b/packages/documentation-v7/.storybook/manager.ts
@@ -1,9 +1,11 @@
 import { addons } from '@storybook/manager-api';
+import themes from './styles/themes';
 
 if (process.env.NODE_ENV) document.documentElement.setAttribute('data-env', process.env.NODE_ENV);
 
 addons.setConfig({
   panelPosition: 'right',
+  theme: themes.light,
   sidebar: {
     collapsedRoots: [],
   },

--- a/packages/documentation-v7/.storybook/preview.ts
+++ b/packages/documentation-v7/.storybook/preview.ts
@@ -12,7 +12,6 @@ import { badgesConfig, prettierOptions, resetComponents } from './helpers';
 import './helpers/register-web-components';
 
 import './styles/preview.scss';
-import themes from './styles/themes';
 
 import { SyntaxHighlighter } from '@storybook/components';
 import scss from 'react-syntax-highlighter/dist/esm/languages/prism/scss';
@@ -47,14 +46,6 @@ const preview: Preview = {
           'Hidden',
         ],
       },
-    },
-    darkMode: {
-      current: 'light',
-      dark: themes.dark,
-      light: themes.light,
-      darkClass: 'bg-dark',
-      lightClass: 'bg-white',
-      stylePreview: true,
     },
     docs: {
       container: DocsLayout,

--- a/packages/documentation-v7/package.json
+++ b/packages/documentation-v7/package.json
@@ -60,7 +60,6 @@
     "rimraf": "5.0.1",
     "sass": "1.64.2",
     "storybook": "7.2.1",
-    "storybook-dark-mode": "3.0.1",
     "typescript": "5.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -698,9 +698,6 @@ importers:
       storybook:
         specifier: 7.2.1
         version: 7.2.1
-      storybook-dark-mode:
-        specifier: 3.0.1
-        version: 3.0.1(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: 5.1.6
         version: 5.1.6


### PR DESCRIPTION
For the moment, dark mode is not implemented for many components. Until it is, the docs look broken when dark mode is enabled. Therefore I suggest to default to light mode until design and a system is available for dark mode.