### PR TITLE
feat(internet-header): focus on klp-widget links obscured fix

### DIFF
--- a/packages/internet-header/src/components/post-klp-login-widget/widget-styles.scss
+++ b/packages/internet-header/src/components/post-klp-login-widget/widget-styles.scss
@@ -653,3 +653,7 @@ li.name-and-surname span.infoHidden {
   color: black;
   font-weight: bold;
 }
+
+a:is(:focus-visible, :focus-within, .pretend-focus) {
+  z-index: 2;
+}


### PR DESCRIPTION
Since the issue is not easily reproducible, because you would have to be logged in, I just fixed it in the dev tools on the live site and put it in the code.