### PR TITLE
chore: update the build workflows trigger

### DIFF
--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -14,6 +14,7 @@
 name: Build Demo App
 on:
   pull_request:
+    types: [ opened, synchronize, edited, reopened ]
     paths:
       - 'packages/intranet-header-workspace/**'
       - 'packages/demo/**'

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -13,6 +13,7 @@
 name: Build Documentation
 on:
   pull_request:
+    types: [opened, synchronize, edited, reopened]
     paths:
       - 'packages/**'
 


### PR DESCRIPTION
Currently, because the changeset action uses force push, the previews are not updated on the release branches.
This PR is to trigger the build workflows as soon as the PR is edited to avoid this issue. 