### PR TITLE
fix(styles): Color-contrast on post-tabs with dark background

### DIFF
--- a/.changeset/pink-carpets-bathe.md
+++ b/.changeset/pink-carpets-bathe.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed color-contrast on post-tabs with dark background.

--- a/packages/components/cypress/e2e/tabs.cy.ts
+++ b/packages/components/cypress/e2e/tabs.cy.ts
@@ -174,9 +174,6 @@ describe('Accessibility', () => {
         'aria-valid-attr-value': {
           enabled: false,
         },
-        'color-contrast': {
-          enabled: false,
-        },
       },
     });
   });

--- a/packages/styles/src/components/tabs/_tab-title.scss
+++ b/packages/styles/src/components/tabs/_tab-title.scss
@@ -8,6 +8,7 @@
 
 .tab-title[role='tab'] {
   display: inline-block;
+  cursor: pointer;
   position: relative;
   box-sizing: border-box;
   padding: nav.$nav-link-padding;
@@ -18,6 +19,7 @@
   opacity: 0.7;
   color: var(--post-contrast-color);
   text-decoration: none;
+  background-color: var(--post-contrast-color-inverted);
 
   &:focus {
     background-color: unset;
@@ -26,16 +28,16 @@
 
   &:hover {
     opacity: 1;
-    background-color: nav.$nav-tabs-link-active-bg;
-    color: var(--post-contrast-color);
+    background-color: rgba(var(--post-contrast-color-rgb), 0.6);
+    color: var(--post-contrast-color-inverted);
   }
 
   // same styles as focus, can't use placeholder here because focus-visible can't be described outside of the support condition
   &:focus-visible {
     outline: transparent;
     opacity: 1;
-    background-color: nav.$nav-tabs-link-active-bg;
-    color: var(--post-contrast-color);
+    background-color: rgba(var(--post-contrast-color-rgb), 0.6);
+    color: var(--post-contrast-color-inverted);
     box-shadow: none;
 
     &::after {
@@ -55,7 +57,7 @@
     border-right-color: nav.$nav-tabs-border-color;
     border-left-color: nav.$nav-tabs-border-color;
     opacity: 1;
-    background-color: nav.$nav-tabs-link-active-bg;
+    background-color: var(--post-contrast-color-inverted);
     color: var(--post-contrast-color);
     font-weight: 700;
 

--- a/packages/styles/src/components/tabs/_tabs-wrapper.scss
+++ b/packages/styles/src/components/tabs/_tabs-wrapper.scss
@@ -9,7 +9,10 @@
   position: relative;
   padding-top: spacing.$spacer;
   border: 0;
-  background-color: color.$gray-background-light;
+  background-color: rgba(
+    var(--post-contrast-color-rgb),
+    0.02
+  ); // 0.02 gets as close as possible to color.$gray-background-light on white background
 
   // Create a line that lies below the active but above the passive elements
   // This way hover works smoothly with the background color
@@ -55,7 +58,7 @@
 }
 
 .tab-content {
-  margin-block: spacing.$spacer;
+  padding-top: spacing.$spacer;
 }
 
 // Careful, this generates a lot of code


### PR DESCRIPTION
1. Fixed color-contrast of post-tabs on dark-background:

From
![Cypress_3Nn8pl3IFf](https://github.com/swisspost/design-system/assets/12294151/6098f7ed-7be5-41c6-ae88-33af32f8cc76)

To 
![Screenshot 2024-03-05 at 08-33-23 snapshots--tabs](https://github.com/swisspost/design-system/assets/12294151/118e3ffe-397c-4875-b569-b96d388e294d)


2. Added cursor pointer to tabs title
3. Revert change from https://github.com/swisspost/design-system/pull/2349/files/344934ab280122c643d2886666f3981829ff2ff1#r1413888274 and fix with added spacing. The margin is visible here: 

![image](https://github.com/swisspost/design-system/assets/12294151/08e89b45-f1e6-4b80-bf64-c4dbd2ef83f7)

Note: @rouvenpost @Cian77 I didn't implement what's in the design https://www.figma.com/file/xZ0IW0MJO0vnFicmrHiKaY/Components-Post?type=design&node-id=70-18&mode=design&t=VxSxr2DejdjVc4mY-0 because it misses how it should look like on dark colored background and because we are quite limited at the moment with this `post-tabs` component as the `:host-context` selector is not available (and will never be it seems) on all browsers, so to adapt to a particular theme given by the parent, we can only use CSS custom properties (like `--post-contrast-color-inverted` or `--post-contrast-color`). That means the component doesn't know anything about the current theme. This is good if we want to go further on theme architecture where you only need to provide different variables to change a component, but we are not there yet. And finally, it is also complex to style for the `post-tabs` component as well for the `tabs` HTML component, perhaps we should decouple those two.