### PR TITLE
feat(styles): Tag component but .tag class name is also used for code examples

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -189,6 +189,15 @@ export namespace Components {
          */
         "show": (panelName: string) => Promise<void>;
     }
+    /**
+     * @class PostTag - representing a stencil component
+     */
+    interface PostTag {
+        "color"?: string;
+        "icon": number;
+        "showIcon"?: boolean;
+        "size"?: string;
+    }
     interface PostTooltip {
         /**
           * Wheter or not to display a little pointer arrow
@@ -339,6 +348,15 @@ declare global {
         prototype: HTMLPostTabsElement;
         new (): HTMLPostTabsElement;
     };
+    /**
+     * @class PostTag - representing a stencil component
+     */
+    interface HTMLPostTagElement extends Components.PostTag, HTMLStencilElement {
+    }
+    var HTMLPostTagElement: {
+        prototype: HTMLPostTagElement;
+        new (): HTMLPostTagElement;
+    };
     interface HTMLPostTooltipElement extends Components.PostTooltip, HTMLStencilElement {
     }
     var HTMLPostTooltipElement: {
@@ -356,6 +374,7 @@ declare global {
         "post-tab-header": HTMLPostTabHeaderElement;
         "post-tab-panel": HTMLPostTabPanelElement;
         "post-tabs": HTMLPostTabsElement;
+        "post-tag": HTMLPostTagElement;
         "post-tooltip": HTMLPostTooltipElement;
     }
 }
@@ -495,6 +514,15 @@ declare namespace LocalJSX {
          */
         "onTabChange"?: (event: PostTabsCustomEvent<HTMLPostTabPanelElement['name']>) => void;
     }
+    /**
+     * @class PostTag - representing a stencil component
+     */
+    interface PostTag {
+        "color"?: string;
+        "icon"?: number;
+        "showIcon"?: boolean;
+        "size"?: string;
+    }
     interface PostTooltip {
         /**
           * Wheter or not to display a little pointer arrow
@@ -516,6 +544,7 @@ declare namespace LocalJSX {
         "post-tab-header": PostTabHeader;
         "post-tab-panel": PostTabPanel;
         "post-tabs": PostTabs;
+        "post-tag": PostTag;
         "post-tooltip": PostTooltip;
     }
 }
@@ -536,6 +565,10 @@ declare module "@stencil/core" {
             "post-tab-header": LocalJSX.PostTabHeader & JSXBase.HTMLAttributes<HTMLPostTabHeaderElement>;
             "post-tab-panel": LocalJSX.PostTabPanel & JSXBase.HTMLAttributes<HTMLPostTabPanelElement>;
             "post-tabs": LocalJSX.PostTabs & JSXBase.HTMLAttributes<HTMLPostTabsElement>;
+            /**
+             * @class PostTag - representing a stencil component
+             */
+            "post-tag": LocalJSX.PostTag & JSXBase.HTMLAttributes<HTMLPostTagElement>;
             "post-tooltip": LocalJSX.PostTooltip & JSXBase.HTMLAttributes<HTMLPostTooltipElement>;
         }
     }

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -189,12 +189,9 @@ export namespace Components {
          */
         "show": (panelName: string) => Promise<void>;
     }
-    /**
-     * @class PostTag - representing a stencil component
-     */
     interface PostTag {
         "color"?: string;
-        "icon": number;
+        "icon"?: number;
         "showIcon"?: boolean;
         "size"?: string;
     }
@@ -348,9 +345,6 @@ declare global {
         prototype: HTMLPostTabsElement;
         new (): HTMLPostTabsElement;
     };
