### PR TITLE
fix(demo): caches match doesn't throw errors

### DIFF
--- a/packages/demo/src/app/common/dependency-link/dependency-link.component.ts
+++ b/packages/demo/src/app/common/dependency-link/dependency-link.component.ts
@@ -59,7 +59,7 @@ export class DependencyLinkComponent implements OnDestroy {
 
     const cachedResponse = caches
       .match(url)
-      .catch(() => fetch(url))
+      .then(response => (response !== undefined ? response : fetch(url)))
       .then(response => {
         caches.open('npm').then(cache => {
           void cache.put(url, response);


### PR DESCRIPTION
I used this snippet to work, but the catch is never called and it doesn't work when the cache is empty: https://developer.mozilla.org/en-US/docs/Web/API/Cache/put#examples

A more appropriate snippet is this one: https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/match


https://github.com/mdn/content/pull/29202