### PR TITLE
chore: bootstrap before checking the publish command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,9 @@ jobs:
       - name: Setup
         uses: swisspost/design-system/.github/actions/setup-pnpm@main
 
-      # Install changesets locally
+      # Install dependencies and build packages
       - name: Install dependencies
-        run: pnpm install
-
-      # Build custom changelog formatter
-      - name: Build changelog formatter
-        run: pnpm --filter design-system-changelog-github build
+        run: pnpm bootstrap
 
       # This will fail the build if something in the publish setup is not correct
       # before changeset magic is starting to run

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "icons:unit": "pnpm --filter design-system-icons test",
     "icons:unit:watch": "pnpm --filter design-system-icons test:watch",
     "migrations:build": "pnpm --filter design-system-migrations build",
-    "changeset:publish": "pnpm bootstrap && pnpm changeset publish",
+    "changeset:publish": "pnpm changeset publish",
     "changeset:version": "pnpm changeset version && pnpm install --lockfile-only"
   },
   "devDependencies": {


### PR DESCRIPTION
Bootstrapping can be done earlier to skip some steps in the release process and make the publish check work (all packages need to be built for this).