### PR TITLE
chore: zip build artifacts

### DIFF
--- a/.github/actions/artifact-download/action.yaml
+++ b/.github/actions/artifact-download/action.yaml
@@ -49,6 +49,7 @@ runs:
         workflow_conclusion: success
 
     - name: Unzip artifacts
+      shell: bash
       run: unzip artifacts.zip
 
     - name: Create outputs

--- a/.github/actions/artifact-download/action.yaml
+++ b/.github/actions/artifact-download/action.yaml
@@ -48,6 +48,9 @@ runs:
         run_id: ${{ github.event.workflow_run.id }}
         workflow_conclusion: success
 
+    - name: Unzip artifacts
+      run: unzip artifacts.zip
+
     - name: Create outputs
       id: build
       shell: bash

--- a/.github/actions/artifact-upload/action.yaml
+++ b/.github/actions/artifact-upload/action.yaml
@@ -35,8 +35,11 @@ runs:
         echo ${{ github.event.number }} > ${{ inputs.folder }}/GHA-EVENT-ID
         echo ${{ github.event.action }} > ${{ inputs.folder }}/GHA-EVENT-ACTION
 
+    - name: Zip artifact folder
+      run: zip artifacts.zip ${{ inputs.folder }} -r
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.name }}
-        path: ${{ inputs.folder }}
+        path: artifacts.zip

--- a/.github/actions/artifact-upload/action.yaml
+++ b/.github/actions/artifact-upload/action.yaml
@@ -36,6 +36,7 @@ runs:
         echo ${{ github.event.action }} > ${{ inputs.folder }}/GHA-EVENT-ACTION
 
     - name: Zip artifact folder
+      shell: bash
       run: zip artifacts.zip ${{ inputs.folder }} -r
 
     - name: Upload artifacts

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -38,13 +38,13 @@ jobs:
         run: pnpm --filter design-system-documentation... build
 
       - name: Upload documentation
-        uses: ./.github/actions/artifact-upload@main
+        uses: ./.github/actions/artifact-upload
         with:
           name: design-system-documentation
           folder: packages/documentation/storybook-static
 
       - name: Upload internet header package
-        uses: ./.github/actions/artifact-upload@main
+        uses: ./.github/actions/artifact-upload
         with:
           name: internet-header
           folder: packages/internet-header/dist

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -38,13 +38,13 @@ jobs:
         run: pnpm --filter design-system-documentation... build
 
       - name: Upload documentation
-        uses: swisspost/design-system/.github/actions/artifact-upload@main
+        uses: ./.github/actions/artifact-upload@main
         with:
           name: design-system-documentation
           folder: packages/documentation/storybook-static
 
       - name: Upload internet header package
-        uses: swisspost/design-system/.github/actions/artifact-upload@main
+        uses: ./.github/actions/artifact-upload@main
         with:
           name: internet-header
           folder: packages/internet-header/dist

--- a/.github/workflows/deploy-documentation.yaml
+++ b/.github/workflows/deploy-documentation.yaml
@@ -25,14 +25,14 @@ jobs:
         uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
       - name: Download build artifacts
-        uses: swisspost/design-system/.github/actions/artifact-download@main
+        uses: ./.github/actions/artifact-download
         id: build
         with:
           name: design-system-documentation
           folder: build-output
 
       - name: Deploy documentation to netlify
-        uses: swisspost/design-system/.github/actions/deploy-to-netlify@main
+        uses: ./.github/actions/deploy-to-netlify
         id: deploy
         with:
           id: ${{ steps.build.outputs.id }}

--- a/packages/documentation/src/noop.txt
+++ b/packages/documentation/src/noop.txt
@@ -1,0 +1,1 @@
+triggering a doc build, nothing to see here


### PR DESCRIPTION
This change will centrally handle zipping and unzipping of build artifacts for faster upload/download. There is one catch to this PR: the download action always runs on the main branch (for security reasons) and cannot be tested, therefore the documentation publishing workflow fails for this PR. To actually test it, we'd need to merge this PR and push a change to the documentation.