### PR TITLE
fix(styles): Small variants for checkbox and radio

### DIFF
--- a/.changeset/four-gifts-watch.md
+++ b/.changeset/four-gifts-watch.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Added small variants for checkbox and radio buttons.

--- a/packages/documentation/src/stories/components/checkbox/checkbox.docs.mdx
+++ b/packages/documentation/src/stories/components/checkbox/checkbox.docs.mdx
@@ -43,6 +43,15 @@ The indeterminate state can only be set via JavaScript and is styled using the `
   language="javascript"
 />
 
+### Sizing
+
+The size can be changed by simply adding a class:
+
+- Small: `.form-check-sm`
+- Large: default
+
+<Canvas of={checkboxStories.Size} />
+
 ### Inline
 
 To show the checkboxes inline, just add the `.form-check-inline` class to each of the checkboxes.

--- a/packages/documentation/src/stories/components/checkbox/checkbox.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/checkbox/checkbox.snapshot.stories.ts
@@ -32,6 +32,7 @@ export const Checkbox: Story = {
                   label: ['Label', longText],
                   validation: context.argTypes.validation.options,
                   checked: ['unchecked', 'checked'],
+                  size: ['null', 'form-check-sm'],
                   hiddenLabel: [false, true],
                   disabled: [false, true],
                 })
@@ -49,7 +50,7 @@ export const Checkbox: Story = {
               ].map(
                 (args: Args) =>
                   html`
-                    <span class=${args.checked === 'indeterminate' ? 'indeterminate' : ''}>
+                    <span class="${args.checked === 'indeterminate' ? 'indeterminate' : ''}">
                       ${meta.render?.({ ...context.args, ...args }, context)}
                     </span>
                   `,

--- a/packages/documentation/src/stories/components/checkbox/checkbox.stories.ts
+++ b/packages/documentation/src/stories/components/checkbox/checkbox.stories.ts
@@ -18,6 +18,7 @@ const meta: Meta = {
     hiddenLabel: false,
     checked: 'unchecked',
     disabled: false,
+    size: 'null',
     validation: 'null',
   },
   argTypes: {
@@ -83,6 +84,21 @@ const meta: Meta = {
         category: 'States',
       },
     },
+    size: {
+      name: 'Size',
+      description: "Sets the size of the component's appearance.",
+      control: {
+        type: 'select',
+        labels: {
+          'form-check-sm': 'Small',
+          'null': 'Large',
+        },
+      },
+      options: ['form-check-sm', 'null'],
+      table: {
+        category: 'General',
+      },
+    },
     disabled: {
       name: 'Disabled',
       description:
@@ -144,13 +160,13 @@ const VALIDATION_STATE_MAP: Record<string, undefined | boolean> = {
 
 function getLabel({ label }: Args, { id }: StoryContext) {
   return html`
-    <label for=${id} class="form-check-label">${label}</label>
+    <label for="${id}" class="form-check-label">${label}</label>
   `;
 }
 
 function getValidationFeedback({ validation }: Args) {
   return html`
-    <p class=${validation + '-feedback'}>
+    <p class="${validation + '-feedback'}">
       ${validation === 'valid' ? 'Ggranda sukceso!' : 'Eraro okazis!'}
     </p>
   `;
@@ -161,6 +177,7 @@ function renderCheckbox(args: Args, context: StoryContext) {
 
   const containerClasses = mapClasses({
     'form-check': true,
+    [args.size]: args.size && args.size !== 'null',
     'form-check-inline': args.inline,
   });
 
@@ -179,16 +196,16 @@ function renderCheckbox(args: Args, context: StoryContext) {
   });
 
   return html`
-    <div class=${containerClasses}>
+    <div class="${containerClasses}">
       <input
-        id=${context.id}
-        class=${checkboxClasses}
+        id="${context.id}"
+        class="${checkboxClasses}"
         type="checkbox"
-        aria-invalid=${ifDefined(VALIDATION_STATE_MAP[args.validation])}
-        aria-label=${ifDefined(args.hiddenLabel ? args.label : undefined)}
-        ?disabled=${args.disabled}
-        .checked=${CHECKED_STATE_MAP[args.checked]}
-        @change=${handleChange}
+        aria-invalid="${ifDefined(VALIDATION_STATE_MAP[args.validation])}"
+        aria-label="${ifDefined(args.hiddenLabel ? args.label : undefined)}"
+        ?disabled="${args.disabled}"
+        .checked="${CHECKED_STATE_MAP[args.checked]}"
+        @change="${handleChange}"
       />
       ${args.hiddenLabel ? nothing : getLabel(args, context)}
       ${args.validation !== 'null' ? getValidationFeedback(args) : nothing}
@@ -218,10 +235,23 @@ export const Validation: Story = {
   },
 };
 
