### PR TITLE
chore(e2e): Fix Cypress issue with xvfb 3

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -34,20 +34,11 @@ jobs:
       - name: Install & build dependencies
         run: pnpm bootstrap
 
-      - name: Prepare Cypress – Spawn Xvfb server
-        run: Xvfb :99 &
-
-      - name: Prepare Cypress – Share Xvfb server as environment variable
-        run: export DISPLAY=:99
-
       - name: Cypress info
         run: pnpm --filter design-system-documentation exec cypress info
 
       - name: Run tests
         run: pnpm e2e:ci
-
-      - name: Post Cypress – Stop Xvfb server
-        run: pkill Xvfb
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4.3.0

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "pnpm -r test",
     "unit": "pnpm -r unit",
     "e2e": "start-server-and-test docs:headless 9001 'pnpm -r --stream e2e'",
-    "e2e:ci": "start-server-and-test docs:headless 9001 'pnpm --filter \"...[origin/main]\" --stream e2e'",
+    "e2e:ci": "start-server-and-test docs:headless 9001 'pnpm --filter \"...[origin/main]\" --stream e2e:ci'",
     "snapshots": "start-server-and-test 'pnpm docs:headless' 9001 'pnpm --filter design-system-documentation snapshots'",
     "demo": "pnpm demo:start",
     "demo:start": "pnpm --filter design-system-demo... --parallel --stream start",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,7 +32,7 @@
     "unit": "stencil test --spec",
     "unit:watch": "stencil test --spec --watchAll --silent",
     "e2e": "cypress run",
-    "e2e:ci": "&& xvfb-run -a cypress run",
+    "e2e:ci": "xvfb-run -a cypress run",
     "e2e:watch": "cypress open",
     "generate": "stencil generate",
     "lint": "eslint src/**/*{.ts,.tsx}"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
     "unit": "stencil test --spec",
     "unit:watch": "stencil test --spec --watchAll --silent",
     "e2e": "cypress run",
+    "e2e:ci": "&& xvfb-run -a cypress run",
     "e2e:watch": "cypress open",
     "generate": "stencil generate",
     "lint": "eslint src/**/*{.ts,.tsx}"

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -21,7 +21,7 @@
     "build": "pnpm clean && pnpm prebuild:managerui --style=compressed --no-source-map & storybook build --quiet --docs",
     "clean": "rimraf storybook-static public/manager",
     "e2e": "cypress run",
-    "e2e:ci": "&& xvfb-run -a cypress run",
+    "e2e:ci": "xvfb-run -a cypress run",
     "e2e:watch": "cypress open",
     "snapshots": "percy exec -- cypress run --config-file ./cypress.snapshot.config.js --record --key 0995e768-43ec-42bd-a127-ff944a2ad8c9"
   },

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -21,6 +21,7 @@
     "build": "pnpm clean && pnpm prebuild:managerui --style=compressed --no-source-map & storybook build --quiet --docs",
     "clean": "rimraf storybook-static public/manager",
     "e2e": "cypress run",
+    "e2e:ci": "&& xvfb-run -a cypress run",
     "e2e:watch": "cypress open",
     "snapshots": "percy exec -- cypress run --config-file ./cypress.snapshot.config.js --record --key 0995e768-43ec-42bd-a127-ff944a2ad8c9"
   },

--- a/packages/internet-header/package.json
+++ b/packages/internet-header/package.json
@@ -35,7 +35,7 @@
     "unit": "jest",
     "unit:watch": "jest --watch",
     "e2e": "cypress run",
-    "e2e:ci": "&& xvfb-run -a cypress run",
+    "e2e:ci": "xvfb-run -a cypress run",
     "e2e:watch": "cypress open",
     "lint": "eslint src/**/*{.ts,.tsx}",
     "lint:fix": "eslint src/**/*{.ts,.tsx} --fix",

--- a/packages/internet-header/package.json
+++ b/packages/internet-header/package.json
@@ -35,6 +35,7 @@
     "unit": "jest",
     "unit:watch": "jest --watch",
     "e2e": "cypress run",
+    "e2e:ci": "&& xvfb-run -a cypress run",
     "e2e:watch": "cypress open",
     "lint": "eslint src/**/*{.ts,.tsx}",
     "lint:fix": "eslint src/**/*{.ts,.tsx} --fix",


### PR DESCRIPTION
Another day, another trial to try to fix issue with xvfb. It appears again in https://github.com/swisspost/design-system/pull/2657 and with this new way it seems to fix it (but for how long)? 

This time instead of reusing the same server we spawn a new server if the port is not available. Using `xvfb-run` with -a makes it automatically use the next free server number. Source: https://github.com/cypress-io/xvfb/issues/98#issuecomment-557170579