### PR TITLE
chore(*): Remove rel=noopener attribute which is not needed anymore

### DIFF
--- a/packages/demo/src/app/bootstrap/components/accordion/accordion-demo-page/accordion-demo-page.component.html
+++ b/packages/demo/src/app/bootstrap/components/accordion/accordion-demo-page/accordion-demo-page.component.html
@@ -9,7 +9,6 @@
     For a similar behavior, check out our new
     <a
       href="https://next.design-system.post.ch/?path=/docs/components-accordion--docs"
-      rel="noopener"
       target="_blank"
     >
       post-accordion component

--- a/packages/demo/src/app/bootstrap/components/alert/toast-demo/toast-demo.component.html
+++ b/packages/demo/src/app/bootstrap/components/alert/toast-demo/toast-demo.component.html
@@ -70,17 +70,11 @@
   <a
     href="https://www.npmjs.com/package/ngx-toastr"
     target="_blank"
-    rel="noopener"
     class="btn btn-sm btn-primary me-2"
   >
     ngx-toastr Documentation
   </a>
-  <a
-    href="https://ngx-toastr.vercel.app/"
-    target="_blank"
-    rel="noopener"
-    class="btn btn-sm btn-primary"
-  >
+  <a href="https://ngx-toastr.vercel.app/" target="_blank" class="btn btn-sm btn-primary">
     ngx-toastr Demo
   </a>
 </div>

--- a/packages/demo/src/app/common/dependency-link/dependency-link.component.html
+++ b/packages/demo/src/app/common/dependency-link/dependency-link.component.html
@@ -25,7 +25,7 @@
 </ng-template>
 
 <ng-template #documentationButton let-label="label" let-url="url">
-  <a [href]="url" class="btn btn-primary btn-sm btn-animated" rel="noopener" target="_blank">
+  <a [href]="url" class="btn btn-primary btn-sm btn-animated" target="_blank">
     <span>{{ label }} Documentation</span>
   </a>
 </ng-template>

--- a/packages/demo/src/app/common/footer/footer.component.html
+++ b/packages/demo/src/app/common/footer/footer.component.html
@@ -19,7 +19,6 @@
         <a
           href="https://github.com/swisspost/design-system/issues"
           target="_blank"
-          rel="noopener"
           class="btn-primary btn btn-rg btn-animated"
         >
           <span>Submit an issue</span>
@@ -31,7 +30,5 @@
 
 <footer class="container d-flex justify-content-between py-regular">
   <span class="bold">&copy; 2024 Swiss Post Ltd.</span>
-  <a href="https://github.com/swisspost/design-system" target="_blank" rel="noopener">
-    Improve this page
-  </a>
+  <a href="https://github.com/swisspost/design-system" target="_blank">Improve this page</a>
 </footer>

--- a/packages/demo/src/app/home/home.component.html
+++ b/packages/demo/src/app/home/home.component.html
@@ -61,12 +61,7 @@
         version gives you a much better overview of the components and their possible states.
       </p>
       <div class="mt-3">
-        <a
-          href="https://next.design-system.post.ch"
-          rel="noopener"
-          target="_blank"
-          class="btn btn-primary"
-        >
+        <a href="https://next.design-system.post.ch" target="_blank" class="btn btn-primary">
           🚀 Take me to the future!
         </a>
       </div>
@@ -77,7 +72,6 @@
         If you have any inquiries about this change, feel free to contact us via our
         <a
           href="https://teams.microsoft.com/l/channel/19%3ae7fa68fb13eb40b4bf4604edea5f4b3e%40thread.tacv2/%25F0%259F%259A%2591%2520Support?groupId=123c7c9e-052a-40e6-98d3-6cc6d46bad0a&tenantId=3ae7c479-0cf1-47f4-8f84-929f364eff67"
-          rel="noopener"
           target="_blank"
         >
           Support channel
@@ -243,28 +237,19 @@
             <li *ngIf="isMigratingAngular">
               <p>
                 Use
