### PR TITLE
chore(components): enable import injection

### DIFF
--- a/.changeset/perfect-ads-type.md
+++ b/.changeset/perfect-ads-type.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-documentation': patch
+'@swisspost/design-system-components': patch
+---
+
+Enabled import injection for components. This fixes an issue with importing dynamically loaded web components with the vite compiler for storybook.

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -29,6 +29,9 @@ export const config: Config = {
       file: 'dist/docs.json',
     },
   ],
+  extras: {
+    enableImportInjection: true,
+  },
   plugins: [
     sass({
       outputStyle: 'compressed',

--- a/packages/documentation/src/stories/components/icons/search-icons/search-icons.styles.scss
+++ b/packages/documentation/src/stories/components/icons/search-icons/search-icons.styles.scss
@@ -70,6 +70,7 @@
 
     post-icon {
       width: 40px;
+      height: 40px;
       transition: transform 100ms linear;
     }
   }
@@ -103,6 +104,7 @@
       height: 60px;
 
       post-icon {
+        width: 32px;
         width: 32px;
       }
     }

--- a/packages/documentation/src/stories/components/icons/search-icons/search-icons.styles.scss
+++ b/packages/documentation/src/stories/components/icons/search-icons/search-icons.styles.scss
@@ -105,7 +105,7 @@
 
       post-icon {
         width: 32px;
-        width: 32px;
+        height: 32px;
       }
     }
   }


### PR DESCRIPTION
Enabled import injection for components. This fixes an issue with importing dynamically loaded web components with the vite compiler for storybook.