### PR TITLE
chore(documentation): Workaround for vite:import-analysis in Internet-header with es5 build

### DIFF
--- a/packages/documentation/.storybook/helpers/register-web-components.ts
+++ b/packages/documentation/.storybook/helpers/register-web-components.ts
@@ -1,4 +1,5 @@
-import { defineCustomElements as defineInternetHeader } from '@swisspost/internet-header/loader';
+// @ts-ignore
+import { defineCustomElements as defineInternetHeader } from '@swisspost/internet-header/loader/index.es2017.js';
 import { defineCustomElements as definePostComponents } from '@swisspost/design-system-components/loader';
 import { setStencilDocJson } from '@pxtrn/storybook-addon-docs-stencil';
 import {


### PR DESCRIPTION
This is a workaround for the following warning that appears when starting the dev server:

```
packages/documentation start: The above dynamic import cannot be analyzed by Vite.
packages/documentation start: See https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#limitations for supported dynamic import formats. If this is intended to be left as-is, you can use the /* @vite-ignore */ co
mment inside the import() call to suppress this warning.
packages/documentation start:
packages/documentation start:   Plugin: vite:import-analysis
packages/documentation start:   File: C:/work/design-system/packages/internet-header/dist/esm-es5/index-a2152ff5.js
```

This is the [linked issue on Stencil repository](https://github.com/ionic-team/stencil/issues/4122) which has not been fixed at the moment. 

I would like to fix it because it takes a large number of lines on the terminal and obscures other warnings.