### PR TITLE
fix(popovercontainer): prevent immediate re-toggle

### DIFF
--- a/.changeset/perfect-grapes-care.md
+++ b/.changeset/perfect-grapes-care.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixes an issue with the post-popover component that stopped working once trigger buttons were removed from the page or new trigger buttons were added to the page asynchronously.

--- a/packages/components/cypress.config.js
+++ b/packages/components/cypress.config.js
@@ -9,7 +9,6 @@ module.exports = defineConfig({
     viewportHeight: 576,
   },
   includeShadowDom: true,
-  chromeWebSecurity: false,
   retries: {
     runMode: 1,
   },

--- a/packages/components/cypress.config.js
+++ b/packages/components/cypress.config.js
@@ -9,6 +9,7 @@ module.exports = defineConfig({
     viewportHeight: 576,
   },
   includeShadowDom: true,
+  chromeWebSecurity: false,
   retries: {
     runMode: 1,
   },

--- a/packages/components/src/components/post-popover/post-popover.tsx
+++ b/packages/components/src/components/post-popover/post-popover.tsx
@@ -14,8 +14,7 @@ const globalToggleHandler = (e: PointerEvent | KeyboardEvent) => {
   const target = e.target as HTMLElement;
   if (!target || !('getAttribute' in target)) return;
   const popoverTarget = target.getAttribute(popoverTargetAttribute);
-  if (!popoverTarget || popoverTarget === '') return;
-  if ('key' in e && e.key !== 'Enter') return;
+  if (!popoverTarget || ('key' in e && e.key !== 'Enter')) return;
   const popover = document.getElementById(popoverTarget) as HTMLPostPopoverElement;
   popover?.toggle(target);
 };

--- a/packages/components/src/components/post-popover/post-popover.tsx
+++ b/packages/components/src/components/post-popover/post-popover.tsx
@@ -33,6 +33,7 @@ const triggerObserver = getAttributeObserver(popoverTargetAttribute, trigger => 
 })
 export class PostPopover {
   private popoverRef: HTMLPostPopovercontainerElement;
+  private localBeforeToggleHandler;
 
   @Element() host: HTMLPostPopoverElement;
 
@@ -53,6 +54,10 @@ export class PostPopover {
   // eslint-disable-next-line @stencil-community/ban-default-true
   @Prop() readonly arrow?: boolean = true;
 
+  constructor() {
+    this.localBeforeToggleHandler = this.beforeToggleHandler.bind(this);
+  }
+
   connectedCallback() {
     // Set up accessibility patcher and event listeners for the first component
     if (popoverInstances === 0) {
@@ -66,6 +71,12 @@ export class PostPopover {
     }
 
     popoverInstances++;
+
+    this.triggers.forEach(trigger => trigger.setAttribute('aria-expanded', 'false'));
+  }
+
+  componentDidLoad() {
+    this.popoverRef.addEventListener('beforetoggle', this.localBeforeToggleHandler);
   }
 
   disconnectedCallback() {
@@ -77,6 +88,9 @@ export class PostPopover {
       window.removeEventListener('keydown', globalToggleHandler);
       triggerObserver.disconnect();
     }
+
+    this.popoverRef.removeEventListener('beforetoggle', this.localBeforeToggleHandler);
+    this.triggers.forEach(trigger => trigger.removeAttribute('aria-expanded'));
   }
 
   /**
@@ -112,6 +126,10 @@ export class PostPopover {
 
   private get triggers() {
     return document.querySelectorAll(`[${popoverTargetAttribute}="${this.host.id}"]`);
+  }
+
+  private beforeToggleHandler() {
+    this.triggers.forEach(trigger => trigger.setAttribute('aria-expanded', 'false'));
   }
 
   render() {

--- a/packages/components/src/components/post-popover/post-popover.tsx
+++ b/packages/components/src/components/post-popover/post-popover.tsx
@@ -1,10 +1,31 @@
 import { Component, Element, h, Host, Method, Prop } from '@stencil/core';
 import { Placement } from '@floating-ui/dom';
 import { version } from '../../../package.json';
+import { getAttributeObserver } from '../../utils/attribute-observer';
 
 /**
  * @slot default - Slot for placing content inside the popover.
  */
+
+let popoverInstances = 0;
+const popoverTargetAttribute = 'data-popover-target';
+
+const globalToggleHandler = (e: PointerEvent | KeyboardEvent) => {
+  const target = e.target as HTMLElement;
+  if (!target || !('getAttribute' in target)) return;
+  const popoverTarget = target.getAttribute(popoverTargetAttribute);
+  if (!popoverTarget || popoverTarget === '') return;
+  if ('key' in e && e.key !== 'Enter') return;
+  // TODO: Check for enter key
+  const popover = document.getElementById(popoverTarget) as HTMLPostPopoverElement;
+  popover?.toggle(target);
+};
+
+// Initialize a mutation observer for patching accessibility features
+const triggerObserver = getAttributeObserver(popoverTargetAttribute, trigger => {
+  const force = trigger.hasAttribute(popoverTargetAttribute);
+  trigger.setAttribute('aria-expanded', force ? 'false' : null);
+});
 
 @Component({
   tag: 'post-popover',
@@ -13,10 +34,6 @@ import { version } from '../../../package.json';
 })
 export class PostPopover {
   private popoverRef: HTMLPostPopovercontainerElement;
-  private localTogglePopover: (e: Event) => Promise<void>;
-  private localEnterTogglePopover: (e: KeyboardEvent) => void;
-  private localTouchTogglePopover: (e: TouchEvent) => void;
-  private currentTarget: HTMLElement;
 
   @Element() host: HTMLPostPopoverElement;
 
@@ -37,43 +54,30 @@ export class PostPopover {
   // eslint-disable-next-line @stencil-community/ban-default-true
   @Prop() readonly arrow?: boolean = true;
 
-  constructor() {
-    this.localTogglePopover = e => this.toggle(e.target as HTMLElement);
-    this.localEnterTogglePopover = e => {
-      if (e.key === 'Enter') this.toggle(e.target as HTMLElement);
-    };
-    this.localTouchTogglePopover = e => {
-      e.preventDefault();
-      this.toggle(e.target as HTMLElement);
-    };
-  }
-
   connectedCallback() {
-    if (!this.triggers) {
-      throw new Error(`No trigger found for <post-popover popover-id="${this.host.id}`);
+    // Set up accessibility patcher and event listeners for the first component
+    if (popoverInstances === 0) {
+      window.addEventListener('pointerup', globalToggleHandler);
+      window.addEventListener('keydown', globalToggleHandler);
+      triggerObserver.observe(document.body, {
+        subtree: true,
+        childList: true,
+        attributeFilter: [popoverTargetAttribute],
+      });
     }
 
-    // As long as cross-shadow-boundary [popovertarget] and button.popoverTargetElement are not working
-    // we're left with listening to trigger events ourselves
-    // https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/popoverTargetElement
-    // https://github.com/whatwg/html/issues/9109#issuecomment-1494030465 (does not seem to work for now)
-    // https://stackoverflow.com/questions/77324143/popovertargetelement-does-not-cross-shadow-boundaries?noredirect=1#comment136318281_77324143
-    this.triggers.forEach(trigger => {
-      // See this.onToggle for one time mouse event listener
-      trigger.addEventListener('mouseup', this.localTogglePopover, { once: true });
-      trigger.addEventListener('keypress', this.localEnterTogglePopover);
-      trigger.addEventListener('touch', this.localTouchTogglePopover, { once: true });
-      trigger.setAttribute('aria-expanded', 'false');
-    });
+    popoverInstances++;
   }
 
   disconnectedCallback() {
-    this.triggers.forEach(trigger => {
-      trigger.removeEventListener('mouseup', this.localTogglePopover);
-      trigger.removeEventListener('keypress', this.localEnterTogglePopover);
-      trigger.removeEventListener('touch', this.localTouchTogglePopover);
-      trigger.removeAttribute('aria-expanded');
-    });
+    popoverInstances--;
+
+    // Remove listeners and observer after the last popover has been destructed
+    if (popoverInstances === 0) {
+      window.removeEventListener('click', globalToggleHandler);
+      window.removeEventListener('keydown', globalToggleHandler);
+      triggerObserver.disconnect();
+    }
   }
 
   /**
@@ -82,7 +86,6 @@ export class PostPopover {
    */
   @Method()
   async show(target: HTMLElement) {
-    this.currentTarget = target;
     this.popoverRef.show(target);
     target.setAttribute('aria-expanded', 'true');
   }
@@ -103,47 +106,13 @@ export class PostPopover {
    */
   @Method()
   async toggle(target: HTMLElement, force?: boolean) {
-    this.currentTarget = target;
     const newState = await this.popoverRef.toggle(target, force);
+    this.triggers.forEach(trigger => trigger.setAttribute('aria-expanded', 'false'));
     target.setAttribute('aria-expanded', `${newState}`);
   }
 
   private get triggers() {
-    return document.querySelectorAll(`[data-popover-target="${this.host.id}"]`);
-  }
-
-  /**
-   * One time event handler for click events
-   * A permanent event listener would prevent a toggle button from working properly:
-   * A click opens the popover, a second click first closes it (due to light dismiss), then directly
-   * opens it again because of the click listener on the button. Registering a new
-   * one time listener after a small timeout solves this issue.
-   * @param e toggle event from post-popovercontainer
-   */
-  private onToggle(e: CustomEvent<boolean>) {
-    if (this.currentTarget) {
-      this.currentTarget.setAttribute('aria-expanded', `${e.detail}`);
-    }
-    if (!e.detail) {
-      window.requestAnimationFrame(() => {
-        this.triggers.forEach(trigger => {
-          trigger.addEventListener('mouseup', this.localTogglePopover, { once: true });
-          trigger.addEventListener('touch', this.localTouchTogglePopover, { once: true });
-        });
-      });
-
-      // Handle missing re-focusing logic after close. Can be removed as soon as popovertarget works correctly
-      if (this.currentTarget) {
-        this.currentTarget.focus();
-        this.currentTarget = null;
-      }
-    }
-  }
-
-  // Fix for firefox to prevent the following lines from triggering
-  // https://github.com/oddbird/popover-polyfill/blob/main/src/popover.ts#L338
-  private stopImmediatePropagation(e: PointerEvent) {
-    e.stopImmediatePropagation();
+    return document.querySelectorAll(`[${popoverTargetAttribute}="${this.host.id}"]`);
   }
 
   render() {
@@ -153,13 +122,8 @@ export class PostPopover {
           arrow={this.arrow}
           placement={this.placement}
           ref={e => (this.popoverRef = e)}
-          onPostPopoverToggled={e => this.onToggle(e)}
         >
-          <div
-            class="popover-container"
-            onPointerDown={e => this.stopImmediatePropagation(e)}
-            onPointerUp={e => this.stopImmediatePropagation(e)}
-          >
+          <div class="popover-container">
             <div class="popover-content">
               <slot></slot>
             </div>

--- a/packages/components/src/components/post-popover/post-popover.tsx
+++ b/packages/components/src/components/post-popover/post-popover.tsx
@@ -16,7 +16,6 @@ const globalToggleHandler = (e: PointerEvent | KeyboardEvent) => {
   const popoverTarget = target.getAttribute(popoverTargetAttribute);
   if (!popoverTarget || popoverTarget === '') return;
   if ('key' in e && e.key !== 'Enter') return;
-  // TODO: Check for enter key
   const popover = document.getElementById(popoverTarget) as HTMLPostPopoverElement;
   popover?.toggle(target);
 };

--- a/packages/components/src/components/post-popover/readme.md
+++ b/packages/components/src/components/post-popover/readme.md
@@ -60,13 +60,6 @@ Type: `Promise<void>`
 
 
 
-## Slots
-
-| Slot        | Description                                  |
-| ----------- | -------------------------------------------- |
-| `"default"` | Slot for placing content inside the popover. |
-
-
 ## Dependencies
 
 ### Depends on

--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
@@ -47,7 +47,7 @@ export class PostPopovercontainer {
   private arrowRef: HTMLElement;
   private eventTarget: Element;
   private clearAutoUpdate: () => void;
-  private toggleTimeout: number;
+  private toggleTimeoutId: number;
 
   /**
    * Fires whenever the popover gets shown or hidden, passing the new state in event.details as a boolean
@@ -86,7 +86,7 @@ export class PostPopovercontainer {
    */
   @Method()
   async show(target: HTMLElement) {
-    if (!this.toggleTimeout) {
+    if (!this.toggleTimeoutId) {
       this.eventTarget = target;
       this.calculatePosition();
       this.popoverRef.showPopover();
@@ -98,7 +98,7 @@ export class PostPopovercontainer {
    */
   @Method()
   async hide() {
-    if (!this.toggleTimeout) {
+    if (!this.toggleTimeoutId) {
       this.eventTarget = null;
       this.popoverRef.hidePopover();
     }
@@ -112,11 +112,11 @@ export class PostPopovercontainer {
   @Method()
   async toggle(target: HTMLElement, force?: boolean): Promise<boolean> {
     // Prevent instant double toggle
-    if (!this.toggleTimeout) {
+    if (!this.toggleTimeoutId) {
       this.eventTarget = target;
       this.calculatePosition();
       this.popoverRef.togglePopover(force);
-      this.toggleTimeout = null;
+      this.toggleTimeoutId = null;
     }
     return this.popoverRef.matches(':popover-open');
   }
@@ -128,7 +128,7 @@ export class PostPopovercontainer {
    * @param e ToggleEvent
    */
   private handleToggle(e: ToggleEvent) {
-    this.toggleTimeout = window.setTimeout(() => (this.toggleTimeout = null), 10);
+    this.toggleTimeoutId = window.setTimeout(() => (this.toggleTimeoutId = null), 10);
     const isOpen = e.newState === 'open';
     if (isOpen) {
       this.startAutoupdates();

--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
@@ -47,6 +47,7 @@ export class PostPopovercontainer {
   private arrowRef: HTMLElement;
   private eventTarget: Element;
   private clearAutoUpdate: () => void;
+  private toggleTimeout: number;
 
   /**
    * Fires whenever the popover gets shown or hidden, passing the new state in event.details as a boolean
@@ -85,9 +86,11 @@ export class PostPopovercontainer {
    */
   @Method()
   async show(target: HTMLElement) {
-    this.eventTarget = target;
-    this.calculatePosition();
-    this.popoverRef.showPopover();
+    if (!this.toggleTimeout) {
+      this.eventTarget = target;
+      this.calculatePosition();
+      this.popoverRef.showPopover();
+    }
   }
 
   /**
@@ -95,8 +98,10 @@ export class PostPopovercontainer {
    */
   @Method()
   async hide() {
-    this.eventTarget = null;
-    this.popoverRef.hidePopover();
+    if (!this.toggleTimeout) {
+      this.eventTarget = null;
+      this.popoverRef.hidePopover();
+    }
   }
 
   /**
@@ -106,9 +111,13 @@ export class PostPopovercontainer {
    */
   @Method()
   async toggle(target: HTMLElement, force?: boolean): Promise<boolean> {
-    this.eventTarget = target;
-    this.calculatePosition();
-    this.popoverRef.togglePopover(force);
+    // Prevent instant double toggle
+    if (!this.toggleTimeout) {
+      this.eventTarget = target;
+      this.calculatePosition();
+      this.popoverRef.togglePopover(force);
+      this.toggleTimeout = null;
+    }
     return this.popoverRef.matches(':popover-open');
   }
 
@@ -119,6 +128,7 @@ export class PostPopovercontainer {
    * @param e ToggleEvent
    */
   private handleToggle(e: ToggleEvent) {
+    this.toggleTimeout = window.setTimeout(() => (this.toggleTimeout = null), 10);
     const isOpen = e.newState === 'open';
     if (isOpen) {
       this.startAutoupdates();

--- a/packages/components/src/utils/attribute-observer.ts
+++ b/packages/components/src/utils/attribute-observer.ts
@@ -1,0 +1,30 @@
+export const getAttributeObserver = (
+  attribute: string,
+  handler: (element: HTMLElement, mutation?: MutationRecord) => void,
+) => {
+  /**
+   * Handle attribute changes and childList changes from the observer
+   * @param {MutationRecord[]} mutationList
+   */
+  const observerHandler: MutationCallback = (mutationList: MutationRecord[]) => {
+    mutationList.forEach(mutation => {
+      if (mutation.type === 'attributes' && mutation.attributeName === attribute) {
+        handler(mutation.target as HTMLElement);
+      }
+
+      if (mutation.type === 'childList') {
+        mutation.addedNodes.forEach(node => {
+          if (
+            node.nodeType === Node.ELEMENT_NODE &&
+            (node as HTMLElement).hasAttribute(attribute)
+          ) {
+            handler(node as HTMLElement);
+          }
+        });
+      }
+    });
+  };
+
+  // Initialize a mutation observer for patching accessibility features
+  return new MutationObserver(observerHandler);
+};


### PR DESCRIPTION
This small timeout prevents the popovercontainer from opening and closing with the same event chain. This happens for example when the popover is open and the trigger button is clicked again. It's because first, an outside click is registered the popover closes. Right after that, the click from the toggle button fires and opens the popover again.