### PR TITLE
feat(components): PoC for post-tabs using light dom (and slot emulation from stencil)

### DIFF
--- a/packages/components/cypress/e2e/tabs.cy.ts
+++ b/packages/components/cypress/e2e/tabs.cy.ts
@@ -169,12 +169,6 @@ describe('tabs', () => {
 describe('Accessibility', () => {
   it('Has no detectable a11y violations on load for all variants', () => {
     cy.getSnapshots('tabs');
-    cy.checkA11y('#root-inner', {
-      rules: {
-        'aria-valid-attr-value': {
-          enabled: false,
-        },
-      },
-    });
+    cy.checkA11y('#root-inner');
   });
 });

--- a/packages/components/src/components/post-tab-header/post-tab-header.tsx
+++ b/packages/components/src/components/post-tab-header/post-tab-header.tsx
@@ -9,7 +9,8 @@ import { checkNonEmpty } from '../../utils';
 @Component({
   tag: 'post-tab-header',
   styleUrl: 'post-tab-header.scss',
-  shadow: true,
+  shadow: false,
+  scoped: true,
 })
 export class PostTabHeader {
   @Element() host: HTMLPostTabHeaderElement;

--- a/packages/components/src/components/post-tab-panel/post-tab-panel.tsx
+++ b/packages/components/src/components/post-tab-panel/post-tab-panel.tsx
@@ -8,7 +8,8 @@ import { version } from '../../../package.json';
 @Component({
   tag: 'post-tab-panel',
   styleUrl: 'post-tab-panel.scss',
-  shadow: true,
+  shadow: false,
+  scoped: true,
 })
 export class PostTabPanel {
   @Element() host: HTMLPostTabPanelElement;

--- a/packages/components/src/components/post-tabs/post-tabs.tsx
+++ b/packages/components/src/components/post-tabs/post-tabs.tsx
@@ -18,6 +18,7 @@ export class PostTabs {
   private showing: Animation;
   private hiding: Animation;
   private isLoaded = false;
+  private slotObserver: MutationObserver;
 
   private get tabs(): NodeListOf<HTMLPostTabHeaderElement> {
     return this.host.querySelectorAll('post-tab-header');
@@ -105,9 +106,12 @@ export class PostTabs {
     };
 
     const slot = this.host;
-    const observer = new MutationObserver(callback);
-    console.log('stlot', slot, this.host);
-    observer.observe(slot, { childList: true, subtree: true });
+    this.slotObserver = new MutationObserver(callback);
+    this.slotObserver.observe(slot, { childList: true, subtree: true }); // Slot attribution happen before the mutation observer callback so we need "subtree"
+  }
+
+  disconnectedCallback() {
+    this.slotObserver.disconnect();
   }
 
   private moveMisplacedTabs() {

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -43,6 +43,8 @@ export const config: Config = {
   ],
   extras: {
     enableImportInjection: true,
+    experimentalSlotFixes: true,
+    experimentalScopedSlotChanges: true,
   },
   plugins: [
     sass({

--- a/packages/documentation/src/stories/components/tabs/tabs.stories.ts
+++ b/packages/documentation/src/stories/components/tabs/tabs.stories.ts
@@ -73,7 +73,7 @@ export const Async: Story = {
           document.querySelectorAll('post-tab-header');
 
         const activeHeader: HTMLPostTabHeaderElement | undefined = Array.from(headers).find(
-          header => header.shadowRoot?.querySelector('.active'),
+          header => header.querySelector('.active'),
         );
         activeHeader?.remove();
 


### PR DESCRIPTION
Currently, we are waiting on https://github.com/ionic-team/stencil/pull/5403 (see, https://github.com/ionic-team/stencil/issues/5335#issuecomment-1982203984). `<post-tab-panel>` are added to the first slot available (the one in `<post-tab-header>`) which is not the slot in `<div class="tab-content">`.

Some preliminary observations of using Stencil light DOM emulation:

| Advantages | Disadvantages |
|------------|---------------|
| No issue with cross-root aria or forms association | Emulation is quite experimental at the moment (and we don't know how it is a priority for stencil team|
|   | Less handle to limit overrided styles |
| | Is it really futur proof and easily translatable into server-side code? |

Other comparisons:
* https://www.matuzo.at/blog/2023/pros-and-cons-of-shadow-dom/#con-styling-slotted-content

Styles can be scoped like any other framework which is good enough, I think.