### PR TITLE
fix(styles): missing calendar icon with named icon

### DIFF
--- a/.changeset/long-pumpkins-repeat.md
+++ b/.changeset/long-pumpkins-repeat.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed the `.pi-calendar` class not showing an icon in the datepicker.

--- a/.changeset/serious-toes-speak.md
+++ b/.changeset/serious-toes-speak.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-demo': patch
+---
+
+Deprecated the `.pi-calendar` class in favor of the `.pi-3203` class to display the calendar icon in the datepicker.

--- a/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-demo-page/datepicker-demo-page.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-demo-page/datepicker-demo-page.component.html
@@ -3,6 +3,11 @@
   <app-dependency-link></app-dependency-link>
 </div>
 
+<div class="alert alert-warning mb-bigger-big">
+  <p>The <code>.pi-calendar</code> class previously used to display the calendar icon in the datepicker button
+    has been deprecated in favor of the <code>.pi-3203</code> class which shows the same icon.</p>
+</div>
+
 <section>
   <p id="languageSelectorTitle" class="light font-curve-regular">Choose a language:</p>
 

--- a/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-simple/datepicker-simple-lg.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-simple/datepicker-simple-lg.component.html
@@ -10,6 +10,6 @@
          type="text"/>
   <label for="dpSimple" class="form-label">Simple datepicker</label>
   <button class="ngb-dp-open" (click)="dpSimple.toggle()" aria-label="Open calendar">
-    <i class="pi pi-calendar" aria-hidden="true"></i>
+    <i class="pi pi-3203" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-simple/datepicker-simple.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-simple/datepicker-simple.component.html
@@ -11,6 +11,6 @@
          placeholder="yyyy-mm-dd"
          type="text">
   <button class="ngb-dp-open" (click)="dpSimple.toggle()" aria-label="Open calendar">
-    <i class="pi pi-calendar" aria-hidden="true"></i>
+    <i class="pi pi-3203" aria-hidden="true"></i>
   </button>
 </div>

--- a/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-validation/datepicker-validation-lg.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-validation/datepicker-validation-lg.component.html
@@ -14,7 +14,7 @@
   <label for="dpValidation" class="form-label">Datepicker with validation</label>
 
   <button class="ngb-dp-open" (click)="dpValidation.toggle()" aria-label="Open calendar">
-    <i class="pi pi-calendar" aria-hidden="true"></i>
+    <i class="pi pi-3203" aria-hidden="true"></i>
   </button>
 
   <p class="valid-feedback">Valid feedback</p>

--- a/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-validation/datepicker-validation.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/datepicker/datepicker-validation/datepicker-validation.component.html
@@ -14,7 +14,7 @@
          type="text">
 
   <button class="ngb-dp-open" (click)="dpValidation.toggle()" aria-label="Open calendar">
-    <i class="pi pi-calendar" aria-hidden="true"></i>
+    <i class="pi pi-3203" aria-hidden="true"></i>
   </button>
 
   <p class="valid-feedback">Valid feedback</p>

--- a/packages/demo/src/styles.scss
+++ b/packages/demo/src/styles.scss
@@ -52,10 +52,6 @@ body {
   @include post.pi(2104, 'white');
 }
 
-.pi-calendar {
-  @include post.pi(3203);
-}
-
 .code-sample {
   margin-top: 35px;
   text-align: center;

--- a/packages/styles/src/components/datepicker.scss
+++ b/packages/styles/src/components/datepicker.scss
@@ -5,6 +5,7 @@
 @use './../variables/components/datepicker';
 @use './../variables/components/forms';
 @use './../variables/commons';
+@use './../mixins/icons' as icons-mx;
 
 ngb-datepicker {
   // Conversion for compatibility
@@ -131,7 +132,9 @@ span.ngb-dp-navigation-chevron {
   width: forms.$input-height-inner;
   background: transparent;
 
+  .pi-3203,
   .pi-calendar {
+    @include icons-mx.pi(3203);
     width: datepicker.$ngb-dp-icon-size;
     height: datepicker.$ngb-dp-icon-size;
     transform: none;
@@ -142,6 +145,7 @@ span.ngb-dp-navigation-chevron {
   height: forms.$input-height-inner-sm;
   width: forms.$input-height-inner-sm;
 
+  .pi-3203,
   .pi-calendar {
     width: datepicker.$ngb-dp-icon-size-sm;
     height: datepicker.$ngb-dp-icon-size-sm;
@@ -158,6 +162,7 @@ span.ngb-dp-navigation-chevron {
   height: forms.$input-height-inner-lg;
   width: forms.$input-height-inner-lg;
 
+  .pi-3203,
   .pi-calendar {
     width: datepicker.$ngb-dp-icon-size-lg;
     height: datepicker.$ngb-dp-icon-size-lg;


### PR DESCRIPTION
I let `.pi-calendar` coexist with `.pi-3203` for now and added a deprecation message.