### PR TITLE
fix(styles): Intranet-header sticky nav prevents interactivity

### DIFF
--- a/.changeset/nasty-spies-explain.md
+++ b/.changeset/nasty-spies-explain.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed intranet-header sticky navigation on mobile which prevent interactivity on the page within a certain viewport width.

--- a/packages/styles/src/components/intranet-header/_sidebar.scss
+++ b/packages/styles/src/components/intranet-header/_sidebar.scss
@@ -80,7 +80,7 @@
     overflow-x: hidden;
     overflow-y: auto; // Scrollable contents if viewport is shorter than content.
 
-    @include media-breakpoint-down(rg) {
+    @include media-breakpoint-down(md) {
       bottom: auto;
     }
 


### PR DESCRIPTION
This was tested on a side project. The issue is not visible in https://design-system.post.ch/#/post-samples/intranet-layout because the components styles have been rewritten to be used inline (position fixed was removed). It would be nice to rewrite this demo by using iframe instead, but it's too much work for the deprecated old design system doc.