### PR TITLE
fix(components): Tab count announcement with VoiceOver

### DIFF
--- a/.changeset/seven-bugs-appear.md
+++ b/.changeset/seven-bugs-appear.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed tabs count announcement with VoiceOver.

--- a/packages/components/src/components/post-tab-header/post-tab-header.tsx
+++ b/packages/components/src/components/post-tab-header/post-tab-header.tsx
@@ -29,15 +29,9 @@ export class PostTabHeader {
   render() {
     return (
       <Host data-version={version}>
-        <li class="nav-item">
-          <a
-            aria-selected="false"
-            class="tab-title nav-link"
-            href="#"
-            id={this.tabId}
-            role="tab"
-          >
-            <slot/>
+        <li class="nav-item" role="tab">
+          <a aria-selected="false" class="tab-title nav-link" href="#" id={this.tabId}>
+            <slot />
           </a>
         </li>
       </Host>


### PR DESCRIPTION
Tested with VoiceOver (Mac Os Ventura, Safari 16.5) and Nvda + Firefox on Windows