### PR TITLE
chore: dry run publish before starting to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,6 @@ jobs:
       # This will fail the build if something in the publish setup is not correct
       # before changeset magic is starting to run
       - name: Test publish step
-        id: publishtest
         run: pnpm -r publish --dry-run
 
       # The changeset action will behave differently based on whether there are

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,12 @@ jobs:
       - name: Build changelog formatter
         run: pnpm --filter design-system-changelog-github build
 
+      # This will fail the build if something in the publish setup is not correct
+      # before changeset magic is starting to run
+      - name: Test publish step
+        id: publishtest
+        run: pnpm -r publish --dry-run
+
       # The changeset action will behave differently based on whether there are
       # new changesets on the main branch:
       #


### PR DESCRIPTION
This will prevent changesets from starting to release packages and then failing because of an invalid setup on one of the packages. Early failure will prevent some packages from being published without the complete workflow to finish (pushing git tags, notifying teams channel).