### PR TITLE
chore: exclude @types/node from batch update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     },
     {
       "matchPackagePatterns": ["*"],
-      "excludePackageNames": ["typescript", "bootstrap"],
+      "excludePackageNames": ["typescript", "bootstrap", "@types/node"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"


### PR DESCRIPTION
This package regularly causes the batch update to fail because of the deprecated Angular Demo App no longer able to build.