### PR TITLE
chore(e2e): Fix Cypress issue with xvfb 2

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -46,6 +46,9 @@ jobs:
       - name: Run tests
         run: pnpm e2e:ci
 
+      - name: Post Cypress – Stop Xvfb server
+        run: pkill Xvfb
+
       - name: Upload screenshots
         uses: actions/upload-artifact@v4.3.0
         if: failure()


### PR DESCRIPTION
Follows https://github.com/swisspost/design-system/pull/2637

In the recommandation, we should also kill the xvfb server after using it: https://docs.cypress.io/guides/continuous-integration/introduction#Xvfb
I thought that it didn't make sense as it's a virtual machine, but perhaps it makes sense, especially when we re-trigger a failed workflow. 

In this PR (where it works the first time I changed the worfklow) after a second run I got the following error: 
```
(EE) Server is already active for display 100
```
https://github.com/swisspost/design-system/actions/runs/7899925921/job/21561150669
It looks like cypress tried to run another server on another port (100 instead of 99) so it might confirm that it's needed. At least next run works with it: https://github.com/swisspost/design-system/actions/runs/7900427399