### PR TITLE
fix(deploy): change  package name in filter

### DIFF
--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -47,4 +47,4 @@ jobs:
           folder: ${{ steps.build.outputs.folder }}
           comment_token: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
           comment_author: swisspost-bot
-          package_name: demo
+          package_name:  @swisspost/design-system-demo

--- a/.github/workflows/deploy-documentation.yaml
+++ b/.github/workflows/deploy-documentation.yaml
@@ -42,4 +42,4 @@ jobs:
           folder: ${{ steps.build.outputs.folder }}
           comment_token: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
           comment_author: swisspost-bot
-          package_name: documentation
+          package_name:  @swisspost/design-system-documentation

--- a/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
+++ b/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
@@ -6,6 +6,8 @@ import SampleCustomTrigger from './accordion-custom-trigger.sample?raw';
 
 # Accordion
 
+This is a nonsentical change to test if netifly v16 works
+
 <p className="lead">Toggle the visibility of a set of related content in your project.</p>
 
 The `<post-accordion>` is a container for `<post-collapsible>` components.

--- a/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
+++ b/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
@@ -6,8 +6,6 @@ import SampleCustomTrigger from './accordion-custom-trigger.sample?raw';
 
 # Accordion
 
-This is a nonsentical change to test if netifly v16 works
-
 <p className="lead">Toggle the visibility of a set of related content in your project.</p>
 
 The `<post-accordion>` is a container for `<post-collapsible>` components.


### PR DESCRIPTION
![image](https://github.com/swisspost/design-system/assets/141234680/b80dfb8c-184b-4647-b836-2a9edf3837f1)

It seems that we need to use  @swisspost/design-system-demo and  @swisspost/design-system-documentation for it to work