### PR TITLE
fix(documentation-v7): Stacked toast - Change style link to component title

### DIFF
--- a/packages/documentation-v7/src/stories/components/toast/toast.stories.ts
+++ b/packages/documentation-v7/src/stories/components/toast/toast.stories.ts
@@ -250,15 +250,15 @@ const meta: Meta = {
 
       if (args.stacked) {
         return html`
-          <div>
+          <div class="toast-container-wrapper-stacked">
             ${story()}
             <style>
-              #story--hidden-demos-components-toast--stacked .toast-container {
+              .toast-container-wrapper-stacked .toast-container {
                 position: relative;
                 inset: 0;
               }
 
-              #story--hidden-demos-components-toast--stacked .toast-container > .toast:last-child {
+              .toast-container-wrapper-stacked .toast-container > .toast:last-child {
                 margin-bottom: 0;
               }
             </style>


### PR DESCRIPTION
Fix style dependency with component title. It broke when we changed the stories from hidden to standard.