### PR TITLE
fix(documentation): remove unneeded badge size class

### DIFF
--- a/.changeset/big-carrots-join.md
+++ b/.changeset/big-carrots-join.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Removed badge size class at wrapper level. It's only used inside the label.

--- a/packages/documentation/src/stories/components/badge/badge.stories.ts
+++ b/packages/documentation/src/stories/components/badge/badge.stories.ts
@@ -111,10 +111,10 @@ function externalControl(story: any, { args }: StoryContext) {
   const button = html`
     <a
       href="#"
-      @click=${(e: Event) => {
+      @click="${(e: Event) => {
         e.preventDefault();
         updateArgs({ dismissed: false });
-      }}
+      }}"
     >
       Show badge
     </a>
@@ -157,19 +157,19 @@ function getCheckableContent(args: Args, updateArgs: (args: Args) => void, conte
 
   return html`
     <input
-      id=${checkboxId}
+      id="${checkboxId}"
       class="badge-check-input"
       type="checkbox"
-      ?checked=${args.checked}
-      @change=${handleChange}
+      ?checked="${args.checked}"
+      @change="${handleChange}"
     />
-    <label class=${labelClasses} for=${checkboxId}>${getDefaultContent(args)}</label>
+    <label class="${labelClasses}" for="${checkboxId}">${getDefaultContent(args)}</label>
   `;
 }
 
 function getDismissButton(updateArgs: (args: Args) => void) {
   return html`
-    <button class="btn-close" @click=${() => updateArgs({ dismissed: true })}>
+    <button class="btn-close" @click="${() => updateArgs({ dismissed: true })}">
       <span class="visually-hidden">Forigi insignon</span>
     </button>
   `;
@@ -189,11 +189,10 @@ function renderBadge(args: Args, context: StoryContext) {
   const badgeClasses = mapClasses({
     'badge': !isCheckable,
     'badge-check': isCheckable,
-    [args.size]: args.size !== 'default',
   });
 
   return html`
-    <div class=${badgeClasses}>
+    <div class="${badgeClasses}">
       ${isCheckable ? getCheckableContent(args, updateArgs, context) : getDefaultContent(args)}
       ${isDismissible ? getDismissButton(updateArgs) : nothing}
     </div>

--- a/packages/documentation/src/stories/components/badge/badge.stories.ts
+++ b/packages/documentation/src/stories/components/badge/badge.stories.ts
@@ -189,6 +189,7 @@ function renderBadge(args: Args, context: StoryContext) {
   const badgeClasses = mapClasses({
     'badge': !isCheckable,
     'badge-check': isCheckable,
+    [args.size]: args.size !== 'default' && !isCheckable,
   });
 
   return html`


### PR DESCRIPTION
###

Remove unneeded badge size class at wrapper level to match https://design-system.post.ch/#/bootstrap-samples/badge

### UI

#### Before

![image](https://github.com/swisspost/design-system/assets/12294151/85884a77-4df5-42d0-a672-c2aec25b7281)


#### After

![image](https://github.com/swisspost/design-system/assets/12294151/3f898ae0-b4fa-4ed8-b19f-2f7cf228f6ab)
