### PR TITLE
chore(versioning): fix versions of main packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,10 +6,12 @@
   ],
   "commit": false,
   "fixed": [
-    "@swisspost/design-system-styles",
-    "@swisspost/design-system-components",
-    "@swisspost/design-system-components-angular",
-    "@swisspost/design-system-components-react"
+    [
+      "@swisspost/design-system-styles",
+      "@swisspost/design-system-components",
+      "@swisspost/design-system-components-angular",
+      "@swisspost/design-system-components-react"
+    ]
   ],
   "linked": [],
   "access": "restricted",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,6 +11,8 @@
       "@swisspost/design-system-components",
       "@swisspost/design-system-components-angular",
       "@swisspost/design-system-components-react",
+      "@swisspost/design-system-intranet-header",
+      "@swisspost/design-system-icons",
       "@swisspost/design-system-migrations"
     ]
   ],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,8 @@
       "@swisspost/design-system-styles",
       "@swisspost/design-system-components",
       "@swisspost/design-system-components-angular",
-      "@swisspost/design-system-components-react"
+      "@swisspost/design-system-components-react",
+      "@swisspost/design-system-migrations"
     ]
   ],
   "linked": [],

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,12 @@
     { "repo": "swisspost/design-system" }
   ],
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    "@swisspost/design-system-styles",
+    "@swisspost/design-system-components",
+    "@swisspost/design-system-components-angular",
+    "@swisspost/design-system-components-react"
+  ],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/.changeset/fifty-rabbits-flow.md
+++ b/.changeset/fifty-rabbits-flow.md
@@ -4,6 +4,8 @@
 '@swisspost/design-system-components-react': major
 '@swisspost/design-system-styles': major
 '@swisspost/design-system-migrations': major
+'@swisspost/design-system-icons': major
+'@swisspost/design-system-intranet-header': major
 ---
 
 Syncing versions of the following packages:
@@ -13,5 +15,7 @@ Syncing versions of the following packages:
 - @swisspost/design-system-components-react
 - @swisspost/design-system-components-angular
 - @swisspost/design-system-migrations
+- @swisspost/design-system-icons
+- @swisspost/design-system-intranet-header
 
 This will help understanding the dependencies between these packages at a glance but also means that for the individual pacakges, semver is no longer being used. This enables us also to talk about and document Design System versions as a whole instead of documenting the fragmented versions in a complex lookup table.

--- a/.changeset/fifty-rabbits-flow.md
+++ b/.changeset/fifty-rabbits-flow.md
@@ -3,6 +3,7 @@
 '@swisspost/design-system-components-angular': major
 '@swisspost/design-system-components-react': major
 '@swisspost/design-system-styles': major
+'@swisspost/design-system-migrations': major
 ---
 
 Syncing versions of the following packages:
@@ -11,5 +12,6 @@ Syncing versions of the following packages:
 - @swisspost/design-system-components
 - @swisspost/design-system-components-react
 - @swisspost/design-system-components-angular
+- @swisspost/design-system-migrations
 
 This will help understanding the dependencies between these packages at a glance but also means that for the individual pacakges, semver is no longer being used. This enables us also to talk about and document Design System versions as a whole instead of documenting the fragmented versions in a complex lookup table.

--- a/.changeset/fifty-rabbits-flow.md
+++ b/.changeset/fifty-rabbits-flow.md
@@ -1,0 +1,15 @@
+---
+'@swisspost/design-system-components': major
+'@swisspost/design-system-components-angular': major
+'@swisspost/design-system-components-react': major
+'@swisspost/design-system-styles': major
+---
+
+Syncing versions of the following packages:
+
+- @swisspost/design-system-styles
+- @swisspost/design-system-components
+- @swisspost/design-system-components-react
+- @swisspost/design-system-components-angular
+
+This will help understanding the dependencies between these packages at a glance but also means that for the individual pacakges, semver is no longer being used. This enables us also to talk about and document Design System versions as a whole instead of documenting the fragmented versions in a complex lookup table.


### PR DESCRIPTION
This will start to align the version of the fixed packages together. Fixed packages will be published under a new version, even if they did not have any changes (https://github.com/changesets/changesets/blob/main/docs/fixed-packages.md).

There are several packages, that are not included in the list because they should still be versioned individually. The reason for this is, that they are not main deliverables of the Design System - styles and components. For example the documnetation, which can only be released with a version bump. If it would be fixed with the other packages, a correction of a typo would cause a version bump for all the deliverables, even if nothing changed for end users.