### PR TITLE
fix(docs): Clean icon component controls from duplicate and null values

### DIFF
--- a/.changeset/blue-bottles-sing.md
+++ b/.changeset/blue-bottles-sing.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Cleaned icon component controls from duplicate and null values.

--- a/packages/documentation/src/stories/components/icons/components/icon.stories.ts
+++ b/packages/documentation/src/stories/components/icons/components/icon.stories.ts
@@ -4,6 +4,7 @@ import { Components } from '@swisspost/design-system-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { BADGE } from '../../../../../.storybook/constants';
+import { spreadArgs } from '../../../../utils';
 
 const meta: Meta = {
   title: 'Components/Icons/Icon Component',
@@ -12,78 +13,54 @@ const meta: Meta = {
     badges: [BADGE.NEEDS_REVISION, BADGE.SINCE_V1],
   },
   args: {
-    'name': '1022',
-    'base': '',
-    'flip-h': false,
-    'flip-v': false,
-    'scale': 1,
-    'rotate': 0,
-    'animation': null,
+    name: '1022',
+    base: '',
+    flipH: false,
+    flipV: false,
+    scale: null,
+    rotate: null,
+    animation: null,
   },
   argTypes: {
-    'name': {
+    name: {
       table: {
         category: 'General',
       },
     },
-    'base': {
+    base: {
       table: {
         category: 'General',
       },
     },
-    'flip-h': {
-      table: {
-        category: 'Transformation',
-      },
-    },
-    'flip-v': {
-      table: {
-        category: 'Transformation',
-      },
-    },
-    'scale': {
+    scale: {
       control: {
         type: 'number',
         min: 0.5,
         max: 3,
         step: 0.1,
       },
-      table: {
-        category: 'Transformation',
-      },
     },
-    'rotate': {
+    rotate: {
       control: {
         type: 'number',
         min: -360,
         max: 360,
         step: 1,
       },
-      table: {
-        category: 'Transformation',
-      },
     },
-    'animation': {
+    animation: {
       options: [null, 'cylon', 'cylon-vertical', 'spin', 'spin-reverse', 'fade', 'throb'],
-      table: {
-        category: 'Transformation',
-      },
     },
   },
   render: args =>
     html`
-      <post-icon ${spread(normalizeArgs(args))}></post-icon>
+      <post-icon ${spreadArgs(normalizeArgs(args))}></post-icon>
     `,
 };
 
 function normalizeArgs(args: Args) {
-  return Object.assign({}, args, {
-    'base': args.base || null,
-    'scale': args.scale !== 1 ? args.scale : null,
-    'rotate': args.rotate !== 0 ? args.rotate : null,
-    'flip-h': args['flip-h'] !== false ? args['flip-h'] : null,
-    'flip-v': args['flip-v'] !== false ? args['flip-v'] : null,
-  });
+  // remove attribute with falsy values
+  return Object.fromEntries(Object.entries(args).filter(([_, v]) => v));
 }
 
 const renderVariants = (


### PR DESCRIPTION
### What

- Fix duplicate `flip-h` and `flip-v` argument
- Change category to make it work with how `flip-h` and `flip-v` are translated from plugin
- Remove args with falsy value so we don't display them at all. Before you could have `animation="null"` or `base=""`