### PR TITLE
fix(styles): Floating-label using scss var inside CSS calc function

### DIFF
--- a/packages/styles/src/components/floating-label.scss
+++ b/packages/styles/src/components/floating-label.scss
@@ -56,9 +56,9 @@
       ~ label {
         padding-top: 0.7rem;
         max-width: calc(
-          (100% * #{forms.$form-floating-label-upscale}) -
-            #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
-            #{forms.$input-border-width * forms.$form-floating-label-upscale * 2}
+          (100% * #{forms.$form-floating-label-upscale}) - #{forms.$form-floating-label-translate-x *
+            forms.$form-floating-label-upscale * 2} - #{forms.$input-border-width * forms.$form-floating-label-upscale *
+            2}
         );
         transition: forms.$form-floating-transition-in;
       }
@@ -82,9 +82,9 @@
     ~ label {
       padding-top: 0.7rem;
       max-width: calc(
-        (100% * #{forms.$form-floating-label-upscale}) -
-          #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
-          #{forms.$input-border-width * forms.$form-floating-label-upscale * 2}
+        (100% * #{forms.$form-floating-label-upscale}) - #{forms.$form-floating-label-translate-x *
+          forms.$form-floating-label-upscale * 2} - #{forms.$input-border-width * forms.$form-floating-label-upscale *
+          2}
       );
       transition: forms.$form-floating-transition-in;
     }
@@ -109,10 +109,9 @@
         padding-top: forms.$input-padding-y-lg * forms.$form-floating-label-scale;
         padding-bottom: 0;
         width: calc(
-          (100% * #{forms.$form-floating-label-upscale}) -
-            #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
-            #{forms.$input-border-width * forms.$form-floating-label-upscale * 2} -
-            #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale}
+          (100% * #{forms.$form-floating-label-upscale}) - #{forms.$form-floating-label-translate-x *
+            forms.$form-floating-label-upscale * 2} - #{forms.$input-border-width * forms.$form-floating-label-upscale *
+            2} - #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale}
         );
         height: auto;
         background: forms.$input-bg;
