### PR TITLE
feat(documentation): Add pseudo-class to snapshots with storybook-addon-pseudo-states plugin

### DIFF
--- a/packages/documentation/.storybook/main.ts
+++ b/packages/documentation/.storybook/main.ts
@@ -27,6 +27,7 @@ const config: StorybookConfig = {
     '@storybook/addon-a11y',
     '@geometricpanda/storybook-addon-badges',
     '@pxtrn/storybook-addon-docs-stencil',
+    'storybook-addon-pseudo-states',
   ],
   staticDirs: [
     {

--- a/packages/documentation/.storybook/preview.ts
+++ b/packages/documentation/.storybook/preview.ts
@@ -67,6 +67,16 @@ const preview: Preview = {
       },
     },
     badgesConfig,
+    pseudo: {
+      hover: '.pseudo-hover',
+      active: '.pseudo-active',
+      focusVisible: '.pseudo-focus-visible',
+      focusWithin: '.pseudo-focus-within',
+      focus: ['.pseudo-focus', '.focused'],
+      visited: '.pseudo-visited',
+      link: '.pseudo-link',
+      target: '.pseudo-target',
+    },
   },
 };
 

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -66,6 +66,7 @@
     "rimraf": "5.0.1",
     "sass": "1.68.0",
     "storybook": "7.4.5",
+    "storybook-addon-pseudo-states": "^2.1.2",
     "typescript": "5.1.6"
   }
 }

--- a/packages/documentation/src/stories/components/badge/badge.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/badge/badge.snapshot.stories.ts
@@ -26,6 +26,7 @@ export const Badge: Story = {
                 interactionType: context.argTypes.interactionType.options,
                 nestedBadge: [false, true],
                 checked: [false, true],
+                pseudoClass: ['null', 'hover', 'focus-visible', ['focus-visible', 'hover']],
                 dismissed: [false],
               })
                 .filter(args => !(args.interactionType !== 'checkable' && args.checked === true))

