### PR TITLE
feat(components, internet-header): Compress embedded sass output on web components

### DIFF
--- a/.changeset/six-hotels-sell.md
+++ b/.changeset/six-hotels-sell.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/internet-header': patch
+'@swisspost/design-system-components': patch
+---
+
+Compressed styles output.

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -31,6 +31,7 @@ export const config: Config = {
   ],
   plugins: [
     sass({
+      outputStyle: 'compressed',
       includePaths: ['node_modules'],
     }),
   ],

--- a/packages/internet-header/stencil.config.ts
+++ b/packages/internet-header/stencil.config.ts
@@ -40,13 +40,13 @@ export const config: Config = {
   ],
   plugins: [
     sass({
+      outputStyle: 'compressed',
       includePaths: ['node_modules'],
     }),
   ],
   rollupPlugins: {
     before: [
       scss({
-        outputStyle: 'compressed',
         output: false,
       }),
     ],

--- a/packages/internet-header/stencil.config.ts
+++ b/packages/internet-header/stencil.config.ts
@@ -46,11 +46,12 @@ export const config: Config = {
   rollupPlugins: {
     before: [
       scss({
+        outputStyle: 'compressed',
         output: false,
       }),
     ],
   },
   extras: {
     enableImportInjection: true,
-  }
+  },
 };


### PR DESCRIPTION
### What

Compress (and remove comments) for sass output of stencil web components

### Before

![idea64_pRAmHp95F3](https://github.com/swisspost/design-system/assets/12294151/bf6ce17a-f1f1-48a8-91c3-1b38960bde89)
