### PR TITLE
chore: improve styles watch performance

### DIFF
--- a/packages/styles/gulpfile.js
+++ b/packages/styles/gulpfile.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const gulp = require('gulp');
 const sass = require('sass');
+const newer = require('gulp-newer');
 const gulpSass = require('gulp-sass')(sass);
 const gulpPostCss = require('gulp-postcss');
 const autoprefixer = require('autoprefixer');
@@ -14,6 +15,7 @@ const options = require('./package.json').sass;
 gulp.task('copy', () => {
   return gulp
     .src(['./LICENSE', './README.md', './package.json', './src/**/*.scss'])
+    .pipe(newer(options.outputDir))
     .pipe(gulp.dest(options.outputDir));
 });
 
@@ -132,7 +134,7 @@ gulp.task('sass:tests', () => {
  * Watch task for scss development
  */
 gulp.task('watch', () => {
-  return gulp.watch('./src/**/*.scss', gulp.series('map-icons', 'copy', 'watch'));
+  return gulp.watch('./src/**/*.scss', gulp.series('copy'));
 });
 
 /**

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -52,6 +52,7 @@
     "cypress-storybook": "0.5.1",
     "glob": "10.3.3",
     "gulp": "4.0.2",
+    "gulp-newer": "^1.4.0",
     "gulp-postcss": "9.0.1",
     "gulp-sass": "5.1.0",
     "jest": "29.6.2",

--- a/packages/styles/src/components/badge.scss
+++ b/packages/styles/src/components/badge.scss
@@ -16,6 +16,8 @@
 
 .badge {
   @extend %badge;
+
+  background-color: red;
 }
 
 a,

--- a/packages/styles/src/components/badge.scss
+++ b/packages/styles/src/components/badge.scss
@@ -16,8 +16,6 @@
 
 .badge {
   @extend %badge;
-
-  background-color: red;
 }
 
 a,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,6 +929,9 @@ importers:
       gulp:
         specifier: 4.0.2
         version: 4.0.2
+      gulp-newer:
+        specifier: ^1.4.0
+        version: 1.4.0
       gulp-postcss:
         specifier: 9.0.1
         version: 9.0.1(postcss@8.4.27)
@@ -11101,6 +11104,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /ansi-cyan@0.1.1:
+    resolution: {integrity: sha512-eCjan3AVo/SxZ0/MyIYRtkpxIu/H3xZN7URr1vXVrISxeyz8fUFz0FJziamK4sS8I+t35y4rHg1b2PklyBe/7A==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-wrap: 0.1.0
+    dev: true
+
   /ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -11119,6 +11129,13 @@ packages:
     resolution: {integrity: sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==}
     engines: {'0': node >= 0.8.0}
     hasBin: true
+    dev: true
+
+  /ansi-red@0.1.1:
+    resolution: {integrity: sha512-ewaIr5y+9CUTGFwZfpECUbFlGcC0GCw1oqR9RI6h1gQCd9Aj2GxSckCnPsVJnmfMZbwFYE+leZGASgkWl06Jow==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-wrap: 0.1.0
     dev: true
 
   /ansi-regex@2.1.1:
@@ -11265,6 +11282,14 @@ packages:
       deep-equal: 2.2.1
     dev: true
 
+  /arr-diff@1.1.0:
+    resolution: {integrity: sha512-OQwDZUqYaQwyyhDJHThmzId8daf4/RFNLaeh3AevmSeZ5Y7ug4Ga/yKc6l6kTZOBW781rCj103ZuTh8GAsB3+Q==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      arr-flatten: 1.1.0
+      array-slice: 0.2.3
+    dev: true
+
   /arr-diff@4.0.0:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
     engines: {node: '>=0.10.0'}
@@ -11287,6 +11312,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       make-iterator: 1.0.1
+    dev: true
+
+  /arr-union@2.1.0:
+    resolution: {integrity: sha512-t5db90jq+qdgk8aFnxEkjqta0B/GHrM1pxzuuZz2zWsOXc5nKu3t+76s/PQBA8FTcM/ipspIH9jWG4OxCBc2eA==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /arr-union@3.1.0:
@@ -11345,6 +11375,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-number: 4.0.0
+    dev: true
+
+  /array-slice@0.2.3:
+    resolution: {integrity: sha512-rlVfZW/1Ph2SNySXwR9QYkChp8EkOEiTMO5Vwx60usw04i4nWemkm9RXmQqgkQFaLHsqLuADvjp6IfgL9l2M8Q==}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /array-slice@1.1.0:
@@ -15435,6 +15470,13 @@ packages:
       type: 2.7.2
     dev: true
 
+  /extend-shallow@1.1.4:
+    resolution: {integrity: sha512-L7AGmkO6jhDkEBBGWlLtftA80Xq8DipnrRPr0pyi7GQLXkaq9JYA4xF4z6qnadIC6euiTDKco0cGSU9muw+WTw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      kind-of: 1.1.0
+    dev: true
+
   /extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -16608,6 +16650,14 @@ packages:
       yargs: 7.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /gulp-newer@1.4.0:
+    resolution: {integrity: sha512-h79fGO55S/P9eAADbLAP9aTtVYpLSR1ONj08VPaSdVVNVYhTS8p1CO1TW7kEMu+hC+sytmCqcUr5LesvZEtDoQ==}
+    dependencies:
+      glob: 7.2.3
+      kew: 0.7.0
+      plugin-error: 0.1.2
     dev: true
 
   /gulp-postcss@9.0.1(postcss@8.4.27):
@@ -19916,6 +19966,15 @@ packages:
       - utf-8-validate
     dev: true
 
+  /kew@0.7.0:
+    resolution: {integrity: sha512-IG6nm0+QtAMdXt9KvbgbGdvY50RSrw+U4sGZg+KlrSKPJEwVE5JVoI3d7RWfSMdBQneRheeAOj3lIjX5VL/9RQ==}
+    dev: true
+
+  /kind-of@1.1.0:
+    resolution: {integrity: sha512-aUH6ElPnMGon2/YkxRIigV32MOpTVcoXQ1Oo8aYn40s+sJ3j+0gFZsT8HKDcxNy7Fi9zuquWtGaGAahOdv5p/g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /kind-of@3.2.2:
     resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
     engines: {node: '>=0.10.0'}
@@ -22533,6 +22592,17 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       find-up: 6.3.0
+    dev: true
+
+  /plugin-error@0.1.2:
+    resolution: {integrity: sha512-WzZHcm4+GO34sjFMxQMqZbsz3xiNEgonCskQ9v+IroMmYgk/tas8dG+Hr2D6IbRPybZ12oWpzE/w3cGJ6FJzOw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      ansi-cyan: 0.1.1
+      ansi-red: 0.1.1
+      arr-diff: 1.1.0
+      arr-union: 2.1.0
+      extend-shallow: 1.1.4
     dev: true
 
   /plugin-error@1.0.1:


### PR DESCRIPTION
Only copies changed files to dist. This will improve performance for development massively because vite reacted to every change in dist individually and before, every single sass file was copied to dist regardless if it changed or not. Also, map-icons creates a theoretical infinite loop and calling watch again is not necessary within the watch task.