### PR TITLE
fix(demo, documentation): Examples with images contains "image" keyword in alt

### DIFF
--- a/packages/demo/src/app/bootstrap/components/card/card-demo/card-demo.component.html
+++ b/packages/demo/src/app/bootstrap/components/card/card-demo/card-demo.component.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-4 col-rg-6 col-12 mb-3">
       <div class="card" style="width: 18rem">
-        <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+        <img class="card-img-top" [src]="imagePath" alt="" />
         <div class="card-body">
           <h5 class="card-title">Card title</h5>
           <p class="card-text">
@@ -34,7 +34,7 @@
     </div>
     <div class="col-lg-4 col-rg-6 col-12 mb-3">
       <div class="card" style="width: 18rem">
-        <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+        <img class="card-img-top" [src]="imagePath" alt="" />
         <div class="card-body">
           <p class="card-text">
             Some quick example text to build on the card title and make up the bulk of the card's
@@ -64,7 +64,7 @@
     </div>
     <div class="col-lg-4 col-rg-6 col-12 mb-3">
       <div class="card" style="width: 18rem">
-        <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+        <img class="card-img-top" [src]="imagePath" alt="" />
         <div class="card-body">
           <h5 class="card-title">Card title</h5>
           <p class="card-text">

--- a/packages/demo/src/app/bootstrap/components/card/complex-card-demo/complex-card-demo.component.html
+++ b/packages/demo/src/app/bootstrap/components/card/complex-card-demo/complex-card-demo.component.html
@@ -9,7 +9,7 @@
 <div class="row">
   <div class="col-lg-4 col-rg-6 col-12 mb-3">
     <div class="card mb-3">
-      <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+      <img class="card-img-top" [src]="imagePath" alt="" />
       <div class="card-body">
         <h5 class="card-title">Card title</h5>
         <p class="card-text">
@@ -30,7 +30,7 @@
         </p>
         <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
       </div>
-      <img class="card-img-bottom" [src]="imagePath" alt="Card image cap" />
+      <img class="card-img-bottom" [src]="imagePath" alt="" />
     </div>
   </div>
 </div>
@@ -65,7 +65,7 @@
 
 <div class="card-group mb-5">
   <div class="card">
-    <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+    <img class="card-img-top" [src]="imagePath" alt="" />
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">
@@ -76,7 +76,7 @@
     </div>
   </div>
   <div class="card">
-    <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+    <img class="card-img-top" [src]="imagePath" alt="" />
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">
@@ -86,7 +86,7 @@
     </div>
   </div>
   <div class="card">
-    <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+    <img class="card-img-top" [src]="imagePath" alt="" />
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">
@@ -100,7 +100,7 @@
 
 <div class="card-group mb-5">
   <div class="card">
-    <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+    <img class="card-img-top" [src]="imagePath" alt="" />
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">
@@ -113,7 +113,7 @@
     </div>
   </div>
   <div class="card">
-    <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+    <img class="card-img-top" [src]="imagePath" alt="" />
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">
@@ -125,7 +125,7 @@
     </div>
   </div>
   <div class="card">
-    <img class="card-img-top" [src]="imagePath" alt="Card image cap" />
+    <img class="card-img-top" [src]="imagePath" alt="" />
     <div class="card-body">
       <h5 class="card-title">Card title</h5>
       <p class="card-text">

--- a/packages/demo/src/app/common/footer/footer.component.html
+++ b/packages/demo/src/app/common/footer/footer.component.html
@@ -5,7 +5,7 @@
     <div class="d-flex flex-wrap mt-huge-r mb-huge-r profile-list">
       <ng-container *ngFor="let dev of shuffledDevs">
         <article class="avatar">
-          <img [src]="dev.avatar" [alt]="'Profile picture ' + dev.name" class="profile-picture" />
+          <img [src]="dev.avatar" [alt]="" class="profile-picture" />
           <div>
             <p class="bold">{{ dev.name }}</p>
             <p>{{ dev.title }}</p>

--- a/packages/demo/src/app/post-sample/components/topic-teaser/topic-teaser-demo/topic-teaser-demo.component.html
+++ b/packages/demo/src/app/post-sample/components/topic-teaser/topic-teaser-demo/topic-teaser-demo.component.html
@@ -8,7 +8,7 @@
             src="https://picsum.photos/id/553/800/800"
             width="100%"
             height="100%"
