### PR TITLE
chore: update netlify command

### DIFF
--- a/.github/actions/deploy-to-netlify/action.yaml
+++ b/.github/actions/deploy-to-netlify/action.yaml
@@ -83,8 +83,7 @@ runs:
       # run command taken from https://gist.github.com/oneohthree/f528c7ae1e701ad990e6, shortened to 28 chars, prepended with build-number
       run: |
         url_alias=`echo "preview-${{ inputs.id }}" | iconv -t ascii//TRANSLIT | sed -E 's/[~\^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+\|-+$//g' | sed -E 's/^-+//g' | sed -E 's/-+$//g' | tr A-Z a-z`
-        netlify link --id ${{ inputs.netlify_site_id }}
-        netlify deploy --alias $url_alias --build false --dir ${{ inputs.folder }}
+        netlify deploy --alias $url_alias --build false --dir ${{ inputs.folder }} --site ${{ inputs.netlify_site_id }}
         echo "url_alias=$url_alias" >> $GITHUB_OUTPUT
 
     - name: Prepare Comment Message


### PR DESCRIPTION
Netlify cli wants to select a site in CI builds. Trying to pass site ID on the deploy command instead of linking beforehand.

Error: https://github.com/swisspost/design-system/actions/runs/5848489770/job/15855837555#step:5:166