### PR TITLE
chore(documentation-v7): simplify the snapshot test urls

### DIFF
--- a/packages/documentation-v7/.storybook/preview.ts
+++ b/packages/documentation-v7/.storybook/preview.ts
@@ -43,7 +43,7 @@ const preview: Preview = {
           'Utilities',
           'Misc',
           ['Migration Guide', 'ChangeLog', 'Versions'],
-          'Hidden',
+          'Snapshots',
         ],
       },
     },

--- a/packages/documentation-v7/.storybook/styles/manager.scss
+++ b/packages/documentation-v7/.storybook/styles/manager.scss
@@ -20,17 +20,6 @@
     }
   }
 
-  // Hide that very specific sidebar navigation entry to hide test pages
-  [data-env='production'] & {
-    #hidden {
-      display: none;
-    }
-
-    .sidebar-item[data-parent-id='hidden'] {
-      display: none;
-    }
-  }
-
   .sidebar-item {
     position: relative;
 

--- a/packages/documentation-v7/cypress/snapshots/components/alert.snapshot.ts
+++ b/packages/documentation-v7/cypress/snapshots/components/alert.snapshot.ts
@@ -1,0 +1,6 @@
+describe('Alert', () => {
+  it('default', () => {
+    cy.visit('./iframe.html?id=snapshots--alert');
+    cy.percySnapshot('Alerts', { widths: [320, 1440] });
+  });
+});

--- a/packages/documentation-v7/cypress/snapshots/components/blockquote.snapshot.ts
+++ b/packages/documentation-v7/cypress/snapshots/components/blockquote.snapshot.ts
@@ -1,6 +1,6 @@
 describe('Blockquote', () => {
   it('default', () => {
-    cy.visit('./iframe.html?id=hidden-snapshots-components--blockquote');
+    cy.visit('./iframe.html?id=snapshots--blockquote');
     cy.percySnapshot('Blockquotes', { widths: [320, 1440] });
   });
 });

--- a/packages/documentation-v7/cypress/snapshots/components/button.snapshot.ts
+++ b/packages/documentation-v7/cypress/snapshots/components/button.snapshot.ts
@@ -1,6 +1,6 @@
 describe('Button', () => {
   it('default', () => {
-    cy.visit('/iframe.html?id=hidden-snapshots-components--button');
+    cy.visit('/iframe.html?id=snapshots--button');
     cy.percySnapshot('Buttons', { widths: [1440] });
   });
 });

--- a/packages/documentation-v7/cypress/snapshots/components/card.snapshot.ts
+++ b/packages/documentation-v7/cypress/snapshots/components/card.snapshot.ts
@@ -1,0 +1,6 @@
+describe('Card', () => {
+  it('default', () => {
+    cy.visit('./iframe.html?id=snapshots--card');
+    cy.percySnapshot('Cards', { widths: [1440] });
+  });
+});

--- a/packages/documentation-v7/cypress/snapshots/components/headings.snapshot.ts
+++ b/packages/documentation-v7/cypress/snapshots/components/headings.snapshot.ts
@@ -1,6 +1,6 @@
 describe('Headings', () => {
   it('default', () => {
-    cy.visit('/iframe.html?id=hidden-snapshots-components--heading');
+    cy.visit('/iframe.html?id=snapshots--heading');
     cy.percySnapshot('Headings', { widths: [1024] });
   });
 });

--- a/packages/documentation-v7/src/stories/components/alert/alert.snapshot.stories.ts
+++ b/packages/documentation-v7/src/stories/components/alert/alert.snapshot.stories.ts
@@ -1,37 +1,43 @@
-import { Args, Meta, StoryObj } from '@storybook/web-components';
+import { Args, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { bombArgs } from '../../utilities/bombArgs';
 import alertMeta from './alert.stories';
 import { getAlertClasses } from './getAlertClasses';
 
-const meta: Meta = {
-  title: 'Hidden/snapshots/components/Alert',
+export default {
+  ...alertMeta,
+  title: 'Snapshots',
+};
+
+type Story = StoryObj;
+
+export const Alert: Story = {
   render: () => html`
     <div class="d-flex gap-3 flex-wrap">
       ${['bg-white', 'bg-dark'].map(
-        bg => html`
+    bg => html`
           <div class=${bg + ' d-flex gap-3 flex-wrap p-3'}>
             ${bombArgs({
-              variant: alertMeta?.argTypes?.variant?.options,
-              noIcon: [true, false],
-              icon: ['null', '1001'],
-              dismissible: [true, false],
-              action: [true, false],
-            })
-              .filter(args => !(args.noIcon && args.icon === 'null'))
-              .map(args => ({ ...args, show: true } as Args))
-              .map(
-                args => html`
+      variant: alertMeta?.argTypes?.variant?.options,
+      noIcon: [true, false],
+      icon: ['null', '1001'],
+      dismissible: [true, false],
+      action: [true, false],
+    })
+      .filter(args => !(args.noIcon && args.icon === 'null'))
+      .map(args => ({ ...args, show: true } as Args))
+      .map(
+        args => html`
                   <div class=${getAlertClasses(args)} role="alert">
                     ${args.dismissible || args.fixed
-                      ? html`
+          ? html`
                           <button class="btn-close">
                             <span class="visually-hidden">Close</span>
                           </button>
                         `
-                      : null}
+          : null}
                     ${args.action
-                      ? html`
+          ? html`
                           <div class="alert-content">
                             <h4 class="alert-heading">Alert</h4>
                             <p>
@@ -41,18 +47,16 @@ const meta: Meta = {
                             </p>
                           </div>
                         `
-                      : html`
+          : html`
                           <h4 class="alert-heading">Alert</h4>
-                          ,
                           <p>
                             Lorem ipsum dolor sit, amet consectetur adipisicing elit. Debitis
                             temporibus blanditiis expedita inventore atque. Numquam velit aut
                             eveniet cumque non?
                           </p>
-                          ,
                         `}
                     ${args.action
-                      ? html`
+          ? html`
                           <div class="alert-buttons">
                             <button class="btn btn-primary btn-animated">
                               <span>Akcepti</span>
@@ -62,19 +66,13 @@ const meta: Meta = {
                             </button>
                           </div>
                         `
-                      : null}
+          : null}
                   </div>
                 `,
-              )}
+      )}
           </div>
         `,
-      )}
+  )}
     </div>
-  `,
+  `
 };
-
-export default meta;
-
-type Story = StoryObj;
-
-export const Alert: Story = {};

--- a/packages/documentation-v7/src/stories/components/blockquote/blockquote.snapshot.stories.ts
+++ b/packages/documentation-v7/src/stories/components/blockquote/blockquote.snapshot.stories.ts
@@ -3,12 +3,12 @@ import meta, { Default } from './blockquote.stories';
 import { html } from 'lit';
 import { bombArgs } from '../../../utils/bombArgs';
 
-type Story = StoryObj;
-
 export default {
   ...meta,
-  title: 'Hidden/snapshots/components',
+  title: 'Snapshots',
 };
+
+type Story = StoryObj;
 
 export const Blockquote: Story = {
   render: (_args: Args, context: StoryContext) => {

--- a/packages/documentation-v7/src/stories/components/button/button.snapshot.stories.ts
+++ b/packages/documentation-v7/src/stories/components/button/button.snapshot.stories.ts
@@ -3,13 +3,12 @@ import meta, { Default, AccentColors, ContextualColors } from './button.stories'
 import { html } from 'lit';
 import { bombArgs } from '../../../utils/bombArgs';
 
-type Story = StoryObj;
-
-
 export default {
   ...meta,
-  title: 'Hidden/snapshots/components',
+  title: 'Snapshots',
 };
+
+type Story = StoryObj;
 
 export const Button: Story = {
   render: (_args: Args, context: StoryContext) => {

--- a/packages/documentation-v7/src/stories/components/card/card.snapshot.stories.tsx
+++ b/packages/documentation-v7/src/stories/components/card/card.snapshot.stories.tsx
@@ -5,7 +5,7 @@ import { bombArgs } from '../../../utils/bombArgs';
 
 export default {
   ...meta,
-  title: 'Hidden/snapshots/components/Card',
+  title: 'Snapshots',
 };
 
 type Story = StoryObj;

--- a/packages/documentation-v7/src/stories/components/heading/heading.snapshot.stories.ts
+++ b/packages/documentation-v7/src/stories/components/heading/heading.snapshot.stories.ts
@@ -3,12 +3,12 @@ import meta, { Default } from './heading.stories';
 import { html } from 'lit';
 import { bombArgs } from '../../../utils/bombArgs';
 
-type Story = StoryObj;
-
 export default {
   ...meta,
-  title: 'Hidden/snapshots/components',
+  title: 'Snapshots',
 };
+
+type Story = StoryObj;
 
 export const Heading: Story = {
   render: (_args: Args, context: StoryContext) => {


### PR DESCRIPTION
The snapshot story of a component is now available at: `'./iframe.html?id=snapshots--[component]`