+export const Size: Story = {
+  args: {
+    size: 'form-check-sm',
+  },
+  parameters: {
+    controls: {
+      exclude: ['Hidden Legend', 'Inline Layout'],
+    },
+  },
+};
+
 export const Inline: Story = {
   render: (args: Args, context: StoryContext) => html`
     <fieldset>
-      <legend class=${ifDefined(args.hiddenLegend ? 'visually-hidden' : undefined)}>Legendo</legend>
+      <legend class="${ifDefined(args.hiddenLegend ? 'visually-hidden' : undefined)}">
+        Legendo
+      </legend>
       ${['Unua Etikedo', 'Dua Etikedo', 'Tria Etikedo', 'Kvara  Etikedo'].map((label, index) =>
         renderCheckbox(
           { ...args, label, checked: false },

--- a/packages/documentation/src/stories/components/radio/radio.docs.mdx
+++ b/packages/documentation/src/stories/components/radio/radio.docs.mdx
@@ -25,6 +25,15 @@ Our radios use custom icons to indicate checked states.
 
 The following examples show the different characteristics of the component. These can differ in the type of visualization, the HTML structure, as well as when, how and why they are displayed.
 
+### Sizing
+
+The size can be changed by simply adding a class:
+
+- Small: `.form-check-sm`
+- Large: default
+
+<Canvas of={RadioStories.Size} />
+
 ### Inline
 
 To render a radio inline, simply add the class `.form-check-inline` to the `.form-check` wrapper element.

--- a/packages/documentation/src/stories/components/radio/radio.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/radio/radio.snapshot.stories.ts
@@ -25,6 +25,7 @@ export const Radio: Story = {
                   ],
                   checked: [false, true],
                   disabled: [false, true],
+                  size: ['null', 'form-check-sm'],
                   validation: context.argTypes.validation.options,
                 }),
                 ...bombArgs({

--- a/packages/documentation/src/stories/components/radio/radio.stories.ts
+++ b/packages/documentation/src/stories/components/radio/radio.stories.ts
@@ -164,13 +164,7 @@ export default meta;
 
 type Story = StoryObj;
 
-export const Default: Story = {
-  decorators: [
-    story => html`
-      <div class="pt-3">${story()}</div>
-    `,
-  ],
-};
+export const Default: Story = {};
 
 function renderInline(args: Args, context: StoryContext) {
   const [_, updateArgs] = useArgs();
@@ -245,36 +239,14 @@ function renderInline(args: Args, context: StoryContext) {
 
 export const Size: Story = {
   render,
-  decorators: [
-    story => html`
-      <div class="pt-3">${story()}</div>
-    `,
-  ],
-  parameters: {
-    controls: {
-      exclude: ['Hidden Label', 'Checked', 'Disabled', 'Validation'],
-    },
-  },
   args: {
     size: 'form-check-sm',
     checkedRadio: null,
-  },
-  argTypes: {
-    checkedRadio: {
-      table: {
-        disable: true,
-      },
-    },
   },
 };
 
 export const Inline: Story = {
   render: renderInline,
-  decorators: [
-    story => html`
-      <div class="pt-3">${story()}</div>
-    `,
-  ],
   parameters: {
     controls: {
       exclude: ['Hidden Label', 'Checked', 'Disabled', 'Validation'],

--- a/packages/documentation/src/stories/components/radio/radio.stories.ts
+++ b/packages/documentation/src/stories/components/radio/radio.stories.ts
@@ -23,6 +23,7 @@ const meta: Meta = {
     hiddenLabel: false,
     checked: false,
     disabled: false,
+    size: 'null',
     validation: 'null',
   },
   argTypes: {
@@ -67,6 +68,21 @@ const meta: Meta = {
         category: 'States',
       },
     },
+    size: {
+      name: 'Size',
+      description: "Sets the size of the component's appearance.",
+      control: {
+        type: 'select',
+        labels: {
+          'form-check-sm': 'Small',
+          'null': 'Large',
+        },
+      },
+      options: ['form-check-sm', 'null'],
+      table: {
+        category: 'General',
+      },
+    },
     disabled: {
       name: 'Disabled',
       description:
@@ -103,6 +119,7 @@ function render(args: Args, context: StoryContext) {
 
   const id = `${context.viewMode}_${context.name.replace(/\s/g, '-')}_ExampleRadio`;
   const classes = ['form-check-input', args.validation].filter(c => c && c !== 'null').join(' ');
+  const groupClasses = ['form-check', args.size].filter(c => c && c !== 'null').join(' ');
 
   const useAriaLabel = args.hiddenLabel;
   const label: TemplateResult | null = !useAriaLabel
@@ -134,12 +151,12 @@ function render(args: Args, context: StoryContext) {
       ?disabled="${args.disabled}"
       aria-label="${useAriaLabel ? args.label : nothing}"
       ?aria-invalid="${VALIDATION_STATE_MAP[args.validation]}"
-      @change=${(e: Event) => updateArgs({ checked: (e.target as HTMLInputElement).checked })}
+      @change="${(e: Event) => updateArgs({ checked: (e.target as HTMLInputElement).checked })}"
     />
   `;
 
   return html`
-    <div class="form-check">${[control, label, ...contextual].filter(el => el !== null)}</div>
+    <div class="${groupClasses}">${[control, label, ...contextual].filter(el => el !== null)}</div>
   `;
 }
 
