### PR TITLE
feat(documenation): add since v1 label on components

### DIFF
--- a/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
+++ b/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
@@ -6,6 +6,10 @@ import SampleCustomTrigger from './accordion-custom-trigger.sample?raw';
 
 # Accordion
 
+<div class="badge badge-sm mb-regular">
+  <span>Since v1</span>
+</div>
+
 <p className="lead">Toggle the visibility of a set of related content in your project.</p>
 
 The `<post-accordion>` is a container for `<post-collapsible>` components.

--- a/packages/documentation/src/stories/components/alert/alert.docs.mdx
+++ b/packages/documentation/src/stories/components/alert/alert.docs.mdx
@@ -15,6 +15,10 @@ import AlertDismissSample from './web-component/alert-dismiss.sample?raw';
 
 # Alert
 
+<div class="badge badge-sm mb-regular">
+  <span>Since v1</span>
+</div>
+
 <div className="lead">
   Use alerts to communicate brief, important, and potentially time-sensitive messages to the user.
 </div>

--- a/packages/documentation/src/stories/components/collapsible/collapsible.docs.mdx
+++ b/packages/documentation/src/stories/components/collapsible/collapsible.docs.mdx
@@ -6,6 +6,10 @@ import SampleCustomTrigger from './collapsible-custom-trigger.sample?raw';
 
 # Collapsible
 
+<div class="badge badge-sm mb-regular">
+  <span>Since v1</span>
+</div>
+
 <p className="lead">Toggle the visibility of content across your project.</p>
 
 The `<post-collapsible>` component is used to show and hide content.

--- a/packages/documentation/src/stories/components/tabs/tabs.docs.mdx
+++ b/packages/documentation/src/stories/components/tabs/tabs.docs.mdx
@@ -6,6 +6,11 @@ import SampleCustomTrigger from './tabs-custom-trigger.sample?raw';
 <Meta of={TabStories} />
 
 # Tabs
+
+<div class="badge badge-sm mb-regular">
+  <span>Since v1</span>
+</div>
+
 <div className="lead">
   Organize content across different sections that are shown one at a time.
 </div>

--- a/packages/documentation/src/stories/components/tooltip/tooltip.docs.mdx
+++ b/packages/documentation/src/stories/components/tooltip/tooltip.docs.mdx
@@ -6,6 +6,10 @@ import LinkTo from '@storybook/addon-links/react';
 
 # Tooltip
 
+<div class="badge badge-sm mb-regular">
+  <span>Since v1</span>
+</div>
+
 <div className="lead">For short, informative messages or explanations.</div>
 
 <Canvas sourceState="shown" of={TooltipStories.Default} />

--- a/packages/documentation/src/stories/icons/components/icon.docs.mdx
+++ b/packages/documentation/src/stories/icons/components/icon.docs.mdx
@@ -6,6 +6,10 @@ import * as IconStories from './icon.stories';
 
 # Icon
 
+<div class="badge badge-sm mb-regular">
+  <span>Since v1</span>
+</div>
+
 <div className="lead">
   Our <code>&lt;post-icon&gt;</code> component renders SVGs, so it scales quickly and easily and can
   be styled with CSS.


### PR DESCRIPTION
Added label in all the docs of the components from the components package (accordion, alert, collapsible, tabs, tooltip, icon).