### PR TITLE
chore: fix artifact path

### DIFF
--- a/.github/actions/artifact-download/action.yaml
+++ b/.github/actions/artifact-download/action.yaml
@@ -49,7 +49,7 @@ runs:
 
     - name: Unzip artifacts
       shell: bash
-      run: unzip ${{inputs.name}}/artifacts.zip -d ${{ inputs.folder }}
+      run: unzip artifacts.zip -d ${{ inputs.folder }}
 
     - name: Create outputs
       id: build

--- a/.github/actions/artifact-download/action.yaml
+++ b/.github/actions/artifact-download/action.yaml
@@ -51,6 +51,10 @@ runs:
       shell: bash
       run: unzip artifacts.zip -d ${{ inputs.folder }}
 
+    - name: Clean up
+      shell: bash
+      run: rm -r artifacts.zip
+
     - name: Create outputs
       id: build
       shell: bash


### PR DESCRIPTION
When a name is defined, the artifact is being unzipped at the root. Tested here https://github.com/gfellerph/artifact-test/actions.