### PR TITLE
fix(internet-header): Close button on click or on focus in the help overlay moves

### DIFF
--- a/.changeset/pink-tomatoes-cross.md
+++ b/.changeset/pink-tomatoes-cross.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fixed position of close button on click or on focus in the help overlay.

--- a/packages/internet-header/src/components/post-internet-breadcrumbs/post-internet-breadcrumbs.scss
+++ b/packages/internet-header/src/components/post-internet-breadcrumbs/post-internet-breadcrumbs.scss
@@ -184,7 +184,7 @@ iframe {
 }
 
 .overlay-close {
-  position: absolute;
+  position: absolute !important;
   top: 1rem;
   right: 1rem; // ca. Scrollbar width
   cursor: pointer;


### PR DESCRIPTION
When we click or focus the close button of the help overlay in the internet-header breadcrumbs, the button moves to the left. This is due to this change : https://github.com/swisspost/design-system/blob/a9997e3ec66914cc94c5ae824918fbe4e052dca3/packages/internet-header/src/utils/_placeholders.scss#L22-L45

Visible on the portal: https://places.post.ch/recherche-de-site?shortcut=fr-sites

https://github.com/swisspost/design-system/assets/12294151/2c5bfd4d-0bc6-4c17-af52-517afbf94144