### PR TITLE
fix(documentation): fix path to entry point for lazy loading components

### DIFF
--- a/.changeset/spicy-swans-punch.md
+++ b/.changeset/spicy-swans-punch.md
@@ -1,0 +1,5 @@
+---
+"@swisspost/design-system-documentation": patch
+---
+
+fix(documentation): fix path to entry point for lazy loading components

--- a/packages/documentation/src/stories/getting-started/components/components-cdn-all.sample.html
+++ b/packages/documentation/src/stories/getting-started/components/components-cdn-all.sample.html
@@ -1,6 +1,9 @@
 <html>
   <head>
-    <script src="https://cdn.jsdelivr.net/npm/@swisspost/design-system-components/dist/index.js"></script>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@swisspost/design-system-components/dist/esm/post-components.js"
+    ></script>
   </head>
   <body>
     <post-icon name="1001"></post-icon>


### PR DESCRIPTION
Hey there 👋 

I am developer for the Stencil team and have been looking into how Stencil suggests to distribute components within design systems like this one. During the research I stumbled upon this bug and I would like to send this patch to fix it. We will hopefully soon have some updates on this and I will come back here to report 😉 

The path in the current docs point to a file that only exports the web components. In the context of the docs though you want to point to the file that lazy loads all components so someone can use them in the HTML.

Have a nice weekend!