### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ yarn.lock
 lerna-debug.log
 
 # System Files
-.DS_Store/
+.DS_Store
 styles/stylelint-report.txt
 
 # dotfiles


### PR DESCRIPTION
.DS_Store files on the mac are not (always) a directory