### PR TITLE
chore: deprecating size variants for text input, textarea and select

### DIFF
--- a/.changeset/calm-swans-begin.md
+++ b/.changeset/calm-swans-begin.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Deprecated sizes "regular" and "medium" for text inputs, textareas and select boxes. Future major versions of the Design System will only support the sizes "small" and "large". This change will make it easier to decide what variant to use where: small for internal applications, large for consumber facing external applications.


### PR DESCRIPTION
We're deprecating the regular and medium sizes for text input, textarea and select. This will make it easier to select the appropriate size variant: small for internal applications, large for external applications.

Dedicated tickets were created for each component:

- [ ] https://github.com/swisspost/design-system/issues/1834
- [ ] https://github.com/swisspost/design-system/issues/1835
- [ ] https://github.com/swisspost/design-system/issues/1836