### PR TITLE
fix(header): return correct scrollparent

### DIFF
--- a/.changeset/polite-suns-promise.md
+++ b/.changeset/polite-suns-promise.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fixed an issue with stickyness scrolling where the logo would not react to scroll events and the header did not appear when scrolling back up.

--- a/packages/internet-header/src/index.html
+++ b/packages/internet-header/src/index.html
@@ -10,7 +10,7 @@
     <script type="module" src="/build/swisspost-internet-header.esm.js"></script>
     <script nomodule src="/build/swisspost-internet-header.js"></script>
   </head>
-  <body style="--header-z-index: 10">
+  <body style="--header-z-index: 10; overflow-x: hidden">
     <swisspost-internet-header
       project="klp"
       stickyness="main"

--- a/packages/internet-header/src/utils/scrollparent.ts
+++ b/packages/internet-header/src/utils/scrollparent.ts
@@ -12,6 +12,9 @@ const isScrollable = (node: Element) => {
 export const getScrollParent = (node: Element): Element | Document => {
   let currentParent = node.parentElement;
   while (currentParent) {
+    if (currentParent.nodeName === 'BODY') {
+      return document;
+    }
     if (isScrollable(currentParent)) {
       return currentParent;
     }


### PR DESCRIPTION
Scroll events don't fire on the body element if the window is scrolled, that prevented the stickiness functionality on most implementations to work properly.