### PR TITLE
feat(documentation): Display color value after color title for quick comparison

### DIFF
--- a/.changeset/rare-shoes-serve.md
+++ b/.changeset/rare-shoes-serve.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added color value after color title to help for comparison.

--- a/packages/documentation/src/stories/foundation/color/color.blocks.tsx
+++ b/packages/documentation/src/stories/foundation/color/color.blocks.tsx
@@ -10,6 +10,10 @@ export const ColorSwatch = (props: { name: string; color: string; noCSS?: boolea
     <article className="color-swatch">
       <div className="color-swatch__description">
         <h3 className="description__title h6">{props.name}</h3>
+        <p className="description__value">
+          <span className="visually-hidden">CSS value: </span>
+          {props.color}
+        </p>
       </div>
       <div className="color-swatch__color">
         <div

--- a/packages/documentation/src/stories/foundation/color/color.styles.scss
+++ b/packages/documentation/src/stories/foundation/color/color.styles.scss
@@ -26,6 +26,10 @@
         text-transform: uppercase;
       }
     }
+    .description__value {
+      font-weight: post.$font-weight-light;
+      font-size: post.$font-size-14;
+    }
   }
 
   .color-swatch__color {


### PR DESCRIPTION
Sometimes, it's nice to be able to have quick access to color value and be able, for example to compare with the design or some other places