### PR TITLE
chore: automatically run snapshot tests on release pr

### DIFF
--- a/.github/workflows/snapshot-tests.yaml
+++ b/.github/workflows/snapshot-tests.yaml
@@ -7,7 +7,11 @@
 ###
 
 name: Run snapshot tests
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - 'changeset/release-main'
 
 jobs:
   snapshots:


### PR DESCRIPTION
We are using very little of our quota for snapshots (25'000). I think we can run the snapshots automatically on the release PR.