@@ -122,7 +121,9 @@
         ~ label {
           padding-top: forms.$form-floating-padding-y;
           padding-bottom: forms.$form-floating-padding-y;
-          width: calc(100% - (#{forms.$input-border-width * 2}) - #{forms.$form-floating-padding-x});
+          width: calc(
+            100% - (#{forms.$input-border-width * 2}) - #{forms.$form-floating-padding-x}
+          );
           height: forms.$form-floating-label-height;
         }
       }
@@ -149,10 +150,9 @@
       ~ label {
         padding-top: forms.$input-padding-y-lg * forms.$form-floating-label-scale;
         width: calc(
-          (100% * #{forms.$form-floating-label-upscale}) -
-            #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
-            #{forms.$input-border-width * forms.$form-floating-label-upscale * 2} -
-            #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale}
+          (100% * #{forms.$form-floating-label-upscale}) - #{forms.$form-floating-label-translate-x *
+            forms.$form-floating-label-upscale * 2} - #{forms.$input-border-width * forms.$form-floating-label-upscale *
+            2} - #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale}
         );
         max-width: none;
         background: forms.$input-bg;
@@ -162,8 +162,8 @@
     &:is(.is-valid, .is-invalid) {
       ~ label {
         width: calc(
-          100% - (#{forms.$input-border-width * 2}) - #{forms.$form-floating-padding-x} -
-          #{form-validation.$form-feedback-icon-offset} - #{form-validation.$form-feedback-icon-size}
+          100% - (#{forms.$input-border-width * 2}) - #{forms.$form-floating-padding-x} - #{form-validation.$form-feedback-icon-offset} -
+            #{form-validation.$form-feedback-icon-size}
         );
       }
 
@@ -171,12 +171,11 @@
       &:not(:placeholder-shown) {
         ~ label {
           width: calc(
-            (100% * #{forms.$form-floating-label-upscale}) -
-              #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
-              #{forms.$input-border-width * forms.$form-floating-label-upscale * 2} -
-              #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale} -
-              #{form-validation.$form-feedback-icon-offset * forms.$form-floating-label-upscale} -
-              #{form-validation.$form-feedback-icon-size * forms.$form-floating-label-upscale}
+            (100% * #{forms.$form-floating-label-upscale}) - #{forms.$form-floating-label-translate-x *
+              forms.$form-floating-label-upscale * 2} - #{forms.$input-border-width * forms.$form-floating-label-upscale *
+              2} - #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale} - #{form-validation.$form-feedback-icon-offset *
+              forms.$form-floating-label-upscale} - #{form-validation.$form-feedback-icon-size *
+              forms.$form-floating-label-upscale}
           );
         }
       }

--- a/packages/styles/src/components/floating-label.scss
+++ b/packages/styles/src/components/floating-label.scss
@@ -30,7 +30,7 @@
     font-size: forms.$form-floating-label-font-size;
     width: auto;
     height: auto;
-    max-width: calc(100% - (forms.$input-border-width * 2));
+    max-width: calc(100% - (#{forms.$input-border-width * 2}));
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -56,9 +56,9 @@
       ~ label {
         padding-top: 0.7rem;
         max-width: calc(
-          (100% * forms.$form-floating-label-upscale) -
-            (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
-            (forms.$input-border-width * forms.$form-floating-label-upscale * 2)
+          (100% * #{forms.$form-floating-label-upscale}) -
+            #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
+            #{forms.$input-border-width * forms.$form-floating-label-upscale * 2}
         );
         transition: forms.$form-floating-transition-in;
       }
@@ -82,9 +82,9 @@
     ~ label {
       padding-top: 0.7rem;
       max-width: calc(
-        (100% * forms.$form-floating-label-upscale) -
-          (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
-          (forms.$input-border-width * forms.$form-floating-label-upscale * 2)
+        (100% * #{forms.$form-floating-label-upscale}) -
+          #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
+          #{forms.$input-border-width * forms.$form-floating-label-upscale * 2}
       );
       transition: forms.$form-floating-transition-in;
     }
@@ -95,7 +95,7 @@
 
       ~ label {
         padding-top: forms.$form-floating-padding-y;
-        max-width: calc(100% - (forms.$input-border-width * 2));
+        max-width: calc(100% - (#{forms.$input-border-width * 2}));
         transform: none;
       }
     }
@@ -109,10 +109,10 @@
         padding-top: forms.$input-padding-y-lg * forms.$form-floating-label-scale;
         padding-bottom: 0;
         width: calc(
-          (100% * forms.$form-floating-label-upscale) -
-            (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
-            (forms.$input-border-width * forms.$form-floating-label-upscale * 2) -
-            (forms.$form-floating-padding-x * forms.$form-floating-label-upscale)
+          (100% * #{forms.$form-floating-label-upscale}) -
+            #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
+            #{forms.$input-border-width * forms.$form-floating-label-upscale * 2} -
+            #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale}
         );
         height: auto;
         background: forms.$input-bg;
@@ -122,7 +122,7 @@
         ~ label {
           padding-top: forms.$form-floating-padding-y;
           padding-bottom: forms.$form-floating-padding-y;
-          width: calc(100% - (forms.$input-border-width * 2) - forms.$form-floating-padding-x);
+          width: calc(100% - (#{forms.$input-border-width * 2}) - #{forms.$form-floating-padding-x});
           height: forms.$form-floating-label-height;
         }
       }
@@ -136,7 +136,7 @@
 
     ~ label {
       padding-bottom: 0;
-      width: calc(100% - (forms.$input-border-width * 2));
+      width: calc(100% - (#{forms.$input-border-width * 2}));
       max-width: none;
       height: unset;
     }
@@ -149,10 +149,10 @@
       ~ label {
         padding-top: forms.$input-padding-y-lg * forms.$form-floating-label-scale;
         width: calc(
-          (100% * forms.$form-floating-label-upscale) -
-            (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
-            (forms.$input-border-width * forms.$form-floating-label-upscale * 2) -
-            (forms.$form-floating-padding-x * forms.$form-floating-label-upscale)
+          (100% * #{forms.$form-floating-label-upscale}) -
+            #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
+            #{forms.$input-border-width * forms.$form-floating-label-upscale * 2} -
+            #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale}
         );
         max-width: none;
         background: forms.$input-bg;
@@ -162,8 +162,8 @@
     &:is(.is-valid, .is-invalid) {
       ~ label {
         width: calc(
-          100% - (forms.$input-border-width * 2) - forms.$form-floating-padding-x -
-            form-validation.$form-feedback-icon-offset - form-validation.$form-feedback-icon-size
+          100% - (#{forms.$input-border-width * 2}) - #{forms.$form-floating-padding-x} -
+          #{form-validation.$form-feedback-icon-offset} - #{form-validation.$form-feedback-icon-size}
         );
       }
 
@@ -171,12 +171,12 @@
       &:not(:placeholder-shown) {
         ~ label {
           width: calc(
-            (100% * forms.$form-floating-label-upscale) -
-              (forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2) -
-              (forms.$input-border-width * forms.$form-floating-label-upscale * 2) -
-              (forms.$form-floating-padding-x * forms.$form-floating-label-upscale) -
-              (form-validation.$form-feedback-icon-offset * forms.$form-floating-label-upscale) -
-              (form-validation.$form-feedback-icon-size * forms.$form-floating-label-upscale)
+            (100% * #{forms.$form-floating-label-upscale}) -
+              #{forms.$form-floating-label-translate-x * forms.$form-floating-label-upscale * 2} -
+              #{forms.$input-border-width * forms.$form-floating-label-upscale * 2} -
+              #{forms.$form-floating-padding-x * forms.$form-floating-label-upscale} -
+              #{form-validation.$form-feedback-icon-offset * forms.$form-floating-label-upscale} -
+              #{form-validation.$form-feedback-icon-size * forms.$form-floating-label-upscale}
           );
         }
       }


### PR DESCRIPTION
Intellij is reporting issues with this pattern to use scss variables inside native CSS calc function.
According to the SCSS doc, we should either use the SCSS calc function (which is the same as CSS calc, but support SCSS variable) or use interpolation: https://sass-lang.com/documentation/values/calculations/