### PR TITLE
chore: remove docs peer dependencies

### DIFF
--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -73,17 +73,5 @@
     "sass": "1.74.1",
     "storybook": "7.6.17",
     "typescript": "5.3.3"
-  },
-  "peerDependencies": {
-    "@swisspost/design-system-components-angular": "workspace:2.0.0",
-    "@swisspost/design-system-intranet-header": "workspace:5.0.11"
-  },
-  "peerDependenciesMeta": {
-    "@swisspost/design-system-components-angular": {
-      "optional": true
-    },
-    "@swisspost/design-system-intranet-header": {
-      "optional": true
-    }
   }
 }


### PR DESCRIPTION
A weird workflow (https://github.com/changesets/changesets/issues/1011) in changesets causes packages depending on others in the monorepo through peer dependencies to cause a major update on the upstream package. This is undesired in this scenario. Example:

design-system-components-angular has a patch update and is a peer dependency of the documentation. Because of that patch, the documentation has a major version bump for this release, even if there are no breaking changes.