### PR TITLE
chore: exclude bootstrap from minor/patch renovate grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     },
     {
       "matchPackagePatterns": ["*"],
-      "excludePackageNames": ["typescript"],
+      "excludePackageNames": ["typescript", "bootstrap"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
We're usually not able to update minor/patch versions of bootstrap without additional effort, therefore updates for bootstrap should be submitted in separate PRs.