@@ -225,6 +242,31 @@ function renderInline(args: Args, context: StoryContext) {
     </fieldset>
   `;
 }
+
+export const Size: Story = {
+  render,
+  decorators: [
+    story => html`
+      <div class="pt-3">${story()}</div>
+    `,
+  ],
+  parameters: {
+    controls: {
+      exclude: ['Hidden Label', 'Checked', 'Disabled', 'Validation'],
+    },
+  },
+  args: {
+    size: 'form-check-sm',
+    checkedRadio: null,
+  },
+  argTypes: {
+    checkedRadio: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+};
 
 export const Inline: Story = {
   render: renderInline,

--- a/packages/styles/src/components/form-check.scss
+++ b/packages/styles/src/components/form-check.scss
@@ -1,6 +1,7 @@
 @forward './../variables/options';
 
 @use '../variables/color';
+@use '../variables/type';
 @use '../variables/spacing';
 @use '../variables/animation';
 @use '../variables/components/form-check';
@@ -82,7 +83,7 @@
       border-radius: 50%;
 
       &:checked::after {
-        margin: spacing.$size-micro;
+        border: spacing.$size-micro solid color.$white;
         background-color: currentColor;
         border-radius: inherit;
       }
@@ -93,10 +94,25 @@
       border-color: rgba(var(--post-contrast-color-rgb), 0.4) !important;
       color: rgba(var(--post-contrast-color-rgb), 0.4) !important;
     }
+
+    .form-check-sm & {
+      height: form-check.$form-check-input-size-sm;
+      width: form-check.$form-check-input-size-sm;
+
+      &[type='radio'] {
+        &:checked::after {
+          border-width: spacing.$size-line;
+        }
+      }
+    }
   }
 
   &-label {
     flex: 1;
+
+    .form-check-sm & {
+      font-size: type.$font-size-12;
+    }
   }
 }
 

--- a/packages/styles/src/components/form-validation.scss
+++ b/packages/styles/src/components/form-validation.scss
@@ -4,6 +4,7 @@
 @use './../mixins/utilities' as utilities-mx;
 @use './../mixins/form-checks' as form-checks-mx;
 @use './../variables/color';
+@use './../variables/type';
 @use './../variables/components/form-validation';
 @use './../variables/components/forms';
 

--- a/packages/styles/src/variables/components/_form-check.scss
+++ b/packages/styles/src/variables/components/_form-check.scss
@@ -11,6 +11,7 @@ $form-check-column-gap: spacing.$size-mini !default;
 $form-check-margin-bottom: spacing.$size-regular !default;
 $form-check-inline-margin-right: spacing.$size-large !default;
 $form-check-input-size: spacing.$size-large !default;
+$form-check-input-size-sm: spacing.$size-regular !default;
 $form-check-input-border-width: forms.$input-border-width !default;
 $form-check-input-focus-box-shadow: forms.$input-focus-box-shadow !default;
 

--- a/packages/styles/src/variables/components/_form-validation.scss
+++ b/packages/styles/src/variables/components/_form-validation.scss
@@ -6,7 +6,7 @@
 
 // Bootstrap variables
 $form-feedback-margin-top: 0 !default;
-$form-feedback-font-size: type.$font-size-regular !default;
+$form-feedback-font-size: type.$font-size-12 !default;
 $form-feedback-valid-color: color.$gray-60 !default;
 $form-feedback-invalid-color: color.$error !default;
 $form-feedback-icon-valid: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='UTF-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='24pt' height='24pt' viewBox='0 0 24 24' version='1.1'%3E%3Cg id='surface1'%3E%3Cpath style=' stroke:none;fill-rule:nonzero;fill:rgb(0%25,50.588235%25,22.745098%25);fill-opacity:1;' d='M 9.5 18.398438 L 3.800781 12.699219 L 5.199219 11.300781 L 9.5 15.597656 L 18.800781 6.300781 L 20.199219 7.699219 Z M 9.5 18.398438 '/%3E%3C/g%3E%3C/svg%3E%0A") !default;


### PR DESCRIPTION
@rouvenpost I made all the feedback validation boxes smaller according to the mockups (for all variants, you can see them in snapshots). I was not sure if it was intended or not. Please let me know if it's not the case.

## Links

### Checkbox
- [Checkbox mockups](https://www.figma.com/file/xZ0IW0MJO0vnFicmrHiKaY/Components-Post?node-id=7750%3A33879&mode=dev)
- [Checkbox documentation page](https://preview-2067--swisspost-design-system-next.netlify.app/?path=/docs/components-checkbox--docs)
- [Checkbox snapshots](https://preview-2067--swisspost-design-system-next.netlify.app/iframe.html?id=snapshots--checkbox&viewMode=story)

### Radio
- [Radio mockups](https://www.figma.com/file/xZ0IW0MJO0vnFicmrHiKaY/Components-Post?node-id=7777%3A33876&mode=dev)
- [Radio documentation page](https://preview-2067--swisspost-design-system-next.netlify.app/?path=/docs/components-radio-button--docs)
- [Radio snapshots](https://preview-2067--swisspost-design-system-next.netlify.app/iframe.html?id=snapshots--radio&viewMode=story)