### PR TITLE
fix(documentation-v7): overwrite hcm styles for .innerZoomElementWrapper border-color

### DIFF
--- a/packages/documentation-v7/.storybook/styles/preview.scss
+++ b/packages/documentation-v7/.storybook/styles/preview.scss
@@ -148,4 +148,12 @@
       }
     }
   }
+
+  @include post.high-contrast-mode() {
+    .innerZoomElementWrapper {
+      > * {
+        border-color: Canvas;
+      }
+    }
+  }
 }


### PR DESCRIPTION
To test:
- go to any story
- activate high-contrast-mode
- there should be no 10px border around the story anymore