### PR TITLE
fix(components): add e2e timeout when trying to get component

### DIFF
--- a/packages/components/cypress/support/commands.ts
+++ b/packages/components/cypress/support/commands.ts
@@ -52,7 +52,7 @@ Cypress.Commands.add('getComponent', (component: string, story = 'default') => {
   cy.visit(`/iframe.html?id=components-${component}--${story}`);
 
   const alias = component.replace(/^post-/, '');
-  cy.get(`post-${alias}`).as(alias);
+  cy.get(`post-${alias}`, { timeout: 30000 }).as(alias);
 });
 
 Cypress.Commands.add('checkVisibility', (visibility: 'visible' | 'hidden') => {


### PR DESCRIPTION
Some of the earliest tests are failing in watch mode, so extend timeout from default 4s to 30s to avoid this issue (like we are doing it for e2e in storybook).