--- a/packages/documentation/src/stories/components/badge/badge.stories.ts
+++ b/packages/documentation/src/stories/components/badge/badge.stories.ts
@@ -3,6 +3,7 @@ import type { Args, Meta, StoryContext, StoryObj } from '@storybook/web-componen
 import { html, nothing } from 'lit';
 import { BADGE } from '../../../../.storybook/constants';
 import { mapClasses } from '../../../utils';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const meta: Meta = {
   title: 'Components/Badge',
@@ -61,9 +62,9 @@ const meta: Meta = {
       control: {
         type: 'inline-radio',
         labels: {
-          'none': 'None',
-          'checkable': 'Checkable',
-          'dismissible': 'Dismissible',
+          none: 'None',
+          checkable: 'Checkable',
+          dismissible: 'Dismissible',
         },
       },
       options: ['none', 'checkable', 'dismissible'],
@@ -76,7 +77,7 @@ const meta: Meta = {
       description: 'If `true`, the badge is checked otherwise it is unchecked.',
       if: {
         arg: 'interactionType',
-        eq: 'checkable'
+        eq: 'checkable',
       },
       control: {
         type: 'boolean',
@@ -111,34 +112,44 @@ function externalControl(story: any, { args }: StoryContext) {
   const button = html`
     <a
       href="#"
-      @click=${(e: Event) => {
+      @click="${(e: Event) => {
         e.preventDefault();
         updateArgs({ dismissed: false });
-      }}
-    >Show badge</a>
+      }}"
+    >
+      Show badge
+    </a>
   `;
 
   return html`
-    ${args.dismissed ? button : nothing}
-    ${story()}
+    ${args.dismissed ? button : nothing} ${story()}
   `;
 }
 
 // RENDERER
 function getDefaultContent(args: Args) {
-  if (!args.nestedBadge) return html`${args.text}`;
+  if (!args.nestedBadge)
+    return html`
+      ${args.text}
+    `;
 
   return html`
-    <span>${html`${args.text}`}</span>
+    <span>
+      ${html`
+        ${args.text}
+      `}
+    </span>
     <span class="badge">10</span>
   `;
 }
 
 function getCheckableContent(args: Args, updateArgs: (args: Args) => void, context: StoryContext) {
-  const checkboxId = `badge-example--${context.name.replace(/ /g, '-').toLowerCase()}`
+  const checkboxId = `badge-example--${context.name.replace(/ /g, '-').toLowerCase()}`;
+  const pseudoClassClass = serializeSimulatedPseudoClass(args.pseudoClass);
   const labelClasses = mapClasses({
     'badge-check-label': true,
-    [args.size]: args.size !== 'default'
+    [pseudoClassClass]: Boolean(pseudoClassClass) && pseudoClassClass !== 'null',
+    [args.size]: args.size !== 'default',
   });
 
   const handleChange = (e: Event) => {
@@ -154,24 +165,19 @@ function getCheckableContent(args: Args, updateArgs: (args: Args) => void, conte
 
   return html`
     <input
-      id=${checkboxId}
+      id="${checkboxId}"
       class="badge-check-input"
       type="checkbox"
-      ?checked=${args.checked}
-      @change=${handleChange}
+      ?checked="${args.checked}"
+      @change="${handleChange}"
     />
-    <label class=${labelClasses} for=${checkboxId}>
-      ${getDefaultContent(args)}
-    </label>
+    <label class="${labelClasses}" for="${checkboxId}">${getDefaultContent(args)}</label>
   `;
 }
 
 function getDismissButton(updateArgs: (args: Args) => void) {
   return html`
-    <button
-      class="btn-close"
-      @click=${() => updateArgs({ dismissed: true })}
-    >
+    <button class="btn-close" @click="${() => updateArgs({ dismissed: true })}">
       <span class="visually-hidden">Forigi insignon</span>
     </button>
   `;
@@ -180,19 +186,25 @@ function getDismissButton(updateArgs: (args: Args) => void) {
 function renderBadge(args: Args, context: StoryContext) {
   const [_, updateArgs] = useArgs();
 
-  if (args.dismissed) return html`${nothing}`;
+  if (args.dismissed)
+    return html`
+      ${nothing}
+    `;
 
   const isCheckable = args.interactionType === 'checkable';
   const isDismissible = args.interactionType === 'dismissible';
 
+  const pseudoClassClass = serializeSimulatedPseudoClass(args.pseudoClass);
+
   const badgeClasses = mapClasses({
     'badge': !isCheckable,
     'badge-check': isCheckable,
-    [args.size]: args.size !== 'default'
+    [pseudoClassClass]: Boolean(pseudoClassClass) && pseudoClassClass !== 'null',
+    [args.size]: args.size !== 'default',
   });
 
   return html`
-    <div class=${badgeClasses}>
+    <div class="${badgeClasses}">
       ${isCheckable ? getCheckableContent(args, updateArgs, context) : getDefaultContent(args)}
       ${isDismissible ? getDismissButton(updateArgs) : nothing}
     </div>

--- a/packages/documentation/src/stories/components/button/button.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/button/button.snapshot.stories.ts
@@ -1,5 +1,5 @@
 import type { Args, StoryContext, StoryObj } from '@storybook/web-components';
-import meta, { Default, AccentColors, ContextualColors } from './button.stories';
+import meta, { AccentColors, ContextualColors, Default } from './button.stories';
 import { html } from 'lit';
 import { bombArgs } from '../../../utils/bombArgs';
 
@@ -10,15 +10,15 @@ export default {
 
 type Story = StoryObj;
 
+const pseudoClass = ['null', 'hover', 'focus-visible', ['focus-visible', 'hover']];
+
 export const Button: Story = {
   render: (_args: Args, context: StoryContext) => {
     return html`
       <div class="d-flex flex-wrap gap-1 align-items-start">
         ${['bg-white', 'bg-dark'].map(
           bg => html`
-            <div
-              class="${bg} d-flex flex-wrap align-items-start gap-regular p-regular"
-            >
+            <div class="${bg} d-flex flex-wrap align-items-start gap-regular p-regular">
               ${bombArgs({
                 variant: context.argTypes.variant.options,
                 size: context.argTypes.size.options,
@@ -26,6 +26,7 @@ export const Button: Story = {
                 disabled: [false, true],
                 iconOnly: [false, true],
                 icon: ['null', '2069'],
+                pseudoClass,
                 iconPosition: context.argTypes.iconPosition.options,
               })
                 .filter(
@@ -37,14 +38,21 @@ export const Button: Story = {
                 )
                 .filter(args => !(args.icon === 'null' && args.iconPosition === 'end'))
                 .filter(args => !(args.icon !== 'null' && args.tag === 'input'))
-                .map((args: Args) => args.tag === 'input' ? { ...args, type: 'button' } : args)
+                .map((args: Args) => (args.tag === 'input' ? { ...args, type: 'button' } : args))
                 .map((args: Args) =>
                   Default.render?.({ ...context.args, ...args, animated: false }, context),
                 )}
               <div class="mt-big w-100"></div>
-              ${AccentColors.render?.({ ...context.args, ...AccentColors.args }, context)}
+              ${bombArgs({ pseudoClass }).map((args: Args) =>
+                AccentColors.render?.({ ...context.args, ...AccentColors.args, ...args }, context),
+              )}
               <div class="mt-big w-100"></div>
-              ${ContextualColors.render?.({ ...context.args, ...ContextualColors.args }, context)}
+              ${bombArgs({ pseudoClass }).map((args: Args) =>
+                ContextualColors.render?.(
+                  { ...context.args, ...ContextualColors.args, ...args },
+                  context,
+                ),
+              )}
             </div>
           `,
         )}

--- a/packages/documentation/src/stories/components/button/button.stories.ts
+++ b/packages/documentation/src/stories/components/button/button.stories.ts
@@ -3,6 +3,7 @@ import { html, unsafeStatic } from 'lit/static-html.js';
 import { spread } from '@open-wc/lit-helpers';
 import { repeat } from 'lit/directives/repeat.js';
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const meta: Meta = {
   title: 'Components/Button',
@@ -133,7 +134,8 @@ const meta: Meta = {
     },
     icon: {
       name: 'Icon',
-      description: 'Defines a custom icon.' +
+      description:
+        'Defines a custom icon.' +
         '<span className="mt-mini alert alert-info alert-sm">' +
         'To use a custom icon, you must first ' +
         '<a href="/?path=/docs/icons-getting-started--docs">set up the icons in your project</a>' +
@@ -221,7 +223,7 @@ const Template = {
       `;
     } else {
       const icon = html`
-        <post-icon aria-hidden="true" name=${args.icon}></post-icon>
+        <post-icon aria-hidden="true" name="${args.icon}"></post-icon>
       `;
       const iconOnlyContent = html`
         <span class="visually-hidden">${args.text}</span>
@@ -251,6 +253,7 @@ function createProps(args: Args, isAnimated: boolean) {
       args.variant,
       args.size,
       isAnimated && 'btn-animated',
+      serializeSimulatedPseudoClass(args.pseudoClass),
       args.iconOnly && 'btn-icon',
     ]
       .filter(c => c && c !== 'null')

--- a/packages/documentation/src/stories/components/card/card.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/card/card.snapshot.stories.ts
@@ -1,5 +1,5 @@
 import type { Args, StoryContext, StoryObj } from '@storybook/web-components';
-import meta, { Default, CustomContent, CardGroup } from './card.stories';
+import meta, { CardGroup, CustomContent, Default } from './card.stories';
 import { html } from 'lit';
 import { bombArgs } from '../../../utils/bombArgs';
 
@@ -30,6 +30,7 @@ export const Card: Story = {
         showSubtitle: [false, true],
         action: ['none', 'button', 'links'],
         showListGroup: [false, true],
+        pseudoClass: ['null', 'hover', 'focus-visible', ['focus-visible', 'hover']],
       }),
     ]
       // Has to show anything
@@ -56,11 +57,13 @@ export const Card: Story = {
           ),
       )
       // Map default template variants
-      .map(args => html`
-        <div class="col-6 p-3">
-          ${Default.render && Default.render({ ...meta.args, ...args }, context)}
-        </div>
-      `);
+      .map(
+        args => html`
+          <div class="col-6 p-3">
+            ${Default.render && Default.render({ ...meta.args, ...args }, context)}
+          </div>
+        `,
+      );
 
     // Define custom template variants
     const customTemplateVariants = [
@@ -68,21 +71,22 @@ export const Card: Story = {
       { story: CardGroup, colWidth: 12 },
     ]
       // Map custom template variants
-      .map(({ story, colWidth }) => html`
-        <div class=${'p-3 col-' + colWidth}>
-          ${story.render && story.render({ ...meta.args, ...story.args }, context)}
-        </div>
-      `);
+      .map(
+        ({ story, colWidth }) => html`
+          <div class="${'p-3 col-' + colWidth}">
+            ${story.render && story.render({ ...meta.args, ...story.args }, context)}
+          </div>
+        `,
+      );
 
     // Render all variants on white and dark background
     return html`
       <div>
-        ${['white', 'dark'].map(bg => html`
-          <div class=${'row bg-' + bg}>
-            ${defaultTemplateVariants}
-            ${customTemplateVariants}
-          </div>
-        `)}
+        ${['white', 'dark'].map(
+          bg => html`
+            <div class=${'row bg-' + bg}>${defaultTemplateVariants} ${customTemplateVariants}</div>
+          `,
+        )}
       </div>
     `;
   },

--- a/packages/documentation/src/stories/components/card/card.stories.ts
+++ b/packages/documentation/src/stories/components/card/card.stories.ts
@@ -2,14 +2,15 @@ import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html, nothing } from 'lit';
 import { choose } from 'lit/directives/choose.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import React from 'react';
 import { BADGE } from '../../../../.storybook/constants';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
+import { appendClass } from '../../../utils';
 
 const meta: Meta = {
   title: 'Components/Card',
-  decorators: [ clickBlocker, paddedContainer ],
+  decorators: [clickBlocker, paddedContainer],
   parameters: {
-    badges: [ BADGE.NEEDS_REVISION ],
+    badges: [BADGE.NEEDS_REVISION],
     controls: {
       exclude: ['Custom Header', 'Custom Body', 'Custom Footer'],
     },
@@ -49,8 +50,8 @@ const meta: Meta = {
       control: {
         type: 'inline-radio',
         labels: {
-          'top': 'Top',
-          'bottom': 'Bottom',
+          top: 'Top',
+          bottom: 'Bottom',
         },
       },
       options: ['top', 'bottom'],
@@ -152,9 +153,9 @@ const meta: Meta = {
       control: {
         type: 'inline-radio',
         labels: {
-          'button': 'Button',
-          'links': 'Links',
-          'none': 'None',
+          button: 'Button',
+          links: 'Links',
+          none: 'None',
         },
       },
       options: ['button', 'links', 'none'],
@@ -203,59 +204,72 @@ export default meta;
 // DECORATORS
 function clickBlocker(story: any) {
   return html`
-    <div @click=${(e: Event) => e.preventDefault()}>
-      ${story()}
-    </div>
+    <div @click="${(e: Event) => e.preventDefault()}">${story()}</div>
   `;
 }
 
 function paddedContainer(story: any) {
   return html`
-    <div class="p-mini">
-      ${story()}
-    </div>
+    <div class="p-mini">${story()}</div>
   `;
 }
 
 function gridContainer(story: any) {
   return html`
     <div class="row">
-      <div class="col-lg-4 col-rg-6 col-12">
-        ${story()}
-      </div>
+      <div class="col-lg-4 col-rg-6 col-12">${story()}</div>
     </div>
   `;
 }
 
 // RENDERER
-function getCardLinks() {
+function getCardLinks(className: string) {
   return html`
-    ${[ 'Ligilo teksto', 'Pli da ligo' ].map(label => html`
-      <a class="card-link" href="#">${label}</a>
-    `)}
+    ${['Ligilo teksto', 'Pli da ligo'].map(
+      label => html`
+        <a class="card-link${appendClass(className)}" href="#">${label}</a>
+      `,
+    )}
   `;
 }
 
-function getCardButton() {
+function getCardButton(className: string) {
   return html`
-    <button class="btn btn-primary btn-animated">
+    <button class="btn btn-primary btn-animated${appendClass(className)}">
       <span>Butonon teksto</span>
     </button>
   `;
 }
 
-function getCardBody({ customBody, content, action, showTitle, showSubtitle }: Args) {
+function getCardBody({ customBody, content, action, showTitle, showSubtitle, pseudoClass }: Args) {
   if (customBody) return unsafeHTML(customBody);
+
+  const pseudoClassClass = serializeSimulatedPseudoClass(pseudoClass);
 
   return html`
     <div class="card-body">
-      ${showTitle ? html`<h5 class="card-title">Titulum</h5>` : nothing}
-      ${showSubtitle ? html`<h6 class="card-subtitle mb-2 text-muted">Sub Titulum</h6>` : nothing}
+      ${showTitle
+        ? html`
+            <h5 class="card-title">Titulum</h5>
+          `
+        : nothing}
+      ${showSubtitle
+        ? html`
+            <h6 class="card-subtitle mb-2 text-muted">Sub Titulum</h6>
+          `
+        : nothing}
       <p class="card-text">${content}</p>
-      ${choose(action, [
-        ['button', getCardButton],
-        ['links', getCardLinks],
-      ], () => html`${nothing}`)}
+      ${choose(
+        action,
+        [
+          ['button', () => getCardButton(pseudoClassClass)],
+          ['links', () => getCardLinks(pseudoClassClass)],
+        ],
+        () =>
+          html`
+            ${nothing}
+          `,
+      )}
     </div>
   `;
 }
@@ -263,9 +277,11 @@ function getCardBody({ customBody, content, action, showTitle, showSubtitle }: A
 function getCardListGroup() {
   return html`
     <ul class="list-group">
-      ${[ 'Ero', 'Dua ero', 'Alio ero' ].map(label => html`
-        <li class="list-group-item">${label}</li>
-      `)}
+      ${['Ero', 'Dua ero', 'Alio ero'].map(
+        label => html`
+          <li class="list-group-item">${label}</li>
+        `,
+      )}
     </ul>
   `;
 }
@@ -289,7 +305,7 @@ function getCardFooter({ customFooter }: Args) {
 function getCardImage({ imagePosition }: Args) {
   return html`
     <img
-      class=${'card-img-' + imagePosition}
+      class="${'card-img-' + imagePosition}"
       src="https://picsum.photos/id/20/300/200"
       alt="Card image"
     />
@@ -302,10 +318,8 @@ function renderCard(args: Args) {
   return html`
     <div class="card">
       ${showImage && imagePosition === 'top' ? getCardImage(args) : nothing}
-      ${showHeader ? getCardHeader(args) : nothing}
-      ${showBody ? getCardBody(args) : nothing}
-      ${showListGroup ? getCardListGroup() : nothing}
-      ${showFooter ? getCardFooter(args) : nothing}
+      ${showHeader ? getCardHeader(args) : nothing} ${showBody ? getCardBody(args) : nothing}
+      ${showListGroup ? getCardListGroup() : nothing} ${showFooter ? getCardFooter(args) : nothing}
       ${showImage && imagePosition === 'bottom' ? getCardImage(args) : nothing}
     </div>
   `;
@@ -315,17 +329,17 @@ function renderCard(args: Args) {
 type Story = StoryObj;
 
 const singleCardStory: Story = {
-  decorators: [ gridContainer ],
+  decorators: [gridContainer],
   render: renderCard,
-}
+};
 
 export const Default: Story = {
   ...singleCardStory,
   parameters: {
     controls: {
       exclude: ['Custom Header', 'Custom Body', 'Custom Footer', 'Show Body', 'Show List Group'],
-    }
-  }
+    },
+  },
 };
 
 export const ListGroup: Story = {
@@ -333,7 +347,7 @@ export const ListGroup: Story = {
   parameters: {
     controls: {
       include: ['Show Image', 'Image Position', 'Show Header', 'Show Body', 'Show Footer'],
-    }
+    },
   },
   args: {
     showImage: false,
@@ -347,7 +361,7 @@ export const CustomContent: Story = {
   parameters: {
     controls: {
       include: ['Show Header', 'Show Footer'],
-    }
+    },
   },
   args: {
     showImage: false,
@@ -389,12 +403,12 @@ export const CardGroup: Story = {
   parameters: {
     controls: {
       include: ['Show Image', 'Image Position', 'Show Header', 'Show Footer'],
-    }
+    },
   },
   args: {
     action: 'none',
   },
-  render: (args) => {
+  render: args => {
     const cardTexts = [
       'Enhavo de la maldekstra karto, ĉi tiu teksto estas tie nur kiel ekzemplo.',
       'Enhavo de la meza karto, ĉi tiu teksto estas tie nur kiel ekzemplo.',
@@ -402,12 +416,17 @@ export const CardGroup: Story = {
     ];
 
     return html`
-    <div class="card-group">
-      ${cardTexts.map(text => html`${renderCard({ ...args, text })}`)}
-    </div>
-  `;
+      <div class="card-group">
+        ${cardTexts.map(
+          text =>
+            html`
+              ${renderCard({ ...args, text })}
+            `,
+        )}
+      </div>
+    `;
   },
-}
+};
 
 export const BackgroundImage: Story = {
   ...singleCardStory,
@@ -429,6 +448,6 @@ export const BackgroundImage: Story = {
         <span>Butonon teksto</span>
       </button>
     </div>
-  </div>`
-  }
-}
+  </div>`,
+  },
+};

--- a/packages/documentation/src/stories/components/checkbox/checkbox.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/checkbox/checkbox.snapshot.stories.ts
@@ -10,6 +10,8 @@ export default {
 
 type Story = StoryObj;
 
+const pseudoClass = ['null', 'hover', 'focus', ['focus', 'hover']];
+
 export const Checkbox: Story = {
   render: (_args: Args, context: StoryContext) => {
     const longText =
@@ -34,6 +36,7 @@ export const Checkbox: Story = {
                   checked: ['unchecked', 'checked'],
                   hiddenLabel: [false, true],
                   disabled: [false, true],
+                  pseudoClass,
                 })
                   .filter(
                     (args: Args) =>
@@ -49,7 +52,7 @@ export const Checkbox: Story = {
               ].map(
                 (args: Args) =>
                   html`
-                    <span class=${args.checked === 'indeterminate' ? 'indeterminate' : ''}>
+                    <span class="${args.checked === 'indeterminate' ? 'indeterminate' : ''}">
                       ${meta.render?.({ ...context.args, ...args }, context)}
                     </span>
                   `,

--- a/packages/documentation/src/stories/components/checkbox/checkbox.stories.ts
+++ b/packages/documentation/src/stories/components/checkbox/checkbox.stories.ts
@@ -3,7 +3,8 @@ import type { Args, Meta, StoryContext, StoryObj } from '@storybook/web-componen
 import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { BADGE } from '../../../../.storybook/constants';
-import { mapClasses } from '../../../utils';
+import { appendClass, mapClasses } from '../../../utils';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const meta: Meta = {
   title: 'Components/Checkbox',
@@ -142,15 +143,15 @@ const VALIDATION_STATE_MAP: Record<string, undefined | boolean> = {
   invalid: true,
 };
 
-function getLabel({ label }: Args, { id }: StoryContext) {
+function getLabel({ label }: Args, { id }: StoryContext, className: string) {
   return html`
-    <label for=${id} class="form-check-label">${label}</label>
+    <label for="${id}" class="form-check-label${appendClass(className)}">${label}</label>
   `;
 }
 
 function getValidationFeedback({ validation }: Args) {
   return html`
-    <p class=${validation + '-feedback'}>
+    <p class="${validation + '-feedback'}">
       ${validation === 'valid' ? 'Ggranda sukceso!' : 'Eraro okazis!'}
     </p>
   `;
@@ -159,6 +160,8 @@ function getValidationFeedback({ validation }: Args) {
 function renderCheckbox(args: Args, context: StoryContext) {
   const [_, updateArgs] = useArgs();
 
+  const pseudoClassClass = serializeSimulatedPseudoClass(args.pseudoClass);
+
   const containerClasses = mapClasses({
     'form-check': true,
     'form-check-inline': args.inline,
@@ -166,6 +169,7 @@ function renderCheckbox(args: Args, context: StoryContext) {
 
   const checkboxClasses = mapClasses({
     'form-check-input': true,
+    [pseudoClassClass]: Boolean(pseudoClassClass) && pseudoClassClass !== 'null',
     ['is-' + args.validation]: args.validation !== 'null',
   });
 
@@ -179,18 +183,18 @@ function renderCheckbox(args: Args, context: StoryContext) {
   });
 
   return html`
-    <div class=${containerClasses}>
+    <div class="${containerClasses}">
       <input
-        id=${context.id}
-        class=${checkboxClasses}
+        id="${context.id}"
+        class="${checkboxClasses}"
         type="checkbox"
-        aria-invalid=${ifDefined(VALIDATION_STATE_MAP[args.validation])}
-        aria-label=${ifDefined(args.hiddenLabel ? args.label : undefined)}
-        ?disabled=${args.disabled}
-        .checked=${CHECKED_STATE_MAP[args.checked]}
-        @change=${handleChange}
+        aria-invalid="${ifDefined(VALIDATION_STATE_MAP[args.validation])}"
+        aria-label="${ifDefined(args.hiddenLabel ? args.label : undefined)}"
+        ?disabled="${args.disabled}"
+        .checked="${CHECKED_STATE_MAP[args.checked]}"
+        @change="${handleChange}"
       />
-      ${args.hiddenLabel ? nothing : getLabel(args, context)}
+      ${args.hiddenLabel ? nothing : getLabel(args, context, pseudoClassClass)}
       ${args.validation !== 'null' ? getValidationFeedback(args) : nothing}
     </div>
   `;
@@ -221,7 +225,9 @@ export const Validation: Story = {
 export const Inline: Story = {
   render: (args: Args, context: StoryContext) => html`
     <fieldset>
-      <legend class=${ifDefined(args.hiddenLegend ? 'visually-hidden' : undefined)}>Legendo</legend>
+      <legend class="${ifDefined(args.hiddenLegend ? 'visually-hidden' : undefined)}">
+        Legendo
+      </legend>
       ${['Unua Etikedo', 'Dua Etikedo', 'Tria Etikedo', 'Kvara  Etikedo'].map((label, index) =>
         renderCheckbox(
           { ...args, label, checked: false },

--- a/packages/documentation/src/stories/components/choice-card/choice-card.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/choice-card/choice-card.snapshot.stories.ts
@@ -1,5 +1,5 @@
 import { bombArgs } from '../../../utils/bombArgs';
-import { choiceCardMeta, choiceCardDefault } from './choice-card';
+import { choiceCardDefault, choiceCardMeta } from './choice-card';
 import { StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 
@@ -17,6 +17,7 @@ const bombedArgs = bombArgs({
   showDescription: [false, true],
   description: ['A very long running description that is wrapping to two lines'],
   showIcon: [false, true],
+  pseudoClass: ['null', 'hover', 'focus-visible', ['focus-visible', 'hover']],
 })
   // Filter out disabled and invalid combinations
   .filter(args => !(args.disabled && args.validation === 'is-invalid'));

--- a/packages/documentation/src/stories/components/choice-card/choice-card.ts
+++ b/packages/documentation/src/stories/components/choice-card/choice-card.ts
@@ -18,7 +18,6 @@ export const choiceCardMeta: Meta = {
     type: 'radio',
     checked: false,
     disabled: false,
-    focused: false,
     validation: 'null',
     showDescription: false,
     description: 'A small description',
@@ -65,14 +64,6 @@ export const choiceCardMeta: Meta = {
       control: {
         type: 'boolean',
       },
-      table: {
-        category: 'States',
-      },
-    },
-    focused: {
-      name: 'Focused',
-      description: 'Render the component in a focused state',
-      control: { type: 'boolean' },
       table: {
         category: 'States',
       },

--- a/packages/documentation/src/stories/components/choice-card/choice-card.ts
+++ b/packages/documentation/src/stories/components/choice-card/choice-card.ts
@@ -4,6 +4,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { BADGE } from '../../../../.storybook/constants';
 import { nothing } from 'lit';
 import { useArgs } from '@storybook/preview-api';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 export const choiceCardMeta: Meta = {
   parameters: {
@@ -145,14 +146,18 @@ let id_ct = 1;
 export const choiceCardDefault = (args: Args, name = 'control') => {
   const [_, updateArgs] = useArgs();
 
+  const pseudoClassClass = serializeSimulatedPseudoClass(args.pseudoClass);
+
   // Conditional classes
   const inputClasses = classMap({
     'form-check-input': true,
+    [pseudoClassClass]: Boolean(pseudoClassClass) && pseudoClassClass !== 'null',
     'is-invalid': args.validation === 'is-invalid',
   });
   const cardClassMap = classMap({
     'checked': args.checked,
     'disabled': args.disabled,
+    [pseudoClassClass]: Boolean(pseudoClassClass) && pseudoClassClass !== 'null',
     'is-invalid': args.validation === 'is-invalid',
     'checkbox-button-card': args.type === 'checkbox',
     'radio-button-card': args.type === 'radio',
@@ -194,18 +199,18 @@ export const choiceCardDefault = (args: Args, name = 'control') => {
   };
 
   return html`
-    <div class=${cardClassMap}>
+    <div class="${cardClassMap}">
       <input
-        id=${id}
+        id="${id}"
         name="${args.type}-button-card-${name}"
-        class=${inputClasses}
-        type=${args.type}
-        ?disabled=${args.disabled}
-        .checked=${args.checked}
-        ?checked=${args.checked}
-        @input=${_handleInput}
-        @focus=${_handleFocus}
-        @blur=${_handleBlur}
+        class="${inputClasses}"
+        type="${args.type}"
+        ?disabled="${args.disabled}"
+        .checked="${args.checked}"
+        ?checked="${args.checked}"
+        @input="${_handleInput}"
+        @focus="${_handleFocus}"
+        @blur="${_handleBlur}"
       />
       <label id="label-${id}" class="form-check-label" for="${id}">
         <span>${args.label}</span>

--- a/packages/documentation/src/stories/components/input/input.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/input/input.snapshot.stories.ts
@@ -1,7 +1,8 @@
 import type { Args, StoryContext, StoryObj } from '@storybook/web-components';
 import meta from './input.stories';
 import { html } from 'lit';
-import { getCombinations, COMBINATIONS } from '../../../utils/inputComponentsGetCombinations';
+import { COMBINATIONS } from '../../../utils/inputComponentsGetCombinations';
+import { bombArgs } from '../../../utils/bombArgs';
 
 export default {
   ...meta,
@@ -10,65 +11,62 @@ export default {
 };
 
 function renderInputSnapshot(_args: Args, context: StoryContext) {
-  const combinations = [
-    ...COMBINATIONS,
-    {
-      label: `Label - no Placeholder`,
-      placeholder: null,
-    },
-    {
-      label: `Label - with Value`,
-      value: 'Lorem Ipsum',
-    },
-  ];
   return html`
     <div class="d-flex flex-wrap align-items-start gap-regular">
       ${['bg-white', 'bg-dark'].map(
         bg => html`
           <div class="${bg} d-flex gap-3 flex-column p-3">
             <h3>Sizes</h3>
-            ${getCombinations('size', context.argTypes.size.options, combinations)
-              .filter(
-                (args: Args) =>
-                  !args.value ||
-                  (args.value &&
-                    (context.args.type === 'text' || context.args.type === 'password')),
-              )
-              .map(
-                (args: Args) =>
-                  html`
-                    <div>
-                      ${args.title !== undefined && args.title
-                        ? html`
-                            <h4>
-                              ${Object.entries(context.argTypes.size.control.labels)
-                                .filter(([key, value]) => key === args.size)
-                                .map(s => s[1])}
-                            </h4>
-                          `
-                        : ''}
-                      <div>${meta.render?.({ ...context.args, ...args }, context)}</div>
-                    </div>
-                  `,
-              )}
+            ${context.argTypes.size.options.map((size: string) => {
+              const variants = bombArgs({
+                combinations: COMBINATIONS,
+                size: [size],
+                pseudoClass: ['null', 'focus'],
+              })
+                .map(extractCombinationsArgs)
+                .filter(
+                  (args: Args) =>
+                    !args.value ||
+                    (args.value &&
+                      (context.args.type === 'text' || context.args.type === 'password')),
+                )
+                .map(args => renderVariant(args, context));
+
+              return html`
+                <section>
+                  <h4>${context.argTypes.size.control.labels[size]}</h4>
+                  <div class="d-flex gap-3 flex-column">${variants}</div>
+                </section>
+              `;
+            })}
             <h3>Floating Label</h3>
-            ${getCombinations('floatingLabel', [true], combinations)
+            ${bombArgs({
+              combinations: COMBINATIONS,
+              floatingLabel: [true],
+              pseudoClass: ['null', 'focus'],
+            })
+              .map(extractCombinationsArgs)
               .filter(
                 (args: Args) =>
                   !args.value ||
                   (args.value &&
                     (context.args.type === 'text' || context.args.type === 'password')),
               )
-              .map(
-                (args: Args) =>
-                  html`
-                    <div>${meta.render?.({ ...context.args, ...args }, context)}</div>
-                  `,
-              )}
+              .map(args => renderVariant(args, context))}
           </div>
         `,
       )}
     </div>
+  `;
+}
+
+function extractCombinationsArgs(args: Args) {
+  return { ...args, ...args.combinations };
+}
+
+function renderVariant(args: Args, context: StoryContext) {
+  return html`
+    <div>${meta.render?.({ ...context.args, ...args }, context)}</div>
   `;
 }
 

--- a/packages/documentation/src/stories/components/input/input.stories.ts
+++ b/packages/documentation/src/stories/components/input/input.stories.ts
@@ -1,6 +1,7 @@
 import { Args, Meta, StoryContext, StoryObj } from '@storybook/web-components';
 import { BADGE } from '../../../../.storybook/constants';
 import { html, nothing, TemplateResult } from 'lit';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const VALIDATION_STATE_MAP: Record<string, undefined | boolean> = {
   'null': undefined,
@@ -166,6 +167,7 @@ function render(args: Args, context: StoryContext) {
   const classes = [
     'form-control',
     args.type === 'color' && 'form-control-color',
+    serializeSimulatedPseudoClass(args.pseudoClass),
     args.size,
     args.validation,
   ]
@@ -210,7 +212,7 @@ function render(args: Args, context: StoryContext) {
       ?disabled="${args.disabled}"
       aria-label="${useAriaLabel ? args.label : nothing}"
       ?aria-invalid="${VALIDATION_STATE_MAP[args.validation]}"
-      value=${args.value ? args.value : nothing}
+      value="${args.value ? args.value : nothing}"
     />
   `;
   if (args.floatingLabel) {

--- a/packages/documentation/src/stories/components/radio/radio.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/radio/radio.snapshot.stories.ts
@@ -25,11 +25,13 @@ export const Radio: Story = {
                   ],
                   checked: [false, true],
                   disabled: [false, true],
+                  pseudoClass: ['null', 'focus'],
                   validation: context.argTypes.validation.options,
                 }),
                 ...bombArgs({
                   hiddenLabel: [true],
                   disabled: [false, true],
+                  pseudoClass: ['null', 'focus'],
                   validation: context.argTypes.validation.options,
                 }),
               ]

--- a/packages/documentation/src/stories/components/radio/radio.stories.ts
+++ b/packages/documentation/src/stories/components/radio/radio.stories.ts
@@ -2,6 +2,7 @@ import { Args, Meta, StoryContext, StoryObj } from '@storybook/web-components';
 import { useArgs } from '@storybook/preview-api';
 import { BADGE } from '../../../../.storybook/constants';
 import { html, nothing, TemplateResult } from 'lit';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const VALIDATION_STATE_MAP: Record<string, undefined | boolean> = {
   'null': undefined,
@@ -102,7 +103,13 @@ function render(args: Args, context: StoryContext) {
   const [_, updateArgs] = useArgs();
 
   const id = `${context.viewMode}_${context.name.replace(/\s/g, '-')}_ExampleRadio`;
-  const classes = ['form-check-input', args.validation].filter(c => c && c !== 'null').join(' ');
+  const classes = [
+    'form-check-input',
+    args.validation,
+    serializeSimulatedPseudoClass(args.pseudoClass),
+  ]
+    .filter(c => c && c !== 'null')
+    .join(' ');
 
   const useAriaLabel = args.hiddenLabel;
   const label: TemplateResult | null = !useAriaLabel
@@ -134,7 +141,7 @@ function render(args: Args, context: StoryContext) {
       ?disabled="${args.disabled}"
       aria-label="${useAriaLabel ? args.label : nothing}"
       ?aria-invalid="${VALIDATION_STATE_MAP[args.validation]}"
-      @change=${(e: Event) => updateArgs({ checked: (e.target as HTMLInputElement).checked })}
+      @change="${(e: Event) => updateArgs({ checked: (e.target as HTMLInputElement).checked })}"
     />
   `;
 

--- a/packages/documentation/src/stories/components/range/range.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/range/range.snapshot.stories.ts
@@ -26,6 +26,7 @@ export const Range: Story = {
                     'Lorem ipsum dolor sit amet consectetur adipisicing elit. Vero mollitia magnam quo quam saepe. Aliquam tempore non deleniti culpa reprehenderit.',
                   ],
                   disabled: [false, true],
+                  pseudoClass: ['null', 'focus'],
                   validation: context.argTypes.validation.options,
                   showValue: context.argTypes.showValue.options,
                 })

--- a/packages/documentation/src/stories/components/range/range.stories.ts
+++ b/packages/documentation/src/stories/components/range/range.stories.ts
@@ -2,6 +2,7 @@ import { Args, Meta, StoryContext, StoryObj } from '@storybook/web-components';
 import { useArgs } from '@storybook/preview-api';
 import { BADGE } from '../../../../.storybook/constants';
 import { html, nothing, TemplateResult } from 'lit';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const VALIDATION_STATE_MAP: Record<string, undefined | boolean> = {
   'null': undefined,
@@ -166,7 +167,9 @@ function render(args: Args, context: StoryContext) {
   const [_, updateArgs] = useArgs();
 
   const id = `${context.viewMode}_${context.name.replace(/\s/g, '-')}_ExampleRange`;
-  const classes = ['form-range', args.validation].filter(c => c && c !== 'null').join(' ');
+  const classes = ['form-range', args.validation, serializeSimulatedPseudoClass(args.pseudoClass)]
+    .filter(c => c && c !== 'null')
+    .join(' ');
 
   const useAriaLabel = args.hiddenLabel;
   const label: TemplateResult | null = !useAriaLabel

--- a/packages/documentation/src/stories/components/select/select.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/select/select.snapshot.stories.ts
@@ -20,15 +20,18 @@ export const Select: Story = {
           'Label - Lorem ipsum dolor sit amet consetetur sadipscing elitr sed diam nonumy eirmod tempor',
         ],
         hint: [''],
+        pseudoClass: ['null', 'focus-visible'],
       }),
       ...bombArgs({
         hiddenLabel: [true],
         hint: ['Hintus textus', context.args.hint],
+        pseudoClass: ['null', 'focus-visible'],
       }),
       ...bombArgs({
         size: context.argTypes.size.options,
         disabled: [false, true],
         validation: context.argTypes.validation.options,
+        pseudoClass: ['null', 'focus-visible'],
       }),
     ]
       // remove disabled & validated examples
@@ -43,17 +46,20 @@ export const Select: Story = {
           'Label - Lorem ipsum dolor sit amet consetetur sadipscing elitr sed diam nonumy eirmod tempor',
         ],
         hint: [''],
+        pseudoClass: ['null', 'focus-visible'],
       }),
       ...bombArgs({
         multiple: [true],
         hiddenLabel: [true],
         hint: ['', 'Hintus textus', context.args.hint],
+        pseudoClass: ['null', 'focus-visible'],
       }),
       ...bombArgs({
         multiple: [true],
         size: context.argTypes.size.options,
         disabled: [false, true],
         validation: context.argTypes.validation.options,
+        pseudoClass: ['null', 'focus-visible'],
       }),
     ]
       // remove disabled & validated examples

--- a/packages/documentation/src/stories/components/select/select.stories.ts
+++ b/packages/documentation/src/stories/components/select/select.stories.ts
@@ -2,6 +2,7 @@ import type { Args, Meta, StoryContext, StoryObj } from '@storybook/web-componen
 import { html, nothing } from 'lit';
 import { useArgs } from '@storybook/preview-api';
 import { BADGE } from '../../../../.storybook/constants';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const VALIDATION_STATE_MAP: Record<string, undefined | boolean> = {
   'null': undefined,
@@ -181,7 +182,12 @@ const Template: Story = {
   render: (args: Args, context: StoryContext) => {
     const [_, updateArgs] = useArgs();
     const id = `${context.viewMode}_${context.story.replace(/\s/g, '-')}_ExampleSelect`;
-    const classes = ['form-select', args.size, args.validation]
+    const classes = [
+      'form-select',
+      args.size,
+      args.validation,
+      serializeSimulatedPseudoClass(args.pseudoClass),
+    ]
       .filter(c => c && c !== 'null')
       .join(' ');
     const useAriaLabel = !args.floatingLabel && args.hiddenLabel;
@@ -220,17 +226,17 @@ const Template: Story = {
     ];
     const control = html`
       <select
-        id=${id}
-        class=${classes}
-        defaultValue=${args.value ?? nothing}
-        ?multiple=${args.multiple}
-        size=${args.multipleSize ?? nothing}
-        ?disabled=${args.disabled}
-        aria-label=${useAriaLabel ? args.label : undefined}
-        aria-invalid=${VALIDATION_STATE_MAP[args.validation]}
-        @change=${(e: Event) => {
+        id="${id}"
+        class="${classes}"
+        defaultValue="${args.value ?? nothing}"
+        ?multiple="${args.multiple}"
+        size="${args.multipleSize ?? nothing}"
+        ?disabled="${args.disabled}"
+        aria-label="${useAriaLabel ? args.label : undefined}"
+        aria-invalid="${VALIDATION_STATE_MAP[args.validation]}"
+        @change="${(e: Event) => {
           updateArgs({ value: (e.target as HTMLSelectElement).value });
-        }}
+        }}"
       >
         ${options}
       </select>

--- a/packages/documentation/src/stories/components/switch/switch.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/switch/switch.snapshot.stories.ts
@@ -21,6 +21,7 @@ export const Switch: Story = {
       checked: [false, true],
       disabled: [false, true],
       validation: ['null', 'is-valid', 'is-invalid'],
+      pseudoClass: ['null', 'focus'],
     })
       .filter((args: Args) => !(args.labelPosition == 'before' && args.label === longerText))
       .map((args: Args) => {
@@ -33,7 +34,7 @@ export const Switch: Story = {
       <div>
         ${['white', 'dark'].map(
           bg => html`
-            <div class=${'row bg-' + bg}>${templateVariants}</div>
+            <div class="${'row bg-' + bg}">${templateVariants}</div>
           `,
         )}
       </div>

--- a/packages/documentation/src/stories/components/switch/switch.stories.ts
+++ b/packages/documentation/src/stories/components/switch/switch.stories.ts
@@ -4,6 +4,7 @@ import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { BADGE } from '../../../../.storybook/constants';
 import { mapClasses } from '../../../utils';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const meta: Meta = {
   title: 'Components/Switch',
@@ -112,9 +113,11 @@ const VALIDATION_STATE_MAP: Record<string, undefined | boolean> = {
 
 function renderSwitch(args: Args, context: StoryContext) {
   const [_, updateArgs] = useArgs();
+  const pseudoClassClass = serializeSimulatedPseudoClass(args.pseudoClass);
 
   const switchClasses = mapClasses({
     'form-check-input': true,
+    [pseudoClassClass]: Boolean(pseudoClassClass) && pseudoClassClass !== 'null',
     [args.validation]: args.validation !== 'null',
   });
 
@@ -125,13 +128,13 @@ function renderSwitch(args: Args, context: StoryContext) {
 
   const labelBefore = useLabelBefore
     ? html`
-        <label for=${context.id} class="form-check-label order-first">${args.label}</label>
+        <label for="${context.id}" class="form-check-label order-first">${args.label}</label>
       `
     : null;
 
   const labelAfter = useLabelAfter
     ? html`
-        <label for=${context.id} class="form-check-label">${args.label}</label>
+        <label for="${context.id}" class="form-check-label">${args.label}</label>
       `
     : null;
 
@@ -139,25 +142,23 @@ function renderSwitch(args: Args, context: StoryContext) {
   const validationFeedback =
     args.validation !== 'null'
       ? html`
-          <p class=${args.validation.split('-')[1] + '-feedback'}>
-            ${validationText}
-          </p>
+          <p class="${args.validation.split('-')[1] + '-feedback'}">${validationText}</p>
         `
       : null;
 
   return html`
     <div class="form-check form-switch">
       <input
-        id=${context.id}
-        class=${switchClasses}
+        id="${context.id}"
+        class="${switchClasses}"
         type="checkbox"
         role="switch"
-        ?checked=${args.checked}
-        .checked=${args.checked}
-        ?disabled=${args.disabled}
-        aria-label=${useAriaLabel ? ariaLabel : nothing}
-        aria-invalid=${ifDefined(VALIDATION_STATE_MAP[args.validation])}
-        @change=${(e: Event) => updateArgs({ checked: !args.checked })}
+        ?checked="${args.checked}"
+        .checked="${args.checked}"
+        ?disabled="${args.disabled}"
+        aria-label="${useAriaLabel ? ariaLabel : nothing}"
+        aria-invalid="${ifDefined(VALIDATION_STATE_MAP[args.validation])}"
+        @change="${(e: Event) => updateArgs({ checked: !args.checked })}"
       />
       ${labelBefore} ${labelAfter} ${args.validation !== 'null' ? validationFeedback : nothing}
     </div>
@@ -171,13 +172,7 @@ export const Default: Story = {};
 export const MultilineLabels: Story = {
   parameters: {
     controls: {
-      exclude: [
-        'Label Position',
-        'Hidden Label',
-        'Checked',
-        'Disabled',
-        'Validation',
-      ],
+      exclude: ['Label Position', 'Hidden Label', 'Checked', 'Disabled', 'Validation'],
     },
   },
   args: {
@@ -190,13 +185,7 @@ export const MultilineLabels: Story = {
 export const Validation: Story = {
   parameters: {
     controls: {
-      exclude: [
-        'Label Position',
-        'Label',
-        'Hidden Label',
-        'Checked',
-        'Disabled',
-      ],
+      exclude: ['Label Position', 'Label', 'Hidden Label', 'Checked', 'Disabled'],
     },
   },
   args: {

--- a/packages/documentation/src/stories/components/toast/toast.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/toast/toast.snapshot.stories.ts
@@ -27,6 +27,7 @@ export const Toast: Story = {
                 variant: context.argTypes.variant.options,
                 noIcon: [false, true],
                 dismissible: [false, true],
+                pseudoClass: ['null', 'focus-visible'],
               })
                 .filter(
                   (args: Args) =>

--- a/packages/documentation/src/stories/components/toast/toast.stories.ts
+++ b/packages/documentation/src/stories/components/toast/toast.stories.ts
@@ -2,6 +2,8 @@ import { useArgs } from '@storybook/preview-api';
 import { Args, Meta, StoryContext, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { BADGE } from '../../../../.storybook/constants';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
+import { appendClass } from '../../../utils';
 
 const meta: Meta = {
   title: 'Components/Toast',
@@ -81,7 +83,8 @@ const meta: Meta = {
     },
     icon: {
       name: 'Icon',
-      description: 'Defines a custom icon.' +
+      description:
+        'Defines a custom icon.' +
         '<span className="mt-mini alert alert-info alert-sm">' +
         'To use a custom icon, you must first ' +
         '<a href="/?path=/docs/icons-getting-started--docs">set up the icons in your project</a>' +
@@ -354,6 +357,8 @@ function render(args: Args, context: StoryContext) {
     .filter(c => c && c !== 'null')
     .join(' ');
 
+  const pseudoClassClass = serializeSimulatedPseudoClass(args.pseudoClass);
+
   const isFixed = args.position === 'fixed';
   const alignV = args.alignVRestricted ?? args.alignV;
   const alignH = args.alignHRestricted ?? args.alignH;
@@ -370,14 +375,17 @@ function render(args: Args, context: StoryContext) {
   const toastIcon =
     !args.noIcon && args.icon !== 'null'
       ? html`
-        <post-icon aria-hidden="true" name=${args.icon}></post-icon>
-      `
+          <post-icon aria-hidden="true" name="${args.icon}"></post-icon>
+        `
       : null;
 
   const dismissButton =
     args.dismissible || isFixed
       ? html`
-          <button class="toast-close-button" aria-label="close"></button>
+          <button
+            class="toast-close-button${appendClass(pseudoClassClass)}"
+            aria-label="close"
+          ></button>
         `
       : null;
 
@@ -391,8 +399,7 @@ function render(args: Args, context: StoryContext) {
       @mouseenter="${() => killAutoHideTimeout(timeoutStore, args)}"
       @mouseleave="${() => createAutoHideTimeout(timeoutStore, args, updateArgs)}"
     >
-      ${toastIcon}
-      ${dismissButton}
+      ${toastIcon} ${dismissButton}
       <div class="toast-title">${args.title}</div>
       ${args.content
         ? html`

--- a/packages/documentation/src/stories/components/topic-teaser/topic-teaser.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/topic-teaser/topic-teaser.snapshot.stories.ts
@@ -18,13 +18,14 @@ export const TopicTeaser: Story = {
       <div>
         ${['white', 'dark'].map(
           bg => html`
-            <div class=${'row bg-' + bg}>
+            <div class="${'row bg-' + bg}">
               ${bombArgs({
                 subtitle: [short, long],
                 title: [short, long],
                 alignment: context.argTypes.alignment.options,
                 backgroundColor: ['bg-nightblue', 'bg-coral-bright'],
                 linkCount: [1, 5, 10],
+                pseudoClass: ['null', 'focus-visible'],
               })
                 .filter((args: Args) => args.title !== args.subtitle || args.linkCount == 5)
                 .map((args: Args) => {

--- a/packages/documentation/src/stories/components/topic-teaser/topic-teaser.stories.ts
+++ b/packages/documentation/src/stories/components/topic-teaser/topic-teaser.stories.ts
@@ -1,7 +1,8 @@
 import type { Args, Meta, StoryObj } from '@storybook/web-components';
 import { html, TemplateResult } from 'lit';
 import { BADGE } from '../../../../.storybook/constants';
-import { mapClasses } from '../../../utils';
+import { appendClass, mapClasses } from '../../../utils';
+import { serializeSimulatedPseudoClass } from '../../../utils/pseudo-class';
 
 const meta: Meta = {
   title: 'Components/Topic Teaser',
@@ -134,9 +135,11 @@ export const Default: Story = {
       [args.alignment]: args.alignment !== 'null',
     });
 
+    const pseudoClassClass = serializeSimulatedPseudoClass(args.pseudoClass);
+
     const links: TemplateResult[] = linkTexts.slice(0, args.linkCount).map(
       text => html`
-        <li class="link-list-item">
+        <li class="link-list-item${appendClass(pseudoClassClass)}">
           <a href="#">
             <span>${text}</span>
           </a>

--- a/packages/documentation/src/utils/index.ts
+++ b/packages/documentation/src/utils/index.ts
@@ -1,4 +1,4 @@
 export * from './component-properties';
 export * from './get-attributes';
-export * from './map-classes';
+export * from './mapClasses';
 export * from './spread-args';

--- a/packages/documentation/src/utils/inputComponentsGetCombinations.ts
+++ b/packages/documentation/src/utils/inputComponentsGetCombinations.ts
@@ -8,7 +8,6 @@ const LONG_TEXT =
 
 export const COMBINATIONS = [
   {
-    title: true, // This property is true when a heading should be rendered above the story
     label: `${SHORT_LABEL} - no Hint`,
     hint: null,
   },
@@ -32,22 +31,12 @@ export const COMBINATIONS = [
     label: `${SHORT_LABEL} - Invalid`,
     validation: 'is-invalid',
   },
+  {
+    label: `${SHORT_LABEL} - no Placeholder`,
+    placeholder: null,
+  },
+  {
+    label: `${SHORT_LABEL} - with Value`,
+    value: 'Lorem Ipsum',
+  },
 ];
-
-export function getCombinations(
-  argumentName: string,
-  argumentValues: Array<unknown>,
-  combinations: Array<{ label: string; [propName: string]: any }>,
-) {
-  let result: Array<Object> = [];
-  for (const argumentValue of argumentValues) {
-    result = [
-      ...result,
-      ...combinations.map(c => ({
-        ...c,
-        [argumentName]: argumentValue,
-      })),
-    ];
-  }
-  return result;
-}

--- a/packages/documentation/src/utils/mapClasses.ts
+++ b/packages/documentation/src/utils/mapClasses.ts
@@ -4,3 +4,7 @@ export function mapClasses(classObject: Record<string, boolean>): string {
     .map(([newClass]) => newClass)
     .join(' ');
 }
+
+export function appendClass(className: string | undefined) {
+  return `${className ? ` ${className}` : ''}`;
+}

--- a/packages/documentation/src/utils/pseudo-class.ts
+++ b/packages/documentation/src/utils/pseudo-class.ts
@@ -1,0 +1,28 @@
+const pseudoClassList = ['hover', 'active', 'focus', 'focus-visible', 'focus-within'];
+
+/**
+ * Serialize snapshot Pseudo-class arguments into class provided by storybook-addon-pseudo-states to simulate the behavior
+ * @param name one or multiple name of a pseudo-class
+ */
+export function serializeSimulatedPseudoClass(name: string | string[] | undefined): string {
+  if (!name) {
+    return '';
+  }
+
+  const pseudoClass = Array.isArray(name) ? name : [name];
+
+  return pseudoClass.reduce((accumulator, currentValue: string | undefined) => {
+    const classes = [accumulator];
+
+    if (currentValue && pseudoClassList.includes(currentValue)) {
+      classes.push(`pseudo-${currentValue}`);
+    }
+
+    // Useful for some components that trigger focus programmatically
+    if (currentValue?.startsWith('focus')) {
+      classes.push('focused');
+    }
+
+    return classes.join(' ');
+  }, '');
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -602,6 +602,9 @@ importers:
       storybook:
         specifier: 7.4.5
         version: 7.4.5
+      storybook-addon-pseudo-states:
+        specifier: ^2.1.2
+        version: 2.1.2(@storybook/components@7.4.5)(@storybook/core-events@7.4.5)(@storybook/manager-api@7.4.5)(@storybook/preview-api@7.4.5)(@storybook/theming@7.4.5)(react-dom@18.2.0)(react@18.2.0)
       typescript:
         specifier: 5.1.6
         version: 5.1.6
@@ -20824,6 +20827,31 @@ packages:
 
   /store2@2.14.2:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
+    dev: true
+
+  /storybook-addon-pseudo-states@2.1.2(@storybook/components@7.4.5)(@storybook/core-events@7.4.5)(@storybook/manager-api@7.4.5)(@storybook/preview-api@7.4.5)(@storybook/theming@7.4.5)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-AHv6q1JiQEUnMyZE3729iV6cNmBW7bueeytc4Lga4+8W1En8YNea5VjqAdrDNJhXVU0QEEIGtxkD3EoC9aVWLw==}
+    peerDependencies:
+      '@storybook/components': ^7.4.6
+      '@storybook/core-events': ^7.4.6
+      '@storybook/manager-api': ^7.4.6
+      '@storybook/preview-api': ^7.4.6
+      '@storybook/theming': ^7.4.6
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=18
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=18
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/components': 7.4.5(@types/react@18.2.22)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-events': 7.4.5
+      '@storybook/manager-api': 7.4.5(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/preview-api': 7.4.5
+      '@storybook/theming': 7.4.5(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
   /storybook@7.4.5:


### PR DESCRIPTION
### What

Use `storybook-addon-pseudo-states` plugin to simulate pseudo-class like `hover`, `focus`, etc. This plugin rewrite the associated stylesheet and try to replace the defined pseudo-class with a class using the following naming template `.pseudo-${pseudoClassName}`.

### Limitation

- No support for @media, see https://github.com/chromaui/storybook-addon-pseudo-states/pull/75
  - Buttons: background-color is right, but we don't see the animated arrow because of `@media (prefers-reduced-motion: no-preference)` usage.
- No support for web-components built stylesheet, see https://github.com/chromaui/storybook-addon-pseudo-states/issues/10
  - Collapsible
  - Tabs
- Currently, it breaks as https://github.com/chromaui/storybook-addon-pseudo-states/pull/82 it doesn't support `::-moz-range-thumb` or `::-webkit-slider-thumb`. This can be fixed by adding them here: https://github.com/chromaui/storybook-addon-pseudo-states/blob/07abc1bb39ee4f3377955b23860c275de12b872f/src/constants.js#L6
- Currently, it uses the DOM API, so the whole stylesheet transformation appears in the browser and for each load of the page, which is not optimal. Also, for this reason, it's limited to 1000, so for us (~3500 lines at the moment) to be usable we need to remove this limit (and fork the package). Lines to be removed: https://github.com/chromaui/storybook-addon-pseudo-states/blob/baaa167909676b6fcfb778564cecb92636db390a/src/rewriteStyleSheet.js#L68-L70

### Misc
- Topic-teaser uses default browser focus-rules, so we can't simulate, and it's invisible in snapshot
- Components without snapshot: [textarea](https://github.com/swisspost/design-system/issues/1172), tooltip, button-group