### PR TITLE
chore(documentation): Cache hash assets in the browser

### DIFF
--- a/packages/demo/src/app/common/footer/footer.component.ts
+++ b/packages/demo/src/app/common/footer/footer.component.ts
@@ -10,17 +10,17 @@ export class FooterComponent {
     {
       name: 'Philipp Gfeller',
       title: 'Lead UI Developer',
-      avatar: 'https://avatars.githubusercontent.com/u/1659006?v=4',
+      avatar: 'https://avatars.githubusercontent.com/u/1659006?v=4&size=80',
     },
     {
       name: 'Alizé Debray',
       title: 'UI Developer',
-      avatar: 'https://avatars.githubusercontent.com/u/33580481?v=4',
+      avatar: 'https://avatars.githubusercontent.com/u/33580481?v=4&size=80',
     },
     {
       name: 'Oliver Schürch',
       title: 'UI Developer',
-      avatar: 'https://avatars.githubusercontent.com/u/9716662?v=4',
+      avatar: 'https://avatars.githubusercontent.com/u/9716662?v=4&size=80',
     },
   ];
 

--- a/packages/documentation/.storybook/blocks/footer.tsx
+++ b/packages/documentation/.storybook/blocks/footer.tsx
@@ -10,22 +10,22 @@ const DEVELOPERS: Developer[] = [
   {
     name: 'Philipp Gfeller',
     title: 'Lead UI Developer',
-    avatar: 'https://avatars.githubusercontent.com/u/1659006?v=4',
+    avatar: 'https://avatars.githubusercontent.com/u/1659006?v=4&size=80',
   },
   {
     name: 'Alizé Debray',
     title: 'UI Developer',
-    avatar: 'https://avatars.githubusercontent.com/u/33580481?v=4',
+    avatar: 'https://avatars.githubusercontent.com/u/33580481?v=4&size=80',
   },
   {
     name: 'Oliver Schürch',
     title: 'UI Developer',
-    avatar: 'https://avatars.githubusercontent.com/u/9716662?v=4',
+    avatar: 'https://avatars.githubusercontent.com/u/9716662?v=4&size=80',
   },
   {
     name: 'Loïc Fürhoff',
     title: 'UI Developer',
-    avatar: 'https://avatars.githubusercontent.com/u/12294151?v=4',
+    avatar: 'https://avatars.githubusercontent.com/u/12294151?v=4&size=80',
   },
 ];
 

--- a/packages/documentation/.storybook/main.ts
+++ b/packages/documentation/.storybook/main.ts
@@ -81,6 +81,15 @@ const config: StorybookConfig = {
       css: {
         devSourcemap: true,
       },
+      build: {
+        rollupOptions: {
+          output: {
+            entryFileNames: `assets/[name]-H-[hash].js`,
+            chunkFileNames: `assets/[name]-H-[hash].js`,
+            assetFileNames: `assets/[name]-H-[hash].[ext]`,
+          },
+        },
+      },
     });
   },
 };

--- a/packages/documentation/public/netlify.toml
+++ b/packages/documentation/public/netlify.toml
@@ -1,4 +1,16 @@
 [[headers]]
+  # Cache assets with -H- hash (defined in main.ts)
+  for = "/*-H-*"
+    [headers.values]
+    cache-control = '''
+      max-age=31536000,
+      immutable'''
+  # Cache fonts as it's quite unlikely that they will change
+  for = "/*.woff2"
+    [headers.values]
+    cache-control = '''
+      max-age=31536000,
+      immutable'''
   for="/assets/versions.json"
     [headers.values]
     Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
Currently our build is quite heavy. The [color page](https://design-system.post.ch/?path=/docs/e869afc1-3c50-4c20-a495-3d846f7a759e--docs), for example, loads 2.2 Mo of gzipped data.

Netlify [by default is working the "Control-Cache" header with](https://docs.netlify.com/platform/caching/#default-values): 

For static assets:

```
Netlify-CDN-Cache-Control: public, s-maxage=31536000, must-revalidate
Cache-Control: public, max-age=0, must-revalidate
```

For dynamic responses:

```
Cache-Control: public, max-age=0, must-revalidate
 ```

If I understood correctly. The idea is [to have a maximum cache control on their CDN](https://www.netlify.com/blog/2017/02/23/better-living-through-caching/) (as an intermediate cache control layer). But it also means that it removes power to the browser to cache things and we "only" get better performance because we can reach the assets quicker, in theory.

WIth this PR, I would like to add "immutable" cache for hashed assets. This strategy is backed up by [CSS Wizardry](https://csswizardry.com/2019/03/cache-control-for-civilians/#cache-busting) and [MDN ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Revalidation_and_reloading#immutable).
Unfortunately, there are obstacles with Storybook. Some assets don't go to the hashing process ([with webpack it seems to be the same story](https://github.com/storybookjs/storybook/issues/6649)). So to ensure that we are targetting the right items, I customized the hashed files with `-H-`. By targetting the `-H-` files and the font files, we should already cache at least half of the data.
