### PR TITLE
chore: mark old issues and pull requests as stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,19 @@
+name: 'Mark stale issues'
+permissions:
+  issues: write
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '9 22 * * *' # the job will run every day at 22:09
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          days-before-stale: 60
+          days-before-close: -1
+          stale-issue-label: 'stale'
+          exempt-milestones: 'next'
+          operations-per-run: 100


### PR DESCRIPTION
More infos and settings at https://github.com/actions/stale. Marks issues and PRs as stale without closing them.