### PR TITLE
chore: remove npm-run-all2

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,7 +61,6 @@
     "cypress-storybook": "0.5.1",
     "eslint": "8.56.0",
     "eslint-plugin-react": "7.33.2",
-    "npm-run-all2": "5.0.2",
     "rimraf": "5.0.5",
     "sass": "1.70.0",
     "ts-jest": "29.1.2",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -53,7 +53,6 @@
     "gulp-postcss": "9.1.0",
     "gulp-sass": "5.1.0",
     "jest": "29.7.0",
-    "npm-run-all2": "5.0.2",
     "postcss": "8.4.33",
     "postcss-scss": "4.0.9",
     "prettier": "3.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
       eslint-plugin-react:
         specifier: 7.33.2
         version: 7.33.2(eslint@8.56.0)
-      npm-run-all2:
-        specifier: 5.0.2
-        version: 5.0.2
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -1037,9 +1034,6 @@ importers:
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@18.19.14)
-      npm-run-all2:
-        specifier: 5.0.2
-        version: 5.0.2
       postcss:
         specifier: 8.4.33
         version: 8.4.33
@@ -16776,11 +16770,6 @@ packages:
       map-or-similar: 1.5.0
     dev: true
 
-  /memorystream@0.3.1:
-    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
-    engines: {node: '>= 0.10.0'}
-    dev: true
-
   /meow@13.1.0:
     resolution: {integrity: sha512-o5R/R3Tzxq0PJ3v3qcQJtSvSE9nKOLSAaDuuoMzDVuGTwHdccMWcYomh9Xolng2tjT6O/Y83d+0coVGof6tqmA==}
     engines: {node: '>=18'}
@@ -17496,20 +17485,6 @@ packages:
       - supports-color
     dev: true
 
-  /npm-run-all2@5.0.2:
-    resolution: {integrity: sha512-S2G6FWZ3pNWAAKm2PFSOtEAG/N+XO/kz3+9l6V91IY+Y3XFSt7Lp7DV92KCgEboEW0hRTu0vFaMe4zXDZYaOyA==}
-    engines: {node: '>= 10'}
-    hasBin: true
-    dependencies:
-      ansi-styles: 5.2.0
-      cross-spawn: 7.0.3
-      memorystream: 0.3.1
-      minimatch: 3.1.2
-      pidtree: 0.5.0
-      read-pkg: 5.2.0
-      shell-quote: 1.8.1
-    dev: true
-
   /npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -18208,12 +18183,6 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  /pidtree@0.5.0:
-    resolution: {integrity: sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-    dev: true
 
   /pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}


### PR DESCRIPTION
This does not seem to be used anywhere, thus can be removed.