-                <a href="https://update.angular.io/" target="_blank" rel="noopener">
-                  https://update.angular.io/
-                </a>
+                <a href="https://update.angular.io/" target="_blank">https://update.angular.io/</a>
                 to update Angular to version 16
               </p>
             </li>
             <li>
               <p>
                 Update Bootstrap to version
-                <a
-                  href="https://getbootstrap.com/docs/5.3/migration"
-                  target="_blank"
-                  rel="noopener"
-                >
-                  5.3.x
-                </a>
+                <a href="https://getbootstrap.com/docs/5.3/migration" target="_blank">5.3.x</a>
                 <ng-container *ngIf="isMigratingAngular">
                   and ng-bootstrap to version
                   <a
                     href="https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CHANGELOG.md#1500-2023-05-25"
                     target="_blank"
-                    rel="noopener"
                   >
                     15.x.x
                   </a>
@@ -441,9 +426,7 @@
           <ol *ngIf="isMigratingAngular">
             <li>
               If your Angular version is lower than 13, use
-              <a href="https://update.angular.io/" target="_blank" rel="noopener">
-                https://update.angular.io/
-              </a>
+              <a href="https://update.angular.io/" target="_blank">https://update.angular.io/</a>
               to update Angular step by step to version 13.
             </li>
             <li>
@@ -457,15 +440,12 @@
 
           <ng-template #bootstrapInstructions>
             Update Bootstrap to version
-            <a href="https://getbootstrap.com/docs/5.1/migration" target="_blank" rel="noopener">
-              5.1.x
-            </a>
+            <a href="https://getbootstrap.com/docs/5.1/migration" target="_blank">5.1.x</a>
             <ng-container *ngIf="isMigratingAngular">
               and ng-bootstrap to version
               <a
                 href="https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CHANGELOG.md#1400-2022-12-07"
                 target="_blank"
-                rel="noopener"
               >
                 12.x.x
               </a>
@@ -2583,7 +2563,6 @@
             <li class="link-list-item">
               <a
                 target="_blank"
-                rel="noopener"
                 [href]="'//getbootstrap.com/docs/' + getVersion(bootstrapVersion, 'Mm')"
               >
                 <span>Bootstrap Documentation</span>
@@ -2592,7 +2571,6 @@
             <li class="link-list-item">
               <a
                 target="_blank"
-                rel="noopener"
                 [href]="'//v' + getVersion(angularVersion, 'M') + '.angular.io/docs'"
               >
                 <span>Angular Docs</span>
@@ -2600,13 +2578,13 @@
             </li>
             <li class="link-list-item">
               <!-- exact link is not possible, because the latest url is different from the previews -->
-              <a target="_blank" rel="noopener" href="https://ng-bootstrap.github.io/#/home">
+              <a target="_blank" href="https://ng-bootstrap.github.io/#/home">
                 <span>ngBootstrap Docs</span>
               </a>
             </li>
             <li class="link-list-item">
               <!-- exact link is not possible, because no version urls available -->
-              <a target="_blank" rel="noopener" href="https://fonts.post.ch/frutigerneueforpost/#/">
+              <a target="_blank" href="https://fonts.post.ch/frutigerneueforpost/#/">
                 <span>Frutiger Neue For Post</span>
               </a>
             </li>

--- a/packages/demo/src/app/ng-bootstrap/components/timepicker/timepicker-demo/timepicker-demo.component.html
+++ b/packages/demo/src/app/ng-bootstrap/components/timepicker/timepicker-demo/timepicker-demo.component.html
@@ -18,12 +18,7 @@
   To use one of these predefined sizes, simply set the
   <code>[size]</code>
   entry as defined in the
-  <a
-    href="https://ng-bootstrap.github.io/#/components/timepicker/api"
-    target="_blank"
-    rel="noopener"
-    rel="noopener"
-  >
+  <a href="https://ng-bootstrap.github.io/#/components/timepicker/api" target="_blank">
     component api
   </a>
   .