-            alt="Test teaser image"
+            alt=""
           />
         </div>
 

--- a/packages/demo/src/app/post-sample/components/topic-teaser/topic-teaser-right-demo/topic-teaser-right-demo.component.html
+++ b/packages/demo/src/app/post-sample/components/topic-teaser/topic-teaser-right-demo/topic-teaser-right-demo.component.html
@@ -32,7 +32,7 @@
             src="https://picsum.photos/id/237/800/800"
             width="100%"
             height="100%"
-            alt="Test teaser image"
+            alt=""
           />
         </div>
       </div>

--- a/packages/documentation/.storybook/blocks/footer.tsx
+++ b/packages/documentation/.storybook/blocks/footer.tsx
@@ -52,11 +52,7 @@ export default (params: { pathToStoryFile?: String }) => (
             <div className="d-flex flex-wrap mt-huge-r mb-huge-r profile-list">
               {DEVELOPERS.sort(() => (Math.random() > 0.5 ? 1 : -1)).map((developer, index) => (
                 <article key={index} className="avatar">
-                  <img
-                    className="profile-picture"
-                    src={developer.avatar}
-                    alt={`Profile picture ${developer.name}`}
-                  />
+                  <img className="profile-picture" src={developer.avatar} alt="" />
                   <div>
                     <p>
                       <strong>{developer.name}</strong>

--- a/packages/documentation/src/stories/components/topic-teaser/topic-teaser.stories.ts
+++ b/packages/documentation/src/stories/components/topic-teaser/topic-teaser.stories.ts
@@ -154,7 +154,7 @@ export const Default: Story = {
           src="https://picsum.photos/id/553/800/800"
           width="100%"
           height="100%"
-          alt="Test teaser image"
+          alt=""
         />
       </div>
     `;

--- a/packages/nextjs-integration/src/app/page.tsx
+++ b/packages/nextjs-integration/src/app/page.tsx
@@ -151,7 +151,7 @@ export default function Home() {
                     height={1000}
                     className="topic-teaser-image w-100 h-100"
                     src="/street.jpg"
-                    alt="Test teaser image"
+                    alt=""
                   />
                 </div>
               </div>
@@ -164,13 +164,7 @@ export default function Home() {
         <div className="row">
           <div className="col-lg-4 col-rg-6 col-12 mb-3">
             <div className="card elevation-0">
-              <Image
-                width={400}
-                height={200}
-                className="card-img-top"
-                src="/street.jpg"
-                alt="Card image cap"
-              />
+              <Image width={400} height={200} className="card-img-top" src="/street.jpg" alt="" />
               <div className="card-body bg-gray">
                 <h3 className="card-title">Hier steckt mehr drin</h3>
                 <p className="card-text">Black-Week-Topangebote nicht verpassen</p>
@@ -184,13 +178,7 @@ export default function Home() {
 
           <div className="col-lg-4 col-rg-6 col-12 mb-3">
             <div className="card elevation-0">
-              <Image
-                width={400}
-                height={200}
-                className="card-img-top"
-                src="/street.jpg"
-                alt="Card image cap"
-              />
+              <Image width={400} height={200} className="card-img-top" src="/street.jpg" alt="" />
               <div className="card-body bg-gray">
                 <h3 className="card-title">Einfach easy frankieren</h3>
                 <p className="card-text">DigitalStamp: Mit der Post-App frankieren</p>
@@ -204,13 +192,7 @@ export default function Home() {
 
           <div className="col-lg-4 col-rg-6 col-12 mb-3">
             <div className="card elevation-0">
-              <Image
-                width={400}
-                height={200}
-                className="card-img-top"
-                src="/street.jpg"
-                alt="Card image cap"
-              />
+              <Image width={400} height={200} className="card-img-top" src="/street.jpg" alt="" />
               <div className="card-body bg-gray">
                 <h3 className="card-title">Neue Briefmarken</h3>
                 <p className="card-text">Entdecken Sie jetzt Ihre liebsten Motive</p>


### PR DESCRIPTION
Example: https://sonarcloud.io/project/issues?open=AY3mTQCpUYAeUCKMCFbV&id=swisspost_common-web-frontend