### PR TITLE
2134 button group do not have focus style for checkbox/radio variants

### DIFF
--- a/packages/styles/src/components/button-group.scss
+++ b/packages/styles/src/components/button-group.scss
@@ -51,7 +51,7 @@
   position: absolute;
   clip: rect(0, 0, 0, 0);
   pointer-events: none;
-  &:focus-visible + .btn {
+  &:is(:focus-visible, :focus-within, .pretend-focus) + .btn {
     outline: forms.$input-focus-outline-thickness solid var(--post-contrast-color);
   }
 }

--- a/packages/styles/src/components/button-group.scss
+++ b/packages/styles/src/components/button-group.scss
@@ -7,6 +7,7 @@
 @use './../mixins/utilities';
 @use './../variables/color';
 @use './../variables/components/button';
+@use './../variables/components/forms';
 
 .btn-group {
   max-width: 100%;
@@ -50,4 +51,7 @@
   position: absolute;
   clip: rect(0, 0, 0, 0);
   pointer-events: none;
+  &:focus-visible + .btn {
+    outline: forms.$input-focus-outline-thickness solid var(--post-contrast-color);
+  }
 }


### PR DESCRIPTION
The solution works for the checkbox. For the radio variant, since with tab you can only focus the first element of the radio button group, it also only shows the focus style of the first label. If you want to focus the others, you have to use the arrow keys. And if I would put all the radio buttons in a seperate group, we would loose the whole functionality of the component.