### PR TITLE
fix(documentation): Nitpick on <post-alert/> self closing

### DIFF
--- a/packages/documentation/src/stories/components/alert/alert.docs.mdx
+++ b/packages/documentation/src/stories/components/alert/alert.docs.mdx
@@ -78,7 +78,7 @@ Alerts are intended to attract the user's attention without interrupting their o
 
       ## Installation
 
-      The `<post-alert/>` element is part of the `@swisspost/design-system-components` package.
+      The `<post-alert>` element is part of the `@swisspost/design-system-components` package.
       For more information, read the [getting started with components guide](/?path=/docs/edfb619b-fda1-4570-bf25-20830303d483--docs).
 
       ## Examples
@@ -87,7 +87,7 @@ Alerts are intended to attract the user's attention without interrupting their o
 
       Alerts can contain various HTML elements like paragraphs, lists, icons and dividers.
 
-      By default all children of the `<post-alert/>` are placed in the body.
+      By default all children of the `<post-alert>` are placed in the body.
       Use the `heading` slot to place a child in the heading, and the `actions` slot for action buttons.
       Learn more about <a rel="noopener" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots#adding_flexibility_with_slots">slots in the mdn web docs</a>.
 


### PR DESCRIPTION
Very nitpick change, but self-closing doesn't exist with Custom Elements, so let's remove this ambiguity. 