### PR TITLE
fix(e2e): Tests are failing because the docs takes too much time to load

### DIFF
--- a/packages/documentation/vite.config.js
+++ b/packages/documentation/vite.config.js
@@ -1,4 +1,18 @@
 // https://vitejs.dev/config/
 
 /** @type {import('vite').UserConfig} */
-export default {};
+export default {
+  optimizeDeps: {
+    include: [
+      '@pxtrn/storybook-addon-docs-stencil',
+      'prettier',
+      '@storybook/components',
+      'react-syntax-highlighter/dist/esm/languages/prism/scss',
+      'react/jsx-dev-runtime',
+      '@storybook/blocks',
+      'prettier/parser-html',
+      '@storybook/theming',
+      '@storybook/addon-links',
+    ],
+  },
+};


### PR DESCRIPTION
All docs e2e checks are failing at the moment. My suspicion is the following line where Vite discovers dependencies to optimize (Common js) after the first load, which ends up by reloading the page and failing some tests: https://github.com/swisspost/design-system/actions/runs/7530101061/job/20495763555?pr=2496#step:7:95