--- a/packages/demo/src/app/post-sample/components/datatable/datatable-demo-page/datatable-demo-page.component.html
+++ b/packages/demo/src/app/post-sample/components/datatable/datatable-demo-page/datatable-demo-page.component.html
@@ -4,7 +4,6 @@
   <a
     href="https://swimlane.gitbook.io/ngx-datatable/"
     target="_blank"
-    rel="noopener"
     class="btn btn-primary btn-sm btn-animated"
   >
     <span>Ngx-datatable documentation</span>
@@ -13,7 +12,6 @@
   <a
     href="http://swimlane.github.io/ngx-datatable/"
     target="_blank"
-    rel="noopener"
     class="btn btn-primary btn-sm btn-animated"
   >
     <span>Ngx-datatable demos</span>

--- a/packages/documentation/.storybook/blocks/footer.tsx
+++ b/packages/documentation/.storybook/blocks/footer.tsx
@@ -39,7 +39,7 @@ export default (params: { pathToStoryFile?: String }) => (
   <>
     <div className="container mt-huge font-size-18 text-end">
       {params.pathToStoryFile && (
-        <a href={getGitHubUrl(params.pathToStoryFile)} target="_blank" rel="noopener">
+        <a href={getGitHubUrl(params.pathToStoryFile)} target="_blank">
           Edit this page on GitHub
         </a>
       )}
@@ -73,7 +73,6 @@ export default (params: { pathToStoryFile?: String }) => (
                 className="btn-primary btn btn-rg btn-animated"
                 href="https://github.com/swisspost/design-system/issues"
                 target="_blank"
-                rel="noopener"
               >
                 <span>Submit an issue</span>
               </a>
@@ -88,7 +87,6 @@ export default (params: { pathToStoryFile?: String }) => (
           <a
             href="https://www.post.ch/en/pages/footer/data-protection-and-disclaimer"
             target="_blank"
-            rel="noopener"
           >
             Data protection and disclaimer
           </a>

--- a/packages/documentation/src/shared/nb-bootstrap/ngb-component-alert.mdx
+++ b/packages/documentation/src/shared/nb-bootstrap/ngb-component-alert.mdx
@@ -1,5 +1,5 @@
 <div className="alert alert-info mb-bigger-big">
   <p className="alert-heading">The {props.component} is an ng-bootstrap component.</p>
   <p>This documentation gives only the specifics for a usage within Post project.<br/>
-    Read the complete information about the component's configuration in <a href={`https://ng-bootstrap.github.io/#/components/${props.component}`} target="_blank" rel="nofollow noopener noreferrer">ng-bootstrap {props.component} documentation</a>.</p>
+    Read the complete information about the component's configuration in <a href={`https://ng-bootstrap.github.io/#/components/${props.component}`} target="_blank" rel="nofollow">ng-bootstrap {props.component} documentation</a>.</p>
 </div>

--- a/packages/documentation/src/shared/nb-bootstrap/ngb-component-demo-link.mdx
+++ b/packages/documentation/src/shared/nb-bootstrap/ngb-component-demo-link.mdx
@@ -2,7 +2,7 @@
   className="btn btn-rg btn-secondary btn-animated"
   href={`https://archive.design-system.post.ch/#/ng-bootstrap-samples/${props.component}`}
   target="_blank"
-  rel="nofollow noopener noreferrer"
+  rel="nofollow"
 >
   <span>See archived documentation</span>
 </a>

--- a/packages/documentation/src/stories/components/alert/alert.docs.mdx
+++ b/packages/documentation/src/stories/components/alert/alert.docs.mdx
@@ -89,7 +89,7 @@ Alerts are intended to attract the user's attention without interrupting their o
 
       By default all children of the `<post-alert/>` are placed in the body.
       Use the `heading` slot to place a child in the heading, and the `actions` slot for action buttons.
-      Learn more about <a rel="noopener" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots#adding_flexibility_with_slots">slots in the mdn web docs</a>.
+      Learn more about <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots#adding_flexibility_with_slots">slots in the mdn web docs</a>.
 
       <Canvas of={PostAlertStories.Contents} />
 

--- a/packages/documentation/src/stories/components/internet-header/getting-started.docs.mdx
+++ b/packages/documentation/src/stories/components/internet-header/getting-started.docs.mdx
@@ -1,5 +1,5 @@
 import { Meta, Source } from '@storybook/blocks';
-import { PostTabs, PostTabHeader, PostTabPanel } from '@swisspost/design-system-components-react';
+import { PostTabHeader, PostTabPanel, PostTabs } from '@swisspost/design-system-components-react';
 import SampleFrameworks from './internet-header-frameworks.sample.html?raw';
 import SampleLazyLoaded from './internet-header-lazy-loaded.sample.js?raw';
 import SampleBareComponent from './internet-header-bare-component.sample.js?raw';
@@ -86,7 +86,6 @@ If you're working on a new project, you probably need a new configuration. Pleas
   className="mb-small-r btn-primary btn"
   href="mailto:digitalconsulting@post.ch"
   target="_blank"
-  rel="noopener"
 >Contact Post Portal Team <post-icon name="1001" className="fs-large" /></a>
 
 Not every Online Service has configurations for all environments.

--- a/packages/documentation/src/stories/home.blocks.tsx
+++ b/packages/documentation/src/stories/home.blocks.tsx
@@ -15,7 +15,7 @@ interface IFeatureProps {
 export function Tile(props: ITileProps) {
   const isLink = props.href !== undefined;
   const Tag = isLink ? 'a' : 'div';
-  const attributes = isLink ? { href: props.href, target: '_blank', rel: 'noopener' } : null;
+  const attributes = isLink ? { href: props.href, target: '_blank' } : null;
 
   return (
     <Tag className="tile" {...attributes}>

--- a/packages/documentation/src/stories/home.docs.mdx
+++ b/packages/documentation/src/stories/home.docs.mdx
@@ -23,7 +23,6 @@ import './home.styles.scss';
     <a
       href="https://www.experience-hub.ch/document/2803"
       target="_blank"
-      rel="noopener"
       className="btn btn-secondary"
     >
       <span>Experience Hub<sup>1</sup></span>
@@ -31,7 +30,6 @@ import './home.styles.scss';
     <a
       href="https://www.figma.com/files/1052961410179009444/project/45002065/Web"
       target="_blank"
-      rel="noopener"
       className="btn btn-secondary"
     >
       <span>Figma<sup>2</sup></span>
@@ -39,7 +37,6 @@ import './home.styles.scss';
     <a
       href="https://fonts.post.ch/frutigerneueforpost/#/"
       target="_blank"
-      rel="noopener"
       className="btn btn-secondary"
     >
       <span>Frutiger Neue For Post</span>
@@ -47,7 +44,6 @@ import './home.styles.scss';
     <a
       href="https://github.com/swisspost/design-system"
       target="_blank"
-      rel="noopener"
       className="btn btn-secondary"
     >
       <span>GitHub</span>
@@ -78,7 +74,7 @@ import './home.styles.scss';
     </div>
     <div className="col-md-4">
       <Feature icon="2136" title="Accessible">
-        <p>Following the <a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noopener">WCAG 2.1</a> guidelines</p>
+        <p>Following the <a href="https://www.w3.org/TR/WCAG21/" target="_blank">WCAG 2.1</a> guidelines</p>
       </Feature>
     </div>
     <div className="col-md-4">
@@ -88,7 +84,7 @@ import './home.styles.scss';
     </div>
     <div className="col-md-4">
       <Feature icon="2444" title="Open Source">
-        <p>Published on <a href="https://github.com/swisspost/design-system" target="_blank" rel="noopener">GitHub</a> under the <a href="https://github.com/swisspost/design-system/blob/main/LICENSE" target="_blank" rel="noopener">Apache 2.0 license</a></p>
+        <p>Published on <a href="https://github.com/swisspost/design-system" target="_blank">GitHub</a> under the <a href="https://github.com/swisspost/design-system/blob/main/LICENSE" target="_blank">Apache 2.0 license</a></p>
       </Feature>
     </div>
   </div>


### PR DESCRIPTION
The security issue with target="_blank" has been resolved since at least 2020, see : https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#browser_compatibility