### PR TITLE
fix(docs): Rowspan 0 is not supported on Safari

### DIFF
--- a/.changeset/witty-beans-dream.md
+++ b/.changeset/witty-beans-dream.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed table span on Safari for the Introduction page.

--- a/packages/documentation/src/stories/getting-started/introduction.docs.mdx
+++ b/packages/documentation/src/stories/getting-started/introduction.docs.mdx
@@ -40,7 +40,7 @@ The design-system is formed with several packages and different compatibilities 
           Internet-header:
           <list-component packageType={PackageType.InternetHeader}></list-component>
         </td>
-        <td rowSpan="0">
+        <td rowSpan="5">
           {[packages.find(pkg => pkg.name === 'Styles')].map((p => (
             <ti-le title={p.name} href={p.link.docs.href} ariaLabel={p.link.docs.ariaLabel} key={p.name}>
               <img src={p.img.src} alt={p.img.alt}/>


### PR DESCRIPTION
`rowspan=0`according to [mdn allows to span over an infinite number of row](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td#rowspan). But it's actually not supported on Safari: https://caniuse.com/mdn-html_elements_td_rowspan_rowspan_zero