### PR TITLE
fix(docs): Missing LinkTo element on rating component and remove all remaining LinkTo element

### DIFF
--- a/.changeset/light-pandas-wonder.md
+++ b/.changeset/light-pandas-wonder.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed missing LinkTo element on post-rating docs page and removed all remaining LinkTo elements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Use these commands whenever you want to work on one of these packages. Ideally, 
 - Add the `id` property in the meta of each story file. The property should contain an UUID (feel free to use your favorite tool)
 - No react related attributes in code snippets (e.g. className, htmlFor, key, etc.)
 - No nested `<p>` tags (beware of .lead and .alert)
-- When using LinkTo use both the `kind` and `story` attributes
+- When adding a link, we do not use the LinkTo element, but the standard `<a>` element
 - `div.hide-col-default` wrapper for controls on CSS only component docs
 - Add the `sourceState="shown"` attribute to the first canvas if the code is not too long (less than 8 lines)
 

--- a/packages/documentation/src/stories/components/forms/card-control/card-control.docs.mdx
+++ b/packages/documentation/src/stories/components/forms/card-control/card-control.docs.mdx
@@ -1,6 +1,5 @@
 import { Canvas, Controls, Meta, Source } from '@storybook/blocks';
 import * as CardControlStories from './card-control.stories';
-import LinkTo from '@storybook/addon-links/react';
 import SampleCardControlMethods from './card-control-methods.sample?raw';
 
 <Meta of={CardControlStories} />
@@ -21,7 +20,7 @@ import SampleCardControlMethods from './card-control-methods.sample?raw';
 ## Installation
 
 The `<post-card-control>` element is part of the `@swisspost/design-system-components` package. For more information, read the
-<LinkTo kind="getting-started-components" story="docs">getting started with components guide</LinkTo>.
+<a href="/?path=/docs/edfb619b-fda1-4570-bf25-20830303d483--docs">getting started with components guide</a>.
 
 ## Examples
 

--- a/packages/documentation/src/stories/components/rating/post-rating.docs.mdx
+++ b/packages/documentation/src/stories/components/rating/post-rating.docs.mdx
@@ -22,7 +22,7 @@ interactive and visually appealing way to gather and display user feedback.</p>
 ## Installation
 
 The `<post-rating/>` element is part of the `@swisspost/design-system-components` package.
-For more information, read the <LinkTo kind="edfb619b-fda1-4570-bf25-20830303d483" story="docs">getting started with components guide</LinkTo>.
+For more information, read the <a href="/?path=/docs/edfb619b-fda1-4570-bf25-20830303d483--docs">getting started with components guide</a>.
 
 ## Examples
 

--- a/packages/documentation/src/stories/components/tag/tag.docs.mdx
+++ b/packages/documentation/src/stories/components/tag/tag.docs.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Controls, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
 import {
   PostTabs,
   PostTabHeader,
@@ -35,7 +34,7 @@ import StylesPackageImport from '../../../shared/styles-package-import.mdx';
     ## Icon
 
     An icon is an optional part of the tag component. You can choose any icon that is available in Swiss Post Icon Library.
-    Find the icon you need with the <LinkTo kind="icons-search-for-icons" story="docs">icon search page</LinkTo>.
+    Find the icon you need with the <a href="/?path=/docs/5704bdc4-c5b5-45e6-b123-c54d01fce2f1--docs">icon search page</a>.
 
     <Canvas of={TagStories.Icon}/>
 
@@ -53,12 +52,12 @@ import StylesPackageImport from '../../../shared/styles-package-import.mdx';
     ## Installation
 
     The `<post-tag>` element is part of the `@swisspost/design-system-components` package.
-    For more information, read the <LinkTo kind="getting-started-components" story="docs">getting started with components guide</LinkTo>.
+    For more information, read the <a href="/?path=/docs/edfb619b-fda1-4570-bf25-20830303d483--docs">getting started with components guide</a>.
 
     ## Icon
 
     An icon is an optional part of the tag component. You can choose any icon that is available in Swiss Post Icon Library.
-    Find the icon you need with the <LinkTo kind="icons-search-for-icons" story="docs">icon search page</LinkTo>.
+    Find the icon you need with the <a href="/?path=/docs/5704bdc4-c5b5-45e6-b123-c54d01fce2f1--docs">icon search page</a>.
 
     <Canvas of={PostTagStories.Icon}/>
 


### PR DESCRIPTION
We removed all LinkTo element in https://github.com/swisspost/design-system/issues/2464