### PR TITLE
chore(e2e): Fix Cypress issue with xvfb

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -34,6 +34,12 @@ jobs:
       - name: Install & build dependencies
         run: pnpm bootstrap
 
+      - name: Prepare Cypress – Spawn Xvfb server
+        run: Xvfb :99 &
+
+      - name: Prepare Cypress – Share Xvfb server as environment variable
+        run: export DISPLAY=:99
+
       - name: Cypress info
         run: pnpm --filter design-system-documentation exec cypress info
 


### PR DESCRIPTION
This is the recommended way to run cypress in parallel: https://docs.cypress.io/guides/continuous-integration/introduction#Xvfb

This was tested successfully in https://github.com/swisspost/design-system/actions/runs/7889393329/job/21529150647?pr=2552