-    /**
-     * @class PostTag - representing a stencil component
-     */
     interface HTMLPostTagElement extends Components.PostTag, HTMLStencilElement {
     }
     var HTMLPostTagElement: {
@@ -514,9 +508,6 @@ declare namespace LocalJSX {
          */
         "onTabChange"?: (event: PostTabsCustomEvent<HTMLPostTabPanelElement['name']>) => void;
     }
-    /**
-     * @class PostTag - representing a stencil component
-     */
     interface PostTag {
         "color"?: string;
         "icon"?: number;
@@ -565,9 +556,6 @@ declare module "@stencil/core" {
             "post-tab-header": LocalJSX.PostTabHeader & JSXBase.HTMLAttributes<HTMLPostTabHeaderElement>;
             "post-tab-panel": LocalJSX.PostTabPanel & JSXBase.HTMLAttributes<HTMLPostTabPanelElement>;
             "post-tabs": LocalJSX.PostTabs & JSXBase.HTMLAttributes<HTMLPostTabsElement>;
-            /**
-             * @class PostTag - representing a stencil component
-             */
             "post-tag": LocalJSX.PostTag & JSXBase.HTMLAttributes<HTMLPostTagElement>;
             "post-tooltip": LocalJSX.PostTooltip & JSXBase.HTMLAttributes<HTMLPostTooltipElement>;
         }

--- a/packages/components/src/components/post-icon/readme.md
+++ b/packages/components/src/components/post-icon/readme.md
@@ -23,11 +23,13 @@ some content
 ### Used by
 
  - [post-alert](../post-alert)
+ - [post-tag](../post-tag)
 
 ### Graph
 ```mermaid
 graph TD;
   post-alert --> post-icon
+  post-tag --> post-icon
   style post-icon fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/components/src/components/post-tag/post-tag.scss
+++ b/packages/components/src/components/post-tag/post-tag.scss
@@ -1,1 +1,5 @@
 @use '@swisspost/design-system-styles/components/tag';
+
+* {
+  box-sizing: border-box;
+}

--- a/packages/components/src/components/post-tag/post-tag.scss
+++ b/packages/components/src/components/post-tag/post-tag.scss
@@ -1,0 +1,1 @@
+@use '@swisspost/design-system-styles/components/tag';

--- a/packages/components/src/components/post-tag/post-tag.tsx
+++ b/packages/components/src/components/post-tag/post-tag.tsx
@@ -1,0 +1,34 @@
+import { Component, Element, h, Host, Prop } from '@stencil/core';
+import { version } from '../../../package.json';
+
+/**
+ * @class PostTag - representing a stencil component
+ */
+@Component({
+  tag: 'post-tag',
+  styleUrl: 'post-tag.scss',
+  shadow: true,
+})
+export class PostTag {
+  @Element() host: HTMLPostTagElement;
+
+  @Prop() readonly color?: string = 'color';
+  @Prop() readonly size?: string = 'size';
+  @Prop() readonly showIcon?: boolean = true;
+  @Prop() readonly icon: number;
+
+  render() {
+    const icon = `${this.icon}`;
+
+    return (
+      <Host data-version={version}>
+        <div class="tag">
+          {this.showIcon ? <post-icon name={icon}></post-icon> : ''}
+          <div class="tag-content">
+            <slot></slot>
+          </div>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/components/src/components/post-tag/post-tag.tsx
+++ b/packages/components/src/components/post-tag/post-tag.tsx
@@ -1,9 +1,6 @@
-import { Component, Element, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop, State } from '@stencil/core';
 import { version } from '../../../package.json';
 
-/**
- * @class PostTag - representing a stencil component
- */
 @Component({
   tag: 'post-tag',
   styleUrl: 'post-tag.scss',
@@ -12,19 +9,25 @@ import { version } from '../../../package.json';
 export class PostTag {
   @Element() host: HTMLPostTagElement;
 
-  @Prop() readonly color?: string = 'color';
-  @Prop() readonly size?: string = 'size';
+  @State() classes: string;
+
+  @Prop() readonly color?: string = 'gray';
+  @Prop() readonly size?: string = 'post-tag';
   @Prop() readonly showIcon?: boolean = true;
-  @Prop() readonly icon: number;
+  @Prop() readonly icon?: number = 1001;
+
+  componentWillRender() {
+    this.classes = `${this.size} bg-${this.color}`;
+  }
 
   render() {
     const icon = `${this.icon}`;
 
     return (
       <Host data-version={version}>
-        <div class="tag">
-          {this.showIcon ? <post-icon name={icon}></post-icon> : ''}
-          <div class="tag-content">
+        <div class={this.classes}>
+          {this.showIcon ? <post-icon name={icon} class="post-tag-icon"></post-icon> : ''}
+          <div>
             <slot></slot>
           </div>
         </div>

--- a/packages/components/src/components/post-tag/readme.md
+++ b/packages/components/src/components/post-tag/readme.md
@@ -1,0 +1,33 @@
+# post-tag
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property   | Attribute   | Description | Type      | Default     |
+| ---------- | ----------- | ----------- | --------- | ----------- |
+| `color`    | `color`     |             | `string`  | `'color'`   |
+| `icon`     | `icon`      |             | `number`  | `undefined` |
+| `showIcon` | `show-icon` |             | `boolean` | `true`      |
+| `size`     | `size`      |             | `string`  | `'size'`    |
+
+
+## Dependencies
+
+### Depends on
+
+- [post-icon](../post-icon)
+
+### Graph
+```mermaid
+graph TD;
+  post-tag --> post-icon
+  style post-tag fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/components/src/components/post-tag/readme.md
+++ b/packages/components/src/components/post-tag/readme.md
@@ -1,18 +1,16 @@
-# post-tag
-
-
+# tag
 
 <!-- Auto Generated Below -->
 
 
 ## Properties
 
-| Property   | Attribute   | Description | Type      | Default     |
-| ---------- | ----------- | ----------- | --------- | ----------- |
-| `color`    | `color`     |             | `string`  | `'color'`   |
-| `icon`     | `icon`      |             | `number`  | `undefined` |
-| `showIcon` | `show-icon` |             | `boolean` | `true`      |
-| `size`     | `size`      |             | `string`  | `'size'`    |
+| Property   | Attribute   | Description | Type      | Default      |
+| ---------- | ----------- | ----------- | --------- | ------------ |
+| `color`    | `color`     |             | `string`  | `'gray'`     |
+| `icon`     | `icon`      |             | `number`  | `1001`       |
+| `showIcon` | `show-icon` |             | `boolean` | `true`       |
+| `size`     | `size`      |             | `string`  | `'post-tag'` |
 
 
 ## Dependencies

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -11,3 +11,4 @@ export { PostTabs } from './components/post-tabs/post-tabs';
 export { PostTabHeader } from './components/post-tab-header/post-tab-header';
 export { PostTabPanel } from './components/post-tab-panel/post-tab-panel';
 export { PostTooltip } from './components/post-tooltip/post-tooltip';
+export { PostTag } from './components/post-tag/post-tag';

--- a/packages/documentation/src/stories/components/tag/tag.docs.mdx
+++ b/packages/documentation/src/stories/components/tag/tag.docs.mdx
@@ -1,0 +1,15 @@
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import * as TagStories from './tag.stories';
+
+<Meta of={TagStories}/>
+
+# Tag
+
+<div className="lead">
+  Work in Progress
+</div>
+
+<Canvas sourceState="shown" of={TagStories.Default}/>
+<Controls of={TagStories.Default}/>
+
+Placeholder

--- a/packages/documentation/src/stories/components/tag/tag.stories.ts
+++ b/packages/documentation/src/stories/components/tag/tag.stories.ts
@@ -1,0 +1,49 @@
+import type { Args, Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit/static-html.js';
+import { BADGE } from '../../../../.storybook/constants';
+
+const meta: Meta = {
+  title: 'Components/Tag',
+  render: renderTag,
+  parameters: {
+    badges: [BADGE.NEEDS_REVISION],
+  },
+  args: {
+    icon: 1001,
+    content: 'letter',
+  },
+  argTypes: {
+    icon: {
+      name: 'Icon',
+      description: 'Number of the icon that is diplayed alongside the text',
+      control: {
+        type: 'number',
+      },
+      table: {
+        category: 'Content',
+      },
+    },
+    content: {
+      name: 'Content',
+      description: 'Content of Tag',
+      control: {
+        type: 'text',
+      },
+      table: {
+        category: 'Content',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+function renderTag(args: Args) {
+  return html`
+    <post-tag icon=${args.icon}>${args.content}</post-tag>
+  `;
+}
+
+export const Default: Story = {};

--- a/packages/documentation/src/stories/components/tag/tag.stories.ts
+++ b/packages/documentation/src/stories/components/tag/tag.stories.ts
@@ -10,7 +10,9 @@ const meta: Meta = {
   },
   args: {
     icon: 1001,
-    content: 'letter',
+    content: 'Tag',
+    size: 'tag',
+    color: 'gray',
   },
   argTypes: {
     icon: {
@@ -33,6 +35,41 @@ const meta: Meta = {
         category: 'Content',
       },
     },
+    size: {
+      name: 'Size',
+      description: 'Number of the icon that is diplayed alongside the text',
+      control: {
+        type: 'select',
+        labels: {
+          'post-tag': 'Large',
+          'post-tag-sm': 'Small',
+        },
+      },
+      options: ['post-tag', 'post-tag-sm'],
+      table: {
+        category: 'Content',
+      },
+    },
+    color: {
+      name: 'Color',
+      description: 'The background color of the tag',
+      control: {
+        type: 'select',
+        labels: {
+          gray: 'Default',
+          white: 'White',
+          info: 'Info',
+          success: 'Success',
+          warning: 'Warning',
+          danger: 'Danger',
+          yellow: 'Yellow',
+        },
+      },
+      options: ['gray', 'white', 'info', 'success', 'warning', 'danger', 'yellow'],
+      table: {
+        category: 'Content',
+      },
+    },
   },
 };
 
@@ -41,8 +78,14 @@ export default meta;
 type Story = StoryObj;
 
 function renderTag(args: Args) {
+  /*   return html`
+    <post-tag icon=${args.icon} color=${args.color} size=${args.size}>${args.content}</post-tag>
+  `; */
   return html`
-    <post-tag icon=${args.icon}>${args.content}</post-tag>
+    <div class="${args.size} bg-${args.color}">
+      <post-icon name="${args.icon}" class="tag-icon"></post-icon>
+      <span>${args.content}</span>
+    </div>
   `;
 }
 

--- a/packages/styles/src/components/_index.scss
+++ b/packages/styles/src/components/_index.scss
@@ -40,6 +40,7 @@
 @use 'transitions';
 @use 'type';
 @use 'utilities';
+@use 'tag';
 
 // Imports depending on source order to override bootstrap styles
 @use 'datepicker';

--- a/packages/styles/src/components/tag.scss
+++ b/packages/styles/src/components/tag.scss
@@ -1,19 +1,43 @@
 @forward './../variables/options';
+@forward './utilities';
 
-@use './../variables/icons' as vars;
-@use './../variables/color';
+@use './../variables/color' as col;
 @use './../variables/spacing' as spacing;
 
-.tag {
+.tag,
+.tag-sm {
   display: inline-flex;
   justify-content: flex-start;
+  justify-items: center;
   align-items: center;
   gap: spacing.$size-micro;
   padding: 0 spacing.$size-mini;
-  border: 4px solid black;
-  font-size: spacing.$size-mini;
+  font-size: spacing.$size-regular;
+  border: spacing.$size-hair solid transparent;
+  border-radius: spacing.$size-micro;
   line-height: inherit;
   text-align: center;
   vertical-align: baseline;
   max-width: 296px;
+  &.bg-white {
+    border-color: col.$black;
+  }
+}
+
+.tag {
+  height: spacing.$size-big;
+
+  .tagIcon {
+    height: spacing.$size-small-large;
+    width: spacing.$size-small-large;
+  }
+}
+
+.tag-sm {
+  height: spacing.$size-large;
+
+  .tag-icon {
+    height: spacing.$size-regular;
+    width: spacing.$size-regular;
+  }
 }

--- a/packages/styles/src/components/tag.scss
+++ b/packages/styles/src/components/tag.scss
@@ -1,0 +1,19 @@
+@forward './../variables/options';
+
+@use './../variables/icons' as vars;
+@use './../variables/color';
+@use './../variables/spacing' as spacing;
+
+.tag {
+  display: inline-flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: spacing.$size-micro;
+  padding: 0 spacing.$size-mini;
+  border: 4px solid black;
+  font-size: spacing.$size-mini;
+  line-height: inherit;
+  text-align: center;
+  vertical-align: baseline;
+  max-width: 296px;
+}

--- a/packages/styles/src/components/tag.scss
+++ b/packages/styles/src/components/tag.scss
@@ -19,6 +19,7 @@
   text-align: center;
   vertical-align: baseline;
   max-width: 296px;
+
   &.bg-white {
     border-color: col.$black;
   }
@@ -27,7 +28,7 @@
 .tag {
   height: spacing.$size-big;
 
-  .tagIcon {
+  .tag-icon {
     height: spacing.$size-small-large;
     width: spacing.$size-small-large;
   }


### PR DESCRIPTION
The code examples also use a class called .tag and when I named my class .tag as well it overwrote the styles for the code examples.