### PR TITLE
fix(docs): Vertical rythmn is not applied to content inside tabs

### DIFF
--- a/.changeset/ten-garlics-relate.md
+++ b/.changeset/ten-garlics-relate.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed vertical rythmn which was not applied to content inside tab like Alert component.

--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -7,7 +7,8 @@
 #storybook-docs {
   overflow: hidden;
 
-  .sbdocs-content .container {
+  .sbdocs-content .container,
+  .sbdocs-content .container > post-tabs > post-tab-panel {
     // Target content headings only
     > h1 {
       margin-block: 5rem 1rem;


### PR DESCRIPTION
To compare with https://next.design-system.post.ch/?path=/docs/components-alert--docs