### PR TITLE
chore: update renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,9 +21,14 @@
       "groupSlug": "all-minor-patch"
     },
     {
-      "matchFiles": ["packages/styles/package.json"],
+      "matchFiles": ["packages/migrations/package.json"],
       "matchPackagePatterns": ["^@angular"],
       "allowedVersions": "<=15.0.4"
+    },
+    {
+      "matchFiles": ["packages/demo/package.json"],
+      "matchPackagePatterns": ["@types/node"],
+      "allowedVersions": "~18.17"
     }
   ],
   "timezone": "Europe/Zurich",


### PR DESCRIPTION
Angular 15.0.4 is now required for the migrations package and the restriction on types bypasses an error in the demo package.