### PR TITLE
fix: stencil config and component implementation in storybook

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,8 +23,8 @@
     "linkDirectory": true
   },
   "scripts": {
-    "dev": "stencil build --port 9200 --serve --watch --docs-readme",
-    "start": "stencil build --watch --docs-readme",
+    "dev": "stencil build --dev --port 9200 --serve --watch --docs --docs-readme",
+    "start": "stencil build --dev --watch --docs --docs-readme",
     "build": "stencil build --docs-readme",
     "clean": "rimraf www dist loader",
     "test": "pnpm run unit",

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -11,7 +11,6 @@ export const config: Config = {
   outputTargets: [
     {
       type: 'dist',
-      empty: false,
       esmLoaderPath: '../loader',
     },
     {

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -7,6 +7,7 @@ import { angularValueAccessorBindings } from './.config/bindings.angular';
 
 export const config: Config = {
   namespace: 'post-components',
+  buildDist: true,
   sourceMap: false,
   outputTargets: [
     {

--- a/packages/documentation/.storybook/helpers/register-web-components.ts
+++ b/packages/documentation/.storybook/helpers/register-web-components.ts
@@ -1,6 +1,12 @@
 // @ts-ignore
-import { defineCustomElements as defineInternetHeader } from '@swisspost/internet-header/loader/index.es2017.js';
-import { defineCustomElements as definePostComponents } from '@swisspost/design-system-components/loader';
+import {
+  applyPolyfills as headerPolyfills,
+  defineCustomElements as defineHeader,
+} from '@swisspost/internet-header/loader/index.es2017.js';
+import {
+  applyPolyfills as componentsPolyfills,
+  defineCustomElements as defineComponents,
+} from '@swisspost/design-system-components/loader';
 import { setStencilDocJson } from '@pxtrn/storybook-addon-docs-stencil';
 import {
   StencilJsonDocs,
@@ -10,8 +16,12 @@ import postComponentsDocJson from '@swisspost/design-system-components/dist/docs
 import internetHeaderDocJson from '@swisspost/internet-header/dist/docs.json';
 import '../../src/shared/link-design/link-design.component';
 
-defineInternetHeader(window);
-definePostComponents(window);
+headerPolyfills().then(() => {
+  defineHeader();
+});
+componentsPolyfills().then(() => {
+  defineComponents();
+});
 
 if (postComponentsDocJson && internetHeaderDocJson) {
   const jsonDocs: StencilJsonDocs = {

--- a/packages/internet-header/stencil.config.ts
+++ b/packages/internet-header/stencil.config.ts
@@ -15,7 +15,6 @@ export const config: Config = {
   outputTargets: [
     {
       type: 'dist',
-      empty: false,
       esmLoaderPath: '../loader',
       copy: [
         {


### PR DESCRIPTION
Sadly, I was not able to find a fix for our development problem, regarding stencil output and vite dynamic import.
But this changes should at least fix the component implementation in storybook and revert the unnecessary "empty" flags in the stencil configs.