### PR TITLE
chore(components): make dev server ready for component development

### DIFF
--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -8,8 +8,11 @@
     />
     <title>Stencil Component Starter</title>
 
+    <link rel="stylesheet" href="/assets/css/index.css" />
     <script type="module" src="/build/post-components.esm.js"></script>
     <script nomodule src="/build/post-components.js"></script>
   </head>
-  <body></body>
+  <body>
+    <div class="p-5">Add your component here and start developing!</div>
+  </body>
 </html>

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -19,6 +19,12 @@ export const config: Config = {
     },
     {
       type: 'www',
+      copy: [
+        {
+          src: '../node_modules/@swisspost/design-system-styles/*.css',
+          dest: 'assets/css',
+        },
+      ],
       serviceWorker: null, // disable service workers,
     },
     {


### PR DESCRIPTION
I've added the index.css from the styles package to the dev server, so we're able to develop component with it, having correct styles set.
This will be a workaround for the dynamic import problem, we're facing, when changing a component, while developing the documentation package.