### PR TITLE
fix(components, internet-header): exclude tests and spec files from build

### DIFF
--- a/packages/components/.eslintrc.json
+++ b/packages/components/.eslintrc.json
@@ -14,7 +14,7 @@
   "parserOptions": {
     "ecmaVersion": "latest",
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.eslint.json"
   },
   "plugins": [
     "@typescript-eslint"
@@ -44,12 +44,25 @@
       }
     ],
     "@stencil-community/strict-boolean-conditions": "off",
-    "@stencil-community/required-prefix": ["error", ["post"]],
+    "@stencil-community/required-prefix": [
+      "error",
+      [
+        "post"
+      ]
+    ],
     "@stencil-community/async-methods": "error",
-    "@stencil-community/ban-prefix": ["error", ["stencil", "stnl", "st"]],
+    "@stencil-community/ban-prefix": [
+      "error",
+      [
+        "stencil",
+        "stnl",
+        "st"
+      ]
+    ],
     "@stencil-community/decorators-context": "error",
     "@stencil-community/decorators-style": [
-      "error", {
+      "error",
+      {
         "prop": "inline",
         "state": "inline",
         "element": "inline",
@@ -57,7 +70,8 @@
         "method": "multiline",
         "watch": "multiline",
         "listen": "multiline"
-      }],
+      }
+    ],
     "@stencil-community/element-type": "error",
     "@stencil-community/host-data-deprecated": "error",
     "@stencil-community/methods-must-be-public": "error",

--- a/packages/components/tsconfig.eslint.json
+++ b/packages/components/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src",
+    "**/tests"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -21,6 +21,8 @@
     "src"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/tests",
+    "**/*.spec.*"
   ]
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -22,7 +22,6 @@
   ],
   "exclude": [
     "node_modules",
-    "**/tests",
-    "**/*.spec.*"
+    "**/tests"
   ]
 }

--- a/packages/internet-header/.eslintrc.json
+++ b/packages/internet-header/.eslintrc.json
@@ -1,14 +1,22 @@
 {
-  "extends": ["plugin:@stencil/recommended"],
+  "extends": [
+    "plugin:@stencil/recommended"
+  ],
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 2020
+    "ecmaVersion": 2020,
+    "project": "./tsconfig.eslint.json"
   },
   "rules": {
-    "@stencil/decorators-context": 0, // This is a broken rule with eslint 8 (https://github.com/stencil-community/stencil-eslint/issues/60)
-    "@stencil/own-methods-must-be-private": 0, // Seems to be buggy as well
-    "@stencil/async-methods": 0, // Also buggy
-    "@stencil/no-unused-watch": 0, // Buggy
-    "react/jsx-no-bind": 0 // No performance problem anymore https://medium.com/@ryanflorence/react-inline-functions-and-performance-bdff784f5578
+    "@stencil/decorators-context": 0,
+    // This is a broken rule with eslint 8 (https://github.com/stencil-community/stencil-eslint/issues/60)
+    "@stencil/own-methods-must-be-private": 0,
+    // Seems to be buggy as well
+    "@stencil/async-methods": 0,
+    // Also buggy
+    "@stencil/no-unused-watch": 0,
+    // Buggy
+    "react/jsx-no-bind": 0
+    // No performance problem anymore https://medium.com/@ryanflorence/react-inline-functions-and-performance-bdff784f5578
   }
 }

--- a/packages/internet-header/tsconfig.eslint.json
+++ b/packages/internet-header/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src",
+    "**/tests"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/internet-header/tsconfig.json
+++ b/packages/internet-header/tsconfig.json
@@ -4,7 +4,11 @@
     "allowUnreachableCode": false,
     "declaration": true,
     "experimentalDecorators": true,
-    "lib": ["dom", "DOM.Iterable", "es2017"],
+    "lib": [
+      "dom",
+      "DOM.Iterable",
+      "es2017"
+    ],
     "moduleResolution": "node",
     "module": "esnext",
     "target": "es2017",
@@ -16,6 +20,12 @@
     "strictNullChecks": true,
     "skipLibCheck": true
   },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/tests",
+    "**/*.spec.*"
+  ]
 }


### PR DESCRIPTION
Today, when building components and internet-header packages, we include test files in the build. This is unnecessary and in addition, it breaks the running test command when locally you have the dist folder generated, as those tests in dist are discovered by jest, but cannot be run.

Before, Stencil provided another way to exclude files and folders, but it was replaced:
https://github.com/ionic-team/stencil/commit/c18cb1f608c7c4668b081b94f292d1f8af721641