### PR TITLE
fix(docs): use react syntax in mdx files

### DIFF
--- a/packages/documentation/src/stories/components/blockquote/blockquote.docs.mdx
+++ b/packages/documentation/src/stories/components/blockquote/blockquote.docs.mdx
@@ -9,7 +9,7 @@ import StylesPackageImport from '../../../shared/styles-package-import.mdx';
 <div className="lead">
   For quoting blocks of content from another source within your document. Wrap `
   <blockquote
-    class="blockquote">` around any HTML as the quote.
+    className="blockquote">` around any HTML as the quote.
 </div>
 
 <Canvas sourceState="shown" of={BlockquoteStories.Default} />

--- a/packages/documentation/src/stories/utilities/sizing/sizing.docs.mdx
+++ b/packages/documentation/src/stories/utilities/sizing/sizing.docs.mdx
@@ -44,8 +44,8 @@ Post sizes can be used as suffixes in the same way. To find out which size name 
 #### Sass variables
 
 {/* prettier-ignore */}
-<div class="alert alert-warning mb-bigger-big">
-  <h2 class="alert-heading">Sizing variables are deprecated</h2>
+<div className="alert alert-warning mb-bigger-big">
+  <h2 className="alert-heading">Sizing variables are deprecated</h2>
   <p>The current set of the post-specific sizing variables is deprecated in favour of a new naming system that is consistent with the Design. For further information, please read the <a href="https://github.com/swisspost/design-system/discussions/588">discussion on sizing variables on GitHub</a> and have a look at the <a href="https://www.figma.com/file/ojCcgC5Zd12eUSzq6V5m24/Foundations?node-id=3%3A2&t=l8qimsXlxeMLOzs6-0">implementation in Figma</a>.</p>
   <p>There is a new solution with updated naming system up coming for spacing sizes.</p>
 </div>

--- a/packages/documentation/src/stories/utilities/spacing/spacing.docs.mdx
+++ b/packages/documentation/src/stories/utilities/spacing/spacing.docs.mdx
@@ -13,8 +13,8 @@ improve the overall user interface.
 
 </div>
 
-<div class="alert alert-warning mb-bigger-big">
-  <h2 class="alert-heading">Sizing variables are deprecated</h2>
+<div className="alert alert-warning mb-bigger-big">
+  <h2 className="alert-heading">Sizing variables are deprecated</h2>
   <p>The current set of the post-specific spacing utility is deprecated in favour of a new naming system that is consistent with the Design. For further information, please read the <a href="https://github.com/swisspost/design-system/discussions/588">discussion on sizing variables on GitHub</a> and have a look at the <a href="https://www.figma.com/file/ojCcgC5Zd12eUSzq6V5m24/Foundations?node-id=3%3A2&t=l8qimsXlxeMLOzs6-0">implementation in Figma</a>.</p>
   <p>There is a new solution with updated naming system up coming for spacing sizes.</p>
 </div>


### PR DESCRIPTION
Not doing so, generates an error in the console (but it seems to work anyways).