### PR TITLE
chore: downgrade other packages to cypress 12

### DIFF
--- a/packages/components/cypress/e2e/tooltip.cy.ts
+++ b/packages/components/cypress/e2e/tooltip.cy.ts
@@ -5,24 +5,27 @@ describe('tooltips', () => {
       cy.get('button[data-tooltip-target="tooltip-multiple"]:first-of-type').as('target1');
       cy.get('button[data-tooltip-target="tooltip-multiple"]:last-of-type').as('target2');
       cy.get('#tooltip-multiple').shadow().find('div[popover]').as('tooltip');
+      cy.get('@target1', { timeout: 30000 }).should('be.visible');
+      cy.get('@tooltip').should('not.be.visible');
     });
 
     it('should display a tooltip', () => {
       cy.get('@tooltip').should('not.be.visible');
-      cy.get('@target2').focus();
+      cy.get('@target2').trigger('focus');
       cy.get('@tooltip').should('be.visible');
-      cy.get('@target2').blur();
+      cy.get('@target2').trigger('blur');
       cy.get('@tooltip').should('not.be.visible');
     });
 
     it('tooltip placement right', () => {
       cy.get('#tooltip-multiple').invoke('attr', 'placement', 'right');
-      cy.get('@target2').focus();
-      cy.wait(10);
+      cy.get('@target2').trigger('focus');
       cy.get('@tooltip')
+        .should('be.visible')
+        .wait(1)
         .should('have.css', 'left')
         .then((v: any) => {
-          expect(parseInt(v)).to.be.greaterThan(150);
+          expect(parseInt(v)).to.be.greaterThan(400);
         });
     });
   });

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,7 +54,7 @@
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "bootstrap": "5.3.2",
-    "cypress": "13.2.0",
+    "cypress": "12.17.4",
     "cypress-storybook": "0.5.1",
     "eslint": "8.50.0",
     "eslint-plugin-react": "7.33.2",

