### PR TITLE
chore(styles): Run autoprefixer on scss files

### DIFF
--- a/.changeset/spicy-cougars-buy.md
+++ b/.changeset/spicy-cougars-buy.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Applied autoprefixer to distributed sass files. Sass files will now contain prefixes for supported browsers according to the browserslist file.

--- a/packages/styles/gulpfile.js
+++ b/packages/styles/gulpfile.js
@@ -5,6 +5,7 @@ const sass = require('sass');
 const newer = require('gulp-newer');
 const gulpSass = require('gulp-sass')(sass);
 const gulpPostCss = require('gulp-postcss');
+const postcssScss = require('postcss-scss');
 const autoprefixer = require('autoprefixer');
 const { globSync } = require('glob');
 const options = require('./package.json').sass;
@@ -16,6 +17,20 @@ gulp.task('copy', () => {
   return gulp
     .src(['./LICENSE', './README.md', './package.json', './src/**/*.scss'])
     .pipe(newer(options.outputDir))
+    .pipe(gulp.dest(options.outputDir));
+});
+
+/**
+ * Autoprefix SCSS files
+ */
+gulp.task('autoprefixer', function () {
+  return gulp
+    .src(`${options.outputDir}/**/*.scss`)
+    .pipe(
+      gulpPostCss([autoprefixer()], {
+        syntax: postcssScss,
+      }),
+    )
     .pipe(gulp.dest(options.outputDir));
 });
 
@@ -142,5 +157,8 @@ gulp.task('watch', () => {
  */
 exports.default = gulp.task(
   'build',
-  gulp.parallel(gulp.series('map-icons', 'copy', 'transform-package-json'), gulp.series('sass')),
+  gulp.parallel(
+    gulp.series('map-icons', 'copy', 'autoprefixer', 'transform-package-json'),
+    gulp.series('sass'),
+  ),
 );

--- a/packages/styles/src/mixins/_icons.scss
+++ b/packages/styles/src/mixins/_icons.scss
@@ -8,15 +8,11 @@
 @use './../mixins/utilities';
 
 @mixin icon($name) {
-  /* stylelint-disable-next-line property-no-vendor-prefix */
-  -webkit-mask-image: url('#{icon-fn.get-svg-url($name)}');
   mask-image: url('#{icon-fn.get-svg-url($name)}');
   background-color: currentColor;
 }
 
 @mixin remove-icon() {
-  /* stylelint-disable-next-line property-no-vendor-prefix */
-  -webkit-mask-image: none;
   mask-image: none;
 }
 


### PR DESCRIPTION
Currently, we autoprefix CSS compressed output files, but not SCSS files that can also be used through the packages.