--- a/packages/components/src/components/post-tooltip/post-tooltip.tsx
+++ b/packages/components/src/components/post-tooltip/post-tooltip.tsx
@@ -103,7 +103,7 @@ export class PostTooltip {
   connectedCallback() {
     if (!this.host.id) {
       throw new Error(
-        "No id set: <post-tooltip> must have an id, linking it to it's target element using the data-tooltip-target attribute.",
+        'No id set: <post-tooltip> must have an id, linking it to it\'s target element using the data-tooltip-target attribute.',
       );
     }
 

--- a/packages/components/src/components/post-tooltip/post-tooltip.tsx
+++ b/packages/components/src/components/post-tooltip/post-tooltip.tsx
@@ -43,9 +43,9 @@ export class PostTooltip {
   private tooltipRef: HTMLDivElement & PopoverElement;
   private arrowRef: HTMLElement;
   private clearAutoUpdate: () => void;
-  private readonly localShowTooltip: (e: Event) => Promise<void>;
-  private readonly localHideTooltip: () => Promise<void>;
-  private readonly localToggleTooltip: () => Promise<void>;
+  private readonly localShowTooltip: (e: Event) => void;
+  private readonly localHideTooltip: () => void;
+  private readonly localToggleTooltip: () => void;
   private eventTarget: Element;
 
   @Element() host: HTMLPostTooltipElement;
@@ -85,7 +85,9 @@ export class PostTooltip {
   constructor() {
     // Create local versions of event handlers for de-registration
     // https://stackoverflow.com/questions/33859113/javascript-removeeventlistener-not-working-inside-a-class
-    this.localShowTooltip = e => this.show(e.target as HTMLElement);
+    this.localShowTooltip = e => {
+      this.show(e.target as HTMLElement);
+    };
     this.localHideTooltip = this.hide.bind(this);
     this.localToggleTooltip = this.toggle.bind(this);
   }
@@ -101,7 +103,7 @@ export class PostTooltip {
   connectedCallback() {
     if (!this.host.id) {
       throw new Error(
-        'No id set: <post-tooltip> must have an id, linking it to it\'s target element using the data-tooltip-target attribute.',
+        "No id set: <post-tooltip> must have an id, linking it to it's target element using the data-tooltip-target attribute.",
       );
     }
 
@@ -206,9 +208,7 @@ export class PostTooltip {
     const isOpen = e.newState === 'open';
     if (isOpen) {
       this.startAutoupdates();
-    } else {
-      if (typeof this.clearAutoUpdate === 'function') this.clearAutoUpdate();
-    }
+    } else if (typeof this.clearAutoUpdate === 'function') this.clearAutoUpdate();
   }
 
   /**

--- a/packages/internet-header/cypress/e2e/stickyness.cy.ts
+++ b/packages/internet-header/cypress/e2e/stickyness.cy.ts
@@ -6,7 +6,7 @@ describe('stickyness', () => {
   });
 
   it('should not show header when scrolling when stickyness is none', () => {
-    cy.get('swisspost-internet-header').should('be.inViewport');
+    cy.get('post-main-navigation').should('be.inViewport');
     cy.changeArg('stickyness', 'none');
     cy.wait(10);
     cy.get('.header-story-wrapper').scrollTo('bottom');
@@ -15,22 +15,17 @@ describe('stickyness', () => {
 
   it('should not show header when scrolling down with stickyness minimal, should show header without meta when scrolling up a little', () => {
     cy.changeArg('stickyness', 'minimal');
-    cy.get('post-meta-navigation').should('be.inViewport');
+    cy.get('post-meta-navigation').should('be.visible');
     cy.get('.header-story-wrapper').scrollTo('bottom');
-    cy.get('.fake-content:last-of-type').should('be.inViewport');
-    cy.get('swisspost-internet-header').should('not.be.inViewport');
-    cy.get('post-meta-navigation').should('not.be.inViewport');
-    cy.get('.header-story-wrapper').scrollTo('center', { duration: 10 });
-    cy.get('.header-story-wrapper').then($el => {
-      const el = $el.get(0); //native DOM element
-      el.scrollTo(0, el.scrollTop - 20);
-    });
+    cy.get('.fake-content:last-of-type').should('be.visible');
+    cy.get('swisspost-internet-header').should('not.be.visible');
+    cy.get('post-meta-navigation').should('not.be.visible');
+    cy.get('.header-story-wrapper').scrollTo('center').trigger('scroll');
     cy.get('post-main-navigation').should('be.visible');
-    cy.get('post-main-navigation').should('be.inViewport');
-    cy.get('post-meta-navigation').should('not.be.inViewport');
+    cy.get('post-meta-navigation').should('not.be.visible');
     cy.get('.header-story-wrapper').scrollTo('top');
-    cy.get('swisspost-internet-header').should('be.inViewport');
-    cy.get('post-meta-navigation').should('be.inViewport');
+    cy.get('swisspost-internet-header').should('be.visible');
+    cy.get('post-meta-navigation').should('be.visible');
   });
 
   it('should show main header when scrolling down', () => {

--- a/packages/internet-header/package.json
+++ b/packages/internet-header/package.json
@@ -67,7 +67,7 @@
     "@types/throttle-debounce": "5.0.0",
     "babel-loader": "9.1.3",
     "bootstrap": "5.3.2",
-    "cypress": "13.2.0",
+    "cypress": "12.17.4",
     "cypress-each": "1.13.3",
     "cypress-storybook": "0.5.1",
     "eslint-plugin-react": "7.33.2",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -48,7 +48,7 @@
     "@types/node": "18.18.0",
     "autoprefixer": "10.4.16",
     "copyfiles": "2.4.1",
-    "cypress": "13.2.0",
+    "cypress": "12.17.4",
     "cypress-storybook": "0.5.1",
     "glob": "10.3.7",
     "gulp": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 1.27.2
       '@percy/cypress':
         specifier: 3.1.2
-        version: 3.1.2(cypress@13.2.0)
+        version: 3.1.2(cypress@12.17.4)
       '@stencil-community/eslint-plugin':
         specifier: 0.5.0
         version: 0.5.0(@typescript-eslint/eslint-plugin@5.62.0)(@typescript-eslint/parser@5.62.0)(eslint-plugin-react@7.33.2)(eslint@8.50.0)(typescript@4.9.5)
@@ -87,11 +87,11 @@ importers:
         specifier: 5.3.2
         version: 5.3.2(@popperjs/core@2.11.8)
       cypress:
-        specifier: 13.2.0
-        version: 13.2.0
+        specifier: 12.17.4
+        version: 12.17.4
       cypress-storybook:
         specifier: 0.5.1
-        version: 0.5.1(cypress@13.2.0)
+        version: 0.5.1(cypress@12.17.4)
       eslint:
         specifier: 8.50.0
         version: 8.50.0
@@ -480,7 +480,7 @@ importers:
         version: 4.9.5
       webpack:
         specifier: 5.88.2
-        version: 5.88.2
+        version: 5.88.2(esbuild@0.18.17)
 
   packages/documentation:
     dependencies:
@@ -689,7 +689,7 @@ importers:
         version: 1.27.2
       '@percy/cypress':
         specifier: 3.1.2
-        version: 3.1.2(cypress@13.2.0)
+        version: 3.1.2(cypress@12.17.4)
       '@stencil/eslint-plugin':
         specifier: 0.4.0
         version: 0.4.0(eslint-plugin-react@7.33.2)(typescript@4.9.5)
@@ -721,14 +721,14 @@ importers:
         specifier: 5.3.2
         version: 5.3.2(@popperjs/core@2.11.8)
       cypress:
-        specifier: 13.2.0
-        version: 13.2.0
+        specifier: 12.17.4
+        version: 12.17.4
       cypress-each:
         specifier: 1.13.3
         version: 1.13.3
       cypress-storybook:
         specifier: 0.5.1
-        version: 0.5.1(cypress@13.2.0)
+        version: 0.5.1(cypress@12.17.4)
       eslint-plugin-react:
         specifier: 7.33.2
         version: 7.33.2(eslint@8.50.0)
@@ -795,7 +795,7 @@ importers:
         version: 1.27.2
       '@percy/cypress':
         specifier: 3.1.2
-        version: 3.1.2(cypress@13.2.0)
+        version: 3.1.2(cypress@12.17.4)
       '@swisspost/design-system-icons':
         specifier: workspace:1.0.12
         version: link:../icons
@@ -809,11 +809,11 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
       cypress:
-        specifier: 13.2.0
-        version: 13.2.0
+        specifier: 12.17.4
+        version: 12.17.4
       cypress-storybook:
         specifier: 0.5.1
-        version: 0.5.1(cypress@13.2.0)
+        version: 0.5.1(cypress@12.17.4)
       glob:
         specifier: 10.3.7
         version: 10.3.7
@@ -990,7 +990,7 @@ packages:
       tslib: 2.6.1
       typescript: 4.9.5
       vite: 4.4.7(@types/node@18.17.19)(less@4.1.3)(sass@1.64.1)(terser@5.19.2)
-      webpack: 5.88.2
+      webpack: 5.88.2(esbuild@0.18.17)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-dev-server: 4.15.1(webpack@5.88.2)
       webpack-merge: 5.9.0
@@ -1154,7 +1154,7 @@ packages:
       source-map: 0.7.3
       tslib: 2.3.0
       typescript: 4.3.5
-      webpack: 5.88.2
+      webpack: 5.88.2(esbuild@0.18.17)
     dev: true
 
   /@angular-devkit/build-webpack@0.1602.3(chokidar@3.5.3)(webpack-dev-server@4.15.1)(webpack@5.88.2):
@@ -4281,30 +4281,6 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@cypress/request@3.0.0:
-    resolution: {integrity: sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==}
-    engines: {node: '>= 6'}
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.12.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.3.3
-      http-signature: 1.3.6
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      performance-now: 2.1.0
-      qs: 6.10.4
-      safe-buffer: 5.2.1
-      tough-cookie: 4.1.3
-      tunnel-agent: 0.6.0
-      uuid: 8.3.2
-    dev: true
-
   /@cypress/xvfb@1.2.4(supports-color@8.1.1):
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
     dependencies:
@@ -6024,15 +6000,6 @@ packages:
     dependencies:
       '@percy/sdk-utils': 1.24.0
       cypress: 12.17.4
-    dev: true
-
-  /@percy/cypress@3.1.2(cypress@13.2.0):
-    resolution: {integrity: sha512-JXrGDZbqwkzQd2h5T5D7PvqoucNaiMh4ChPp8cLQiEtRuLHta9nf1lEuXH+jnatGL2j+3jJFIHJ0L7XrgVnvQA==}
-    peerDependencies:
-      cypress: '>=3'
-    dependencies:
-      '@percy/sdk-utils': 1.24.0
-      cypress: 13.2.0
     dev: true
 
   /@percy/dom@1.27.2:
@@ -8190,10 +8157,6 @@ packages:
     resolution: {integrity: sha512-8q9ZexmdYYyc5/cfujaXb4YOucpQxAV4RMG0himLyDUOEr8Mr79VrqsFI+cQ2M2h89YIuy95lbxuYjxT4Hk4kQ==}
     dev: true
 
-  /@types/node@18.17.18:
-    resolution: {integrity: sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==}
-    dev: true
-
   /@types/node@18.17.19:
     resolution: {integrity: sha512-+pMhShR3Or5GR0/sp4Da7FnhVmTalWm81M6MkEldbwjETSaPalw138Z4KdpQaistvqQxLB7Cy4xwYdxpbSOs9Q==}
     dev: true
@@ -8568,7 +8531,7 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      vite: 4.4.7(@types/node@18.17.19)(less@4.1.3)(sass@1.68.0)
+      vite: 4.4.7(@types/node@18.17.19)(less@4.1.3)(sass@1.64.1)(terser@5.19.2)
     dev: true
 
   /@web-types/lit@2.0.0-3:
@@ -9574,7 +9537,7 @@ packages:
       '@babel/core': 7.22.20
       find-cache-dir: 4.0.0
       schema-utils: 4.0.1
-      webpack: 5.88.2
+      webpack: 5.88.2(esbuild@0.18.17)
     dev: true
 
   /babel-loader@9.1.3(@babel/core@7.22.9)(webpack@5.88.2):
@@ -10973,12 +10936,12 @@ packages:
     resolution: {integrity: sha512-aNFoDuybFAQ7OObbeO5yxBGmXkGKVAcT1wLHLiL3+HQi+g+q3vECbn4J9cYOXJ7yYfbcBLh8dgQd/IG3Ls2z7A==}
     dev: true
 
-  /cypress-storybook@0.5.1(cypress@13.2.0):
+  /cypress-storybook@0.5.1(cypress@12.17.4):
     resolution: {integrity: sha512-+CNDdcrFD3QRvHrjwpVclFpLtseyXA0NxeB3PDTheisvg/OJjLkP96t0I9R66IkZRYUUE3mLhqZpmpsv59FIIw==}
     peerDependencies:
       cypress: '*'
     dependencies:
-      cypress: 13.2.0
+      cypress: 12.17.4
     dev: true
 
   /cypress@12.17.4:
@@ -10990,57 +10953,6 @@ packages:
       '@cypress/request': 2.88.12
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
       '@types/node': 16.18.39
-      '@types/sinonjs__fake-timers': 8.1.1
-      '@types/sizzle': 2.3.3
-      arch: 2.2.0
-      blob-util: 2.0.2
-      bluebird: 3.7.2
-      buffer: 5.7.1
-      cachedir: 2.3.0
-      chalk: 4.1.2
-      check-more-types: 2.24.0
-      cli-cursor: 3.1.0
-      cli-table3: 0.6.3
-      commander: 6.2.1
-      common-tags: 1.8.2
-      dayjs: 1.11.7
-      debug: 4.3.4(supports-color@8.1.1)
-      enquirer: 2.3.6
-      eventemitter2: 6.4.7
-      execa: 4.1.0
-      executable: 4.1.1
-      extract-zip: 2.0.1(supports-color@8.1.1)
-      figures: 3.2.0
-      fs-extra: 9.1.0
-      getos: 3.2.1
-      is-ci: 3.0.1
-      is-installed-globally: 0.4.0
-      lazy-ass: 1.6.0
-      listr2: 3.14.0(enquirer@2.3.6)
-      lodash: 4.17.21
-      log-symbols: 4.1.0
-      minimist: 1.2.8
-      ospath: 1.2.2
-      pretty-bytes: 5.6.0
-      process: 0.11.10
-      proxy-from-env: 1.0.0
-      request-progress: 3.0.0
-      semver: 7.5.4
-      supports-color: 8.1.1
-      tmp: 0.2.1
-      untildify: 4.0.0
-      yauzl: 2.10.0
-    dev: true
-
-  /cypress@13.2.0:
-    resolution: {integrity: sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==}
-    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      '@cypress/request': 3.0.0
-      '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/node': 18.17.18
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
       arch: 2.2.0
@@ -19285,7 +19197,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
-      webpack: 5.88.2
+      webpack: 5.88.2(esbuild@0.18.17)
     dev: true
 
   /react-colorful@5.6.1(react-dom@18.2.0)(react@18.2.0):
@@ -21352,30 +21264,6 @@ packages:
       webpack: 5.88.2(esbuild@0.18.17)
     dev: true
 
-  /terser-webpack-plugin@5.3.8(webpack@5.88.2):
-    resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.2
-      webpack: 5.88.2
-    dev: true
-
   /terser@5.19.2:
     resolution: {integrity: sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==}
     engines: {node: '>=10'}
@@ -22677,46 +22565,6 @@ packages:
 
   /webpack-virtual-modules@0.5.0:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
-    dev: true
-
-  /webpack@5.88.2:
-    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.9.0
-      acorn-import-assertions: 1.9.0(acorn@8.9.0)
-      browserslist: 4.21.9
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.2.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.8(webpack@5.88.2)
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
     dev: true
 
   /webpack@5.88.2(esbuild@0.18.17):


### PR DESCRIPTION
This change is not strictly necessary, as for these packages, cypress 13 is working just fine. However, for the local binary installation, it makes sense to sync cypress versions across packages.