### PR TITLE
chore(components): implement path aliases

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,7 +48,7 @@
     "@percy/cypress": "3.1.2",
     "@stencil-community/eslint-plugin": "0.7.2",
     "@stencil/angular-output-target": "0.8.4",
-    "@stencil/core": "4.14.0",
+    "@stencil/core": "4.17.1",
     "@stencil/react-output-target": "0.5.3",
     "@stencil/sass": "3.0.11",
     "@types/jest": "29.5.12",

--- a/packages/components/src/components/post-accordion-item/post-accordion-item.tsx
+++ b/packages/components/src/components/post-accordion-item/post-accordion-item.tsx
@@ -1,6 +1,5 @@
 import { Component, Element, h, Host, Listen, Method, Prop, State, Watch } from '@stencil/core';
-import { version } from '../../../package.json';
-import { checkEmptyOrOneOf } from '../../utils';
+import { pkg, checkEmptyOrOneOf } from '@/utils';
 import { HEADING_LEVELS, HeadingLevel } from './heading-levels';
 
 /**
@@ -68,7 +67,7 @@ export class PostAccordionItem {
     const HeadingTag = `h${this.headingLevel ?? 2}`;
 
     return (
-      <Host id={this.id} data-version={version}>
+      <Host id={this.id} data-version={pkg.version}>
         <div part="accordion-item" class="accordion-item">
           <HeadingTag class="accordion-header" id={`${this.id}--header`}>
             <button

--- a/packages/components/src/components/post-accordion/post-accordion.tsx
+++ b/packages/components/src/components/post-accordion/post-accordion.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Host, Listen, Method, Prop } from '@stencil/core';
-import { version } from '../../../package.json';
+import { pkg } from '@/utils';
 
 /**
  * @slot default - Slot for placing post-accordion-item components.
@@ -104,7 +104,7 @@ export class PostAccordion {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <div class="accordion">
           <slot onSlotchange={() => this.registerAccordionItems()} />
         </div>

--- a/packages/components/src/components/post-alert/post-alert.tsx
+++ b/packages/components/src/components/post-alert/post-alert.tsx
@@ -10,9 +10,8 @@ import {
   State,
   Watch,
 } from '@stencil/core';
-import { version } from '../../../package.json';
-import { fadeOut } from '../../animations';
-import { checkEmptyOrOneOf, checkEmptyOrPattern, checkNonEmpty, checkType } from '../../utils';
+import { pkg, checkEmptyOrOneOf, checkEmptyOrPattern, checkNonEmpty, checkType } from '@/utils';
+import { fadeOut } from '@/animations';
 import { ALERT_TYPES, AlertType } from './alert-types';
 
 /**
@@ -155,7 +154,7 @@ export class PostAlert {
     ];
 
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <div role="alert" class={this.classes}>
           {this.dismissible && (
             <button class="btn-close" onClick={this.onDismissButtonClick}>

--- a/packages/components/src/components/post-card-control/post-card-control.tsx
+++ b/packages/components/src/components/post-card-control/post-card-control.tsx
@@ -11,13 +11,11 @@ import {
   State,
   Watch,
 } from '@stencil/core';
-import { checkNonEmpty, checkOneOf } from '../../utils';
-import { version } from '../../../package.json';
+import { pkg, checkNonEmpty, checkOneOf, parse } from '@/utils';
 
 // remove as soon as all browser support :host-context()
 // https://caniuse.com/?search=%3Ahost-context()
 import scss from './post-card-control.module.scss';
-import { parse } from '../../utils/sass-export';
 
 const SCSS_VARIABLES = parse(scss);
 const EVENT_MAP = {
@@ -351,7 +349,7 @@ export class PostCardControl {
 
   render() {
     return (
-      <Host data-version={version} onClick={this.cardClickHandler}>
+      <Host data-version={pkg.version} onClick={this.cardClickHandler}>
         <div
           class={{
             'card-control': true,

--- a/packages/components/src/components/post-collapsible/post-collapsible.tsx
+++ b/packages/components/src/components/post-collapsible/post-collapsible.tsx
@@ -10,9 +10,8 @@ import {
   State,
   Watch,
 } from '@stencil/core';
-import { version } from '../../../package.json';
-import { collapse, expand } from '../../animations/collapse';
-import { checkEmptyOrType, isMotionReduced } from '../../utils';
+import { pkg, checkEmptyOrType, isMotionReduced } from '@/utils';
+import { collapse, expand } from '@/animations/collapse';
 
 /**
  * @slot default - Slot for placing content within the collapsible element.
@@ -91,7 +90,7 @@ export class PostCollapsible {
 
   render() {
     return (
-      <Host id={this.id} data-version={version}>
+      <Host id={this.id} data-version={pkg.version}>
         <div class="collapse" id={`${this.id}--collapse`} ref={el => (this.collapsible = el)}>
           <slot />
         </div>

--- a/packages/components/src/components/post-icon/post-icon.tsx
+++ b/packages/components/src/components/post-icon/post-icon.tsx
@@ -1,6 +1,5 @@
 import { Component, Element, Host, h, Prop, State, Watch } from '@stencil/core';
-import { checkNonEmpty, checkType, checkEmptyOrType, checkEmptyOrOneOf } from '../../utils';
-import { version } from '../../../package.json';
+import { pkg, checkNonEmpty, checkType, checkEmptyOrType, checkEmptyOrOneOf } from '@/utils';
 
 const CDN_URL = 'https://unpkg.com/@swisspost/design-system-icons/public/post-icons';
 const ANIMATION_NAMES = [
@@ -150,7 +149,7 @@ export class PostIcon {
       .filter(([_key, value]) => value !== null)
       .reduce((styles, [key, value]) => Object.assign(styles, { [key]: value }), {});
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <span style={svgStyles}></span>
       </Host>
     );

--- a/packages/components/src/components/post-popover/post-popover.tsx
+++ b/packages/components/src/components/post-popover/post-popover.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Host, Method, Prop } from '@stencil/core';
 import { Placement } from '@floating-ui/dom';
-import { version } from '../../../package.json';
-import { getAttributeObserver } from '../../utils/attribute-observer';
+import { pkg } from '@/utils';
+import { getAttributeObserver } from '@/utils/attribute-observer';
 
 /**
  * @slot default - Slot for placing content inside the popover.
@@ -133,7 +133,7 @@ export class PostPopover {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <post-popovercontainer
           arrow={this.arrow}
           placement={this.placement}

--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
@@ -15,7 +15,7 @@ import {
 // Polyfill for popovers, can be removed when https://caniuse.com/?search=popover is green
 import '@oddbird/popover-polyfill';
 
-import { version } from '../../../package.json';
+import { pkg } from '@/utils';
 
 const SIDE_MAP = {
   top: 'bottom',
@@ -214,7 +214,7 @@ export class PostPopovercontainer {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <div
           class="popover"
           part="popover"

--- a/packages/components/src/components/post-rating/post-rating.tsx
+++ b/packages/components/src/components/post-rating/post-rating.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Host, Prop, State } from '@stencil/core';
-import { version } from '../../../package.json';
+import { pkg } from '@/utils';
 
 @Component({
   tag: 'post-rating',
@@ -108,7 +108,7 @@ export class PostRating {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <div
           role="slider"
           class="rating"

--- a/packages/components/src/components/post-tab-header/post-tab-header.tsx
+++ b/packages/components/src/components/post-tab-header/post-tab-header.tsx
@@ -1,6 +1,5 @@
 import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
-import { version } from '../../../package.json';
-import { checkNonEmpty } from '../../utils';
+import { pkg, checkNonEmpty } from '@/utils';
 
 /**
  * @slot default - Slot for the content of the tab header.
@@ -35,7 +34,7 @@ export class PostTabHeader {
       <Host
         id={this.tabId}
         role="tab"
-        data-version={version}
+        data-version={pkg.version}
         aria-selected="false"
         tabindex="-1"
         class="tab-title"

--- a/packages/components/src/components/post-tab-panel/post-tab-panel.tsx
+++ b/packages/components/src/components/post-tab-panel/post-tab-panel.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Host, Prop, State } from '@stencil/core';
-import { version } from '../../../package.json';
+import { pkg } from '@/utils';
 
 /**
  * @slot default - Slot for placing the content of the tab panel.
@@ -27,7 +27,7 @@ export class PostTabPanel {
 
   render() {
     return (
-      <Host data-version={version} id={this.panelId} role="tabpanel">
+      <Host data-version={pkg.version} id={this.panelId} role="tabpanel">
         <slot />
       </Host>
     );

--- a/packages/components/src/components/post-tabs/post-tabs.tsx
+++ b/packages/components/src/components/post-tabs/post-tabs.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, Event, EventEmitter, h, Host, Method, Prop } from '@stencil/core';
-import { version } from '../../../package.json';
-import { fadeIn, fadeOut } from '../../animations';
+import { pkg } from '@/utils';
+import { fadeIn, fadeOut } from '@/animations';
 
 /**
  * @slot tabs - Slot for placing tab headers. Each tab header should be a <post-tab-header> element.
@@ -195,7 +195,7 @@ export class PostTabs {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <div class="tabs-wrapper">
           <div class="tabs" role="tablist">
             <slot name="tabs" onSlotchange={() => this.enableTabs()} />

--- a/packages/components/src/components/post-tag/post-tag.tsx
+++ b/packages/components/src/components/post-tag/post-tag.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
-import { version } from '../../../package.json';
+import { pkg } from '@/utils';
 
 /**
  * @slot default - Content to place in the `default` slot.<p>Markup accepted: <a href="https://developer.mozilla.org/en-US/docs/Glossary/Inline-level_content" target="_blank">inline content</a>.</p>
@@ -46,7 +46,11 @@ export class PostTag {
   }
 
   private setClasses() {
-    this.classes = ['tag', this.size ? `tag-${this.size}` : null, this.variant ? `tag-${this.variant}` : null]
+    this.classes = [
+      'tag',
+      this.size ? `tag-${this.size}` : null,
+      this.variant ? `tag-${this.variant}` : null,
+    ]
       .filter(c => c !== null)
       .join(' ');
   }
@@ -57,7 +61,7 @@ export class PostTag {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={pkg.version}>
         <div class={this.classes}>
           {this.icon ? <post-icon name={this.icon}></post-icon> : null}
           <div class="tag-text">

--- a/packages/components/src/components/post-tooltip/post-tooltip.tsx
+++ b/packages/components/src/components/post-tooltip/post-tooltip.tsx
@@ -1,9 +1,9 @@
 import { Component, Element, h, Host, Method, Prop } from '@stencil/core';
 import { Placement } from '@floating-ui/dom';
-import { version } from '../../../package.json';
+import { pkg } from '@/utils';
 import isFocusable from 'ally.js/is/focusable';
 import 'long-press-event';
-import { getAttributeObserver } from '../../utils/attribute-observer';
+import { getAttributeObserver } from '@/utils/attribute-observer';
 
 /**
  * @slot default - Slot for the content of the tooltip.
@@ -212,7 +212,7 @@ export class PostTooltip {
     const popoverClass = `${this.arrow ? ' has-arrow' : ''}`;
     return (
       <Host
-        data-version={version}
+        data-version={pkg.version}
         role="tooltip"
         onPointerOver={this.handleInterest}
         onPointerOut={this.handleInterestLost}

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './package';
 export * from './property-checkers';
 export * from './is-motion-reduced';
 export * from './sass-export';

--- a/packages/components/src/utils/package.ts
+++ b/packages/components/src/utils/package.ts
@@ -1,0 +1,2 @@
+import * as packageJson from '@root/package.json';
+export const pkg = packageJson;

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "paths": {
+      "@root/*": ["./*"],
+      "@/*": ["./src/*"]
+    },
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "declaration": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,16 +76,16 @@ importers:
         version: 0.7.2(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3))(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.3.3))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0)(typescript@5.3.3)
       '@stencil/angular-output-target':
         specifier: 0.8.4
-        version: 0.8.4(@stencil/core@4.14.0)
+        version: 0.8.4(@stencil/core@4.17.1)
       '@stencil/core':
-        specifier: 4.14.0
-        version: 4.14.0
+        specifier: 4.17.1
+        version: 4.17.1
       '@stencil/react-output-target':
         specifier: 0.5.3
-        version: 0.5.3(@stencil/core@4.14.0)
+        version: 0.5.3(@stencil/core@4.17.1)
       '@stencil/sass':
         specifier: 3.0.11
-        version: 3.0.11(@stencil/core@4.14.0)
+        version: 3.0.11(@stencil/core@4.17.1)
       '@types/jest':
         specifier: 29.5.12
         version: 29.5.12
@@ -106,7 +106,7 @@ importers:
         version: 13.7.2
       cypress-axe:
         specifier: 1.5.0
-        version: 1.5.0(axe-core@4.7.0)(cypress@13.7.2)
+        version: 1.5.0(axe-core@4.9.0)(cypress@13.7.2)
       cypress-storybook:
         specifier: 0.5.1
         version: 0.5.1(cypress@13.7.2)
@@ -176,7 +176,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 17.3.3
-        version: 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@20.11.16)(chokidar@3.5.3)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.11.16)(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(typescript@5.3.3)
+        version: 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.6(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@20.12.7)(chokidar@3.6.0)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(typescript@5.3.3)
       '@angular-eslint/builder':
         specifier: 17.3.0
         version: 17.3.0(eslint@8.57.0)(typescript@5.3.3)
@@ -191,13 +191,13 @@ importers:
         version: 17.3.0(eslint@8.57.0)(typescript@5.3.3)
       '@angular/cli':
         specifier: 17.3.3
-        version: 17.3.3(chokidar@3.5.3)
+        version: 17.3.3(chokidar@3.6.0)
       '@angular/compiler-cli':
         specifier: 17.3.3
         version: 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@cypress/schematic':
         specifier: 2.5.1
-        version: 2.5.1(@angular/cli@17.3.3(chokidar@3.5.3))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))
+        version: 2.5.1(@angular/cli@17.3.3(chokidar@3.6.0))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))
       '@typescript-eslint/eslint-plugin':
         specifier: 7.5.0
         version: 7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
@@ -227,7 +227,7 @@ importers:
         version: 2.1.0(jasmine-core@5.1.2)(karma-jasmine@5.1.0(karma@6.4.3))(karma@6.4.3)
       ng-packagr:
         specifier: 17.3.0
-        version: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
+        version: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -380,7 +380,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 17.3.3
-        version: 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.17.19)(chokidar@3.5.3)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.17.19)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(typescript@5.3.3)
+        version: 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.17.19)(chokidar@3.6.0)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.17.19)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(typescript@5.3.3)
       '@angular-eslint/builder':
         specifier: 17.3.0
         version: 17.3.0(eslint@8.57.0)(typescript@5.3.3)
@@ -395,7 +395,7 @@ importers:
         version: 17.3.0(eslint@8.57.0)(typescript@5.3.3)
       '@angular/cli':
         specifier: 17.3.3
-        version: 17.3.3(chokidar@3.5.3)
+        version: 17.3.3(chokidar@3.6.0)
       '@angular/compiler-cli':
         specifier: 17.3.3
         version: 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
@@ -561,7 +561,7 @@ importers:
         version: 8.0.8(encoding@0.1.13)(lit@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/web-components-vite':
         specifier: 8.0.8
-        version: 8.0.8(encoding@0.1.13)(lit@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)(vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.74.1)(terser@5.29.1))
+        version: 8.0.8(encoding@0.1.13)(lit@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)(vite@5.2.10(@types/node@20.12.7)(less@4.2.0)(sass@1.74.1)(terser@5.30.4))
       '@types/css-modules':
         specifier: 1.0.5
         version: 1.0.5
@@ -579,7 +579,7 @@ importers:
         version: 13.7.2
       cypress-axe:
         specifier: 1.5.0
-        version: 1.5.0(axe-core@4.7.0)(cypress@13.7.2)
+        version: 1.5.0(axe-core@4.9.0)(cypress@13.7.2)
       lit:
         specifier: 3.1.2
         version: 3.1.2
@@ -700,7 +700,7 @@ importers:
         version: 3.1.2(cypress@13.7.2)
       '@stencil-community/eslint-plugin':
         specifier: 0.7.2
-        version: 0.7.2(@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0)(typescript@4.9.5)
+        version: 0.7.2(@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1(eslint@9.1.1)(typescript@4.9.5))(eslint@9.1.1)(typescript@4.9.5))(@typescript-eslint/parser@7.7.1(eslint@9.1.1)(typescript@4.9.5))(eslint-plugin-react@7.34.1(eslint@9.1.1))(eslint@9.1.1)(typescript@4.9.5)
       '@stencil/core':
         specifier: 4.14.0
         version: 4.14.0
@@ -745,7 +745,7 @@ importers:
         version: 0.5.1(cypress@13.7.2)
       eslint-plugin-react:
         specifier: 7.34.1
-        version: 7.34.1(eslint@8.57.0)
+        version: 7.34.1(eslint@9.1.1)
       globby:
         specifier: 14.0.1
         version: 14.0.1
@@ -766,7 +766,7 @@ importers:
         version: 4.0.0
       rollup-plugin-visualizer:
         specifier: 5.12.0
-        version: 5.12.0(rollup@4.13.0)
+        version: 5.12.0(rollup@4.16.4)
       sass:
         specifier: 1.74.1
         version: 1.74.1
@@ -836,7 +836,7 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 17.3.3
-        version: 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.19.28)(chokidar@3.5.3)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.19.28)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(typescript@5.3.3)
+        version: 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.19.28)(chokidar@3.6.0)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.19.28)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(typescript@5.3.3)
       '@angular-eslint/builder':
         specifier: 17.3.0
         version: 17.3.0(eslint@8.57.0)(typescript@5.3.3)
@@ -851,7 +851,7 @@ importers:
         version: 17.3.0(eslint@8.57.0)(typescript@5.3.3)
       '@angular/cli':
         specifier: 17.3.3
-        version: 17.3.3(chokidar@3.5.3)
+        version: 17.3.3(chokidar@3.6.0)
       '@angular/compiler-cli':
         specifier: 17.3.3
         version: 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
@@ -890,7 +890,7 @@ importers:
         version: 2.1.0(jasmine-core@5.1.2)(karma-jasmine@5.1.0(karma@6.4.3))(karma@6.4.3)
       ng-packagr:
         specifier: 17.3.0
-        version: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
+        version: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
       rimraf:
         specifier: 5.0.5
         version: 5.0.5
@@ -916,10 +916,10 @@ importers:
     dependencies:
       '@angular-devkit/core':
         specifier: '=15.0.4'
-        version: 15.0.4(chokidar@3.5.3)
+        version: 15.0.4(chokidar@3.6.0)
       '@angular-devkit/schematics':
         specifier: '=15.0.4'
-        version: 15.0.4(chokidar@3.5.3)
+        version: 15.0.4(chokidar@3.6.0)
       '@angular/core':
         specifier: '=15.0.4'
         version: 15.0.4(rxjs@7.8.1)(zone.js@0.14.4)
@@ -999,7 +999,7 @@ importers:
     dependencies:
       '@ng-bootstrap/ng-bootstrap':
         specifier: ^15.0.0 || ^16.0.0
-        version: 16.0.0(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(@angular/forms@17.3.3(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@17.3.3(@angular/animations@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@popperjs/core@2.11.8)(rxjs@7.8.1)
+        version: 16.0.0(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(@angular/forms@17.3.6(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@17.3.6(@angular/animations@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1))(@angular/localize@17.3.6(@angular/compiler-cli@17.3.6(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))))(@popperjs/core@2.11.8)(rxjs@7.8.1)
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
@@ -1030,7 +1030,7 @@ importers:
         version: 1.4.0
       gulp-postcss:
         specifier: 10.0.0
-        version: 10.0.0(jiti@1.20.0)(postcss@8.4.38)
+        version: 10.0.0(jiti@1.21.0)(postcss@8.4.38)
       gulp-sass:
         specifier: 5.1.0
         version: 5.1.0
@@ -1204,6 +1204,12 @@ packages:
     peerDependencies:
       '@angular/core': 17.3.3
 
+  '@angular/animations@17.3.6':
+    resolution: {integrity: sha512-ev99cnmc1S/SXYz9OwOyZQyHXHiUf+ZwQFpjYBRPoyKqZV4sOYMlyBbfjBO/GgCVrsGfMvBsCI6PtY3yquuabA==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    peerDependencies:
+      '@angular/core': 17.3.6
+
   '@angular/cdk@17.3.3':
     resolution: {integrity: sha512-hfS9pwaNE6CTZqP3FBh9tZPbuf//bDqZ5IpMzscfDFrwX8ycxBiI3znH/rFSf9l1rL0OQGoqWWNVfJCT+RrukA==}
     peerDependencies:
@@ -1230,6 +1236,13 @@ packages:
       '@angular/core': 17.3.3
       rxjs: ^6.5.3 || ^7.4.0
 
+  '@angular/common@17.3.6':
+    resolution: {integrity: sha512-ufviCFzQQKWcwc2j3Zi8bHbwkvqh4QU6GDH0u0usOee8xd8KrjgcYl3vD0r1/yxlDsd53Wg9kNRvz/fY+5qQoQ==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    peerDependencies:
+      '@angular/core': 17.3.6
+      rxjs: ^6.5.3 || ^7.4.0
+
   '@angular/compiler-cli@17.3.3':
     resolution: {integrity: sha512-vM0lqwuXQZ912HbLnIuvUblvIz2WEUsU7a5Z2ieNey6famH4zxPH12vCbVwXgicB6GLHorhOfcWC5443wD2mJw==}
     engines: {node: ^18.13.0 || >=20.9.0}
@@ -1238,11 +1251,28 @@ packages:
       '@angular/compiler': 17.3.3
       typescript: '>=5.2 <5.5'
 
+  '@angular/compiler-cli@17.3.6':
+    resolution: {integrity: sha512-LaoUkY6uzcNocIEHJBvexvuU0a333IRQaG3Sj5IXhM1t864wTsfycn6yWJcQ7PhklB8BtNqiMbUQuEFtkxT8pg==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    hasBin: true
+    peerDependencies:
+      '@angular/compiler': 17.3.6
+      typescript: '>=5.2 <5.5'
+
   '@angular/compiler@17.3.3':
     resolution: {integrity: sha512-ZNMRfagMxMjk1KW5H3ssCg5QL0J6ZW1JAZ1mrTXixqS7gbdwl60bTGE+EfuEwbjvovEYaj4l9cga47eMaxZTbQ==}
     engines: {node: ^18.13.0 || >=20.9.0}
     peerDependencies:
       '@angular/core': 17.3.3
+    peerDependenciesMeta:
+      '@angular/core':
+        optional: true
+
+  '@angular/compiler@17.3.6':
+    resolution: {integrity: sha512-ybx9O76RGv4J97IThiSVvvWukuGcuXu50KsBDPUd874BFT3ml0OcRGhXoMh/isz7EQipiiGgsA51cJVTLES5Zw==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    peerDependencies:
+      '@angular/core': 17.3.6
     peerDependenciesMeta:
       '@angular/core':
         optional: true
@@ -1268,6 +1298,13 @@ packages:
       rxjs: ^6.5.3 || ^7.4.0
       zone.js: ~0.14.0
 
+  '@angular/core@17.3.6':
+    resolution: {integrity: sha512-8IoeZVNqyeHA+H2dR3VFfz76/TFN1BpXP0aABs2aIUNVQRYlKxALSm1UlavijX8IT0uvd/6GXwE3WgymTcg0wg==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    peerDependencies:
+      rxjs: ^6.5.3 || ^7.4.0
+      zone.js: ~0.14.0
+
   '@angular/elements@17.3.3':
     resolution: {integrity: sha512-XE2T7KY5Qkxvsnh1jfyQr1eN2wUjKBaScpB3bG0YLIs5+5JetUzW+aAmHE/2JVLZOEhqXJy/EN0jPZODA5VDHQ==}
     engines: {node: ^18.13.0 || >=20.9.0}
@@ -1284,6 +1321,15 @@ packages:
       '@angular/platform-browser': 17.3.3
       rxjs: ^6.5.3 || ^7.4.0
 
+  '@angular/forms@17.3.6':
+    resolution: {integrity: sha512-WXxWhwvgRfYLNP2dB4Qe83tavEh2LnS4H0uoiecWHXijW2R9z8304X1vEyS1EtQK7o/s8fCVDVDjeY+hxLnCLw==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    peerDependencies:
+      '@angular/common': 17.3.6
+      '@angular/core': 17.3.6
+      '@angular/platform-browser': 17.3.6
+      rxjs: ^6.5.3 || ^7.4.0
+
   '@angular/language-service@17.3.3':
     resolution: {integrity: sha512-OtdWNY0Syg4UvA8j2IhQJeq/UjWHYbRiyUcZjGKPRzuqIPjUhsmMyuW3zpi7Pwx2CpBzZXcik1Ra2WZ0gbwigg==}
     engines: {node: ^18.13.0 || >=20.9.0}
@@ -1295,6 +1341,14 @@ packages:
     peerDependencies:
       '@angular/compiler': 17.3.3
       '@angular/compiler-cli': 17.3.3
+
+  '@angular/localize@17.3.6':
+    resolution: {integrity: sha512-bgXuhCiQoKJUJPj30b5VFApQw2/L34M1vnVI1pYOdcFM0rQbK9EQHqi7kdoz9j2IOdaSOTmVEGRmfxtxyyhZiw==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    hasBin: true
+    peerDependencies:
+      '@angular/compiler': 17.3.6
+      '@angular/compiler-cli': 17.3.6
 
   '@angular/platform-browser-dynamic@17.3.3':
     resolution: {integrity: sha512-jSgSNHRTXCIat20I+4tLm/e8qOvrIE3Zv7S/DtYZEiAth84uoznvo1kXnN+KREse2vP/WoNgSDKQ2JLzkwYXSQ==}
@@ -1312,6 +1366,17 @@ packages:
       '@angular/animations': 17.3.3
       '@angular/common': 17.3.3
       '@angular/core': 17.3.3
+    peerDependenciesMeta:
+      '@angular/animations':
+        optional: true
+
+  '@angular/platform-browser@17.3.6':
+    resolution: {integrity: sha512-UikrgvMwtZIXp2pCP5AtkM7ibz2B5wBiGpnhhkYsqHKy9ndKVDA+3B5Z+/j9xeYYdsJAAtHl45zqILewyg+4iw==}
+    engines: {node: ^18.13.0 || >=20.9.0}
+    peerDependencies:
+      '@angular/animations': 17.3.6
+      '@angular/common': 17.3.6
+      '@angular/core': 17.3.6
     peerDependenciesMeta:
       '@angular/animations':
         optional: true
@@ -2165,6 +2230,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.20.2':
+    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.19.12':
     resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
@@ -2173,6 +2244,12 @@ packages:
 
   '@esbuild/android-arm64@0.20.1':
     resolution: {integrity: sha512-hCnXNF0HM6AjowP+Zou0ZJMWWa1VkD77BXe959zERgGJBBxB+sV+J9f/rcjeg2c5bsukD/n17RKWXGFCO5dD5A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.20.2':
+    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -2189,6 +2266,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.20.2':
+    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.19.12':
     resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
@@ -2197,6 +2280,12 @@ packages:
 
   '@esbuild/android-x64@0.20.1':
     resolution: {integrity: sha512-MSfZMBoAsnhpS+2yMFYIQUPs8Z19ajwfuaSZx+tSl09xrHZCjbeXXMsUF/0oq7ojxYEpsSo4c0SfjxOYXRbpaA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.20.2':
+    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -2213,6 +2302,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.20.2':
+    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.19.12':
     resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
@@ -2221,6 +2316,12 @@ packages:
 
   '@esbuild/darwin-x64@0.20.1':
     resolution: {integrity: sha512-pFIfj7U2w5sMp52wTY1XVOdoxw+GDwy9FsK3OFz4BpMAjvZVs0dT1VXs8aQm22nhwoIWUmIRaE+4xow8xfIDZA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.20.2':
+    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -2237,6 +2338,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.20.2':
+    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.19.12':
     resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
@@ -2245,6 +2352,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.20.1':
     resolution: {integrity: sha512-itPwCw5C+Jh/c624vcDd9kRCCZVpzpQn8dtwoYIt2TJF3S9xJLiRohnnNrKwREvcZYx0n8sCSbvGH349XkcQeg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.20.2':
+    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -2261,6 +2374,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.20.2':
+    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.19.12':
     resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
@@ -2269,6 +2388,12 @@ packages:
 
   '@esbuild/linux-arm@0.20.1':
     resolution: {integrity: sha512-LojC28v3+IhIbfQ+Vu4Ut5n3wKcgTu6POKIHN9Wpt0HnfgUGlBuyDDQR4jWZUZFyYLiz4RBBBmfU6sNfn6RhLw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.20.2':
+    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -2285,6 +2410,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.20.2':
+    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.19.12':
     resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
@@ -2293,6 +2424,12 @@ packages:
 
   '@esbuild/linux-loong64@0.20.1':
     resolution: {integrity: sha512-c0jgtB+sRHCciVXlyjDcWb2FUuzlGVRwGXgI+3WqKOIuoo8AmZAddzeOHeYLtD+dmtHw3B4Xo9wAUdjlfW5yYA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.20.2':
+    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -2309,6 +2446,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.20.2':
+    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.19.12':
     resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
@@ -2317,6 +2460,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.20.1':
     resolution: {integrity: sha512-b+yuD1IUeL+Y93PmFZDZFIElwbmFfIKLKlYI8M6tRyzE6u7oEP7onGk0vZRh8wfVGC2dZoy0EqX1V8qok4qHaw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.20.2':
+    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -2333,6 +2482,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.20.2':
+    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.19.12':
     resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
     engines: {node: '>=12'}
@@ -2341,6 +2496,12 @@ packages:
 
   '@esbuild/linux-s390x@0.20.1':
     resolution: {integrity: sha512-5BepC2Au80EohQ2dBpyTquqGCES7++p7G+7lXe1bAIvMdXm4YYcEfZtQrP4gaoZ96Wv1Ute61CEHFU7h4FMueQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.20.2':
+    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -2357,6 +2518,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.20.2':
+    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-x64@0.19.12':
     resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
     engines: {node: '>=12'}
@@ -2365,6 +2532,12 @@ packages:
 
   '@esbuild/netbsd-x64@0.20.1':
     resolution: {integrity: sha512-4fL68JdrLV2nVW2AaWZBv3XEm3Ae3NZn/7qy2KGAt3dexAgSVT+Hc97JKSZnqezgMlv9x6KV0ZkZY7UO5cNLCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.20.2':
+    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -2381,6 +2554,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.20.2':
+    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/sunos-x64@0.19.12':
     resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
     engines: {node: '>=12'}
@@ -2389,6 +2568,12 @@ packages:
 
   '@esbuild/sunos-x64@0.20.1':
     resolution: {integrity: sha512-ZnWEyCM0G1Ex6JtsygvC3KUUrlDXqOihw8RicRuQAzw+c4f1D66YlPNNV3rkjVW90zXVsHwZYWbJh3v+oQFM9Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.20.2':
+    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -2405,6 +2590,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.20.2':
+    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.19.12':
     resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
     engines: {node: '>=12'}
@@ -2413,6 +2604,12 @@ packages:
 
   '@esbuild/win32-ia32@0.20.1':
     resolution: {integrity: sha512-HzcJa1NcSWTAU0MJIxOho8JftNp9YALui3o+Ny7hCh0v5f90nprly1U3Sj1Ldj/CvKKdvvFsCRvDkpsEMp4DNw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.20.2':
+    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -2429,11 +2626,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@esbuild/win32-x64@0.20.2':
+    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@eslint-community/eslint-utils@4.4.0':
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.10.0':
+    resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint-community/regexpp@4.6.2':
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
@@ -2443,6 +2650,10 @@ packages:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@eslint/eslintrc@3.0.2':
+    resolution: {integrity: sha512-wV19ZEGEMAC1eHgrS7UQPqsdEiCIbTKTasEfcXAigzoXICcqZSjBZEHlZwNVvKg6UBCjSlos84XiLqsRJnIcIg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@8.56.0':
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2450,6 +2661,10 @@ packages:
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@9.1.1':
+    resolution: {integrity: sha512-5WoDz3Y19Bg2BnErkZTp0en+c/i9PvgFS7MBe1+m60HjFr0hrphlAGp4yzI7pxpt4xShln4ZyYp4neJm8hmOkQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@fal-works/esbuild-plugin-global-externals@2.1.2':
     resolution: {integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==}
@@ -2503,6 +2718,10 @@ packages:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
 
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+    engines: {node: '>=10.10.0'}
+
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
@@ -2512,6 +2731,13 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.2':
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+
+  '@humanwhocodes/retry@0.2.3':
+    resolution: {integrity: sha512-X38nUbachlb01YMlvPFojKoiXq+LzZvuSce70KPMPdeM1Rj03k4dR7lDslhbqXn3Ang4EU3+EAmwEAsbrjHW3g==}
+    engines: {node: '>=18.18'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -2613,6 +2839,9 @@ packages:
 
   '@jridgewell/source-map@0.3.3':
     resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
+
+  '@jridgewell/source-map@0.3.6':
+    resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
 
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
@@ -3003,8 +3232,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.16.4':
+    resolution: {integrity: sha512-GkhjAaQ8oUTOKE4g4gsZ0u8K/IHU1+2WQSgS1TwTcYvL+sjbaQjNHFXbOJ6kgqGHIO1DfUhI/Sphi9GkRT9K+Q==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.13.0':
     resolution: {integrity: sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.16.4':
+    resolution: {integrity: sha512-Bvm6D+NPbGMQOcxvS1zUl8H7DWlywSXsphAeOnVeiZLQ+0J6Is8T7SrjGTH29KtYkiY9vld8ZnpV3G2EPbom+w==}
     cpu: [arm64]
     os: [android]
 
@@ -3013,8 +3252,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.16.4':
+    resolution: {integrity: sha512-i5d64MlnYBO9EkCOGe5vPR/EeDwjnKOGGdd7zKFhU5y8haKhQZTN2DgVtpODDMxUr4t2K90wTUJg7ilgND6bXw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.13.0':
     resolution: {integrity: sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.16.4':
+    resolution: {integrity: sha512-WZupV1+CdUYehaZqjaFTClJI72fjJEgTXdf4NbW69I9XyvdmztUExBtcI2yIIU6hJtYvtwS6pkTkHJz+k08mAQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -3023,8 +3272,23 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.16.4':
+    resolution: {integrity: sha512-ADm/xt86JUnmAfA9mBqFcRp//RVRt1ohGOYF6yL+IFCYqOBNwy5lbEK05xTsEoJq+/tJzg8ICUtS82WinJRuIw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.16.4':
+    resolution: {integrity: sha512-tJfJaXPiFAG+Jn3cutp7mCs1ePltuAgRqdDZrzb1aeE3TktWWJ+g7xK9SNlaSUFw6IU4QgOxAY4rA+wZUT5Wfg==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-gnu@4.13.0':
     resolution: {integrity: sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.16.4':
+    resolution: {integrity: sha512-7dy1BzQkgYlUTapDTvK997cgi0Orh5Iu7JlZVBy1MBURk7/HSbHkzRnXZa19ozy+wwD8/SlpJnOOckuNZtJR9w==}
     cpu: [arm64]
     os: [linux]
 
@@ -3033,13 +3297,38 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-musl@4.16.4':
+    resolution: {integrity: sha512-zsFwdUw5XLD1gQe0aoU2HVceI6NEW7q7m05wA46eUAyrkeNYExObfRFQcvA6zw8lfRc5BHtan3tBpo+kqEOxmg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.16.4':
+    resolution: {integrity: sha512-p8C3NnxXooRdNrdv6dBmRTddEapfESEUflpICDNKXpHvTjRRq1J82CbU5G3XfebIZyI3B0s074JHMWD36qOW6w==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.13.0':
     resolution: {integrity: sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==}
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.16.4':
+    resolution: {integrity: sha512-Lh/8ckoar4s4Id2foY7jNgitTOUQczwMWNYi+Mjt0eQ9LKhr6sK477REqQkmy8YHY3Ca3A2JJVdXnfb3Rrwkng==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.16.4':
+    resolution: {integrity: sha512-1xwwn9ZCQYuqGmulGsTZoKrrn0z2fAur2ujE60QgyDpHmBbXbxLaQiEvzJWDrscRq43c8DnuHx3QorhMTZgisQ==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.13.0':
     resolution: {integrity: sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.16.4':
+    resolution: {integrity: sha512-LuOGGKAJ7dfRtxVnO1i3qWc6N9sh0Em/8aZ3CezixSTM+E9Oq3OvTsvC4sm6wWjzpsIlOCnZjdluINKESflJLA==}
     cpu: [x64]
     os: [linux]
 
@@ -3048,8 +3337,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.16.4':
+    resolution: {integrity: sha512-ch86i7KkJKkLybDP2AtySFTRi5fM3KXp0PnHocHuJMdZwu7BuyIKi35BE9guMlmTpwwBTB3ljHj9IQXnTCD0vA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-win32-arm64-msvc@4.13.0':
     resolution: {integrity: sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.16.4':
+    resolution: {integrity: sha512-Ma4PwyLfOWZWayfEsNQzTDBVW8PZ6TUUN1uFTBQbF2Chv/+sjenE86lpiEwj2FiviSmSZ4Ap4MaAfl1ciF4aSA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3058,8 +3357,18 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.16.4':
+    resolution: {integrity: sha512-9m/ZDrQsdo/c06uOlP3W9G2ENRVzgzbSXmXHT4hwVaDQhYcRpi9bgBT0FTG9OhESxwK0WjQxYOSfv40cU+T69w==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.13.0':
     resolution: {integrity: sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.16.4':
+    resolution: {integrity: sha512-YunpoOAyGLDseanENHmbFvQSfVL5BxW3k7hhy0eN4rb3gS/ct75dVD0EXOWIqFT/nE8XYW6LP6vz6ctKRi0k9A==}
     cpu: [x64]
     os: [win32]
 
@@ -3141,6 +3450,11 @@ packages:
 
   '@stencil/core@4.14.0':
     resolution: {integrity: sha512-+s0u/KsNolXZ7tC2hEMgMA3jaNaqOhZvYKwSzjQbc0Wv+cB481Isxzo7ifgEWRYqsJzNSyqhO6cyu/EJrGGTdg==}
+    engines: {node: '>=16.0.0', npm: '>=7.10.0'}
+    hasBin: true
+
+  '@stencil/core@4.17.1':
+    resolution: {integrity: sha512-nlARe1QtK5abnCG8kPQKJMWiELg39vKabvf3ebm6YEhQA35CgrxC1pVYTsYq3yktJKoY+k+VzGRnATLKyaLbvA==}
     engines: {node: '>=16.0.0', npm: '>=7.10.0'}
     hasBin: true
 
@@ -3604,6 +3918,9 @@ packages:
   '@types/json-schema@7.0.14':
     resolution: {integrity: sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
@@ -3646,6 +3963,9 @@ packages:
   '@types/node@20.11.16':
     resolution: {integrity: sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==}
 
+  '@types/node@20.12.7':
+    resolution: {integrity: sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==}
+
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
 
@@ -3687,6 +4007,9 @@ packages:
 
   '@types/semver@7.5.0':
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+
+  '@types/semver@7.5.8':
+    resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
 
   '@types/send@0.17.1':
     resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
@@ -3772,6 +4095,17 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/eslint-plugin@7.7.1':
+    resolution: {integrity: sha512-KwfdWXJBOviaBVhxO3p5TJiLpNuh2iyXyjmWN0f1nU87pwyvfS0EmjC6ukQVYVFJd/K1+0NWGPDXiyEyQorn0Q==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^7.0.0
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/parser@5.62.0':
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3802,6 +4136,16 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/parser@7.7.1':
+    resolution: {integrity: sha512-vmPzBOOtz48F6JAGVS/kZYk4EkXao6iGrD838sp1w3NQQC0W8ry/q641KU4PrG7AKNAf56NOcR8GOpH8l9FPCw==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/scope-manager@5.62.0':
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3816,6 +4160,10 @@ packages:
 
   '@typescript-eslint/scope-manager@7.5.0':
     resolution: {integrity: sha512-Z1r7uJY0MDeUlql9XJ6kRVgk/sP11sr3HKXn268HZyqL7i4cEfrdFuSSY/0tUqT37l5zT0tJOsuDP16kio85iA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/scope-manager@7.7.1':
+    resolution: {integrity: sha512-PytBif2SF+9SpEUKynYn5g1RHFddJUcyynGpztX3l/ik7KmZEv19WCMhUBkHXPU9es/VWGD3/zg3wg90+Dh2rA==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/type-utils@5.62.0':
@@ -3858,6 +4206,16 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/type-utils@7.7.1':
+    resolution: {integrity: sha512-ZksJLW3WF7o75zaBPScdW1Gbkwhd/lyeXGf1kQCxJaOeITscoSl0MjynVvCzuV5boUz/3fOI06Lz8La55mu29Q==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/types@5.62.0':
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3872,6 +4230,10 @@ packages:
 
   '@typescript-eslint/types@7.5.0':
     resolution: {integrity: sha512-tv5B4IHeAdhR7uS4+bf8Ov3k793VEVHd45viRRkehIUZxm0WF82VPiLgHzA/Xl4TGPg1ZD49vfxBKFPecD5/mg==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/types@7.7.1':
+    resolution: {integrity: sha512-AmPmnGW1ZLTpWa+/2omPrPfR7BcbUU4oha5VIbSbS1a1Tv966bklvLNXxp3mrbc+P2j4MNOTfDffNsk4o0c6/w==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@typescript-eslint/typescript-estree@5.62.0':
@@ -3910,6 +4272,15 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/typescript-estree@7.7.1':
+    resolution: {integrity: sha512-CXe0JHCXru8Fa36dteXqmH2YxngKJjkQLjxzoj6LYwzZ7qZvgsLSc+eqItCrqIop8Vl2UKoAi0StVWu97FQZIQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@typescript-eslint/utils@5.62.0':
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3934,6 +4305,12 @@ packages:
     peerDependencies:
       eslint: ^8.56.0
 
+  '@typescript-eslint/utils@7.7.1':
+    resolution: {integrity: sha512-QUvBxPEaBXf41ZBbaidKICgVL8Hin0p6prQDu6bbetWo39BKbWJxRsErOzMNT1rXvTll+J7ChrbmMCXM9rsvOQ==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+    peerDependencies:
+      eslint: ^8.56.0
+
   '@typescript-eslint/visitor-keys@5.62.0':
     resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3948,6 +4325,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@7.5.0':
     resolution: {integrity: sha512-mcuHM/QircmA6O7fy6nn2w/3ditQkj+SgtOc8DW3uQ10Yfj42amm2i+6F2K4YAOPNNTmE6iM1ynM6lrSwdendA==}
+    engines: {node: ^18.18.0 || >=20.0.0}
+
+  '@typescript-eslint/visitor-keys@7.7.1':
+    resolution: {integrity: sha512-gBL3Eq25uADw1LQ9kVpf3hRM+DWzs0uZknHYK3hq4jcTPqVCClHGDnB6UUUV2SFeBeA4KWHWbbLqmbGcZ4FYbw==}
     engines: {node: ^18.18.0 || >=20.0.0}
 
   '@ungap/structured-clone@1.2.0':
@@ -4090,6 +4471,11 @@ packages:
   acorn-walk@8.2.0:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
+
+  acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
 
   acorn@8.9.0:
     resolution: {integrity: sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==}
@@ -4459,6 +4845,10 @@ packages:
     resolution: {integrity: sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==}
     engines: {node: '>=4'}
 
+  axe-core@4.9.0:
+    resolution: {integrity: sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==}
+    engines: {node: '>=4'}
+
   axios@1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
 
@@ -4793,6 +5183,10 @@ packages:
 
   chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
   chownr@1.1.4:
@@ -5709,6 +6103,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.20.2:
+    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -5856,6 +6255,10 @@ packages:
     resolution: {integrity: sha512-zj3Byw6jX4TcFCJmxOzLt6iol5FAr9xQyZZSQjEzW2UiCJXLwXdRIKCYVFftnpZckaC9Ps9xlC7jB8tSeWWOaw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-scope@8.0.1:
+    resolution: {integrity: sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-utils@3.0.0:
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
@@ -5870,6 +6273,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.0.0:
+    resolution: {integrity: sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.56.0:
     resolution: {integrity: sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5880,9 +6287,18 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
 
+  eslint@9.1.1:
+    resolution: {integrity: sha512-b4cRQ0BeZcSEzPpY2PjFY70VbO32K7BStTGtBsnIGdTSEEQzBi8hPBcGQmTG2zUvFr9uLe0TK42bw8YszuHEqg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
+
+  espree@10.0.1:
+    resolution: {integrity: sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -6424,6 +6840,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
@@ -7395,6 +7815,10 @@ packages:
     resolution: {integrity: sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==}
     hasBin: true
 
+  jiti@1.21.0:
+    resolution: {integrity: sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==}
+    hasBin: true
+
   joi@17.11.0:
     resolution: {integrity: sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==}
 
@@ -7980,6 +8404,10 @@ packages:
 
   minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimatch@9.0.4:
+    resolution: {integrity: sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist-options@4.1.0:
@@ -9281,6 +9709,9 @@ packages:
     resolution: {integrity: sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==}
     deprecated: This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer.
 
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+
   reflect.getprototypeof@1.0.5:
     resolution: {integrity: sha512-62wgfC8dJWrmxv44CA36pLDnP6KKl3Vhxb7PL+8+qrrFMMoJij4vgiMP8zV4O8+CBMXY1mHxI5fITGHXFHVmQQ==}
     engines: {node: '>= 0.4'}
@@ -9504,6 +9935,11 @@ packages:
 
   rollup@4.13.0:
     resolution: {integrity: sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.16.4:
+    resolution: {integrity: sha512-kuaTJSUbz+Wsb2ATGvEknkI12XV40vIiHmLuFlejoo7HtDok/O5eDDD0UpCVY5bBX5U5RYo8wWP83H7ZsqVEnA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -10163,6 +10599,11 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
+  tailwindcss@3.4.3:
+    resolution: {integrity: sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -10223,6 +10664,11 @@ packages:
 
   terser@5.29.1:
     resolution: {integrity: sha512-lZQ/fyaIGxsbGxApKmoPTODIzELy3++mXhS5hOqaAWZjQtpq/hFHAc+rm29NND1rYRxRWKcjuARNwULNXa5RtQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  terser@5.30.4:
+    resolution: {integrity: sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -10344,6 +10790,12 @@ packages:
   ts-api-utils@1.0.2:
     resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
     engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+
+  ts-api-utils@1.3.0:
+    resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
+    engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
 
@@ -10788,6 +11240,34 @@ packages:
       terser:
         optional: true
 
+  vite@5.2.10:
+    resolution: {integrity: sha512-PAzgUZbP7msvQvqdSD+ErD5qGnSFiGOoWmV5yAKUEI0kdhjbH6nMWVyZQC/hSc4aXwc0oJ9aEdIiF9Oje0JFCw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   void-elements@2.0.1:
     resolution: {integrity: sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==}
     engines: {node: '>=0.10.0'}
@@ -11162,19 +11642,19 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@angular-devkit/architect@0.1703.3(chokidar@3.5.3)':
+  '@angular-devkit/architect@0.1703.3(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/core': 17.3.3(chokidar@3.5.3)
+      '@angular-devkit/core': 17.3.3(chokidar@3.6.0)
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.17.19)(chokidar@3.5.3)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.17.19)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(typescript@5.3.3)':
+  '@angular-devkit/build-angular@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.17.19)(chokidar@3.6.0)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.17.19)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(typescript@5.3.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1703.3(chokidar@3.5.3)
-      '@angular-devkit/build-webpack': 0.1703.3(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))
-      '@angular-devkit/core': 17.3.3(chokidar@3.5.3)
+      '@angular-devkit/architect': 0.1703.3(chokidar@3.6.0)
+      '@angular-devkit/build-webpack': 0.1703.3(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))
+      '@angular-devkit/core': 17.3.3(chokidar@3.6.0)
       '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@babel/core': 7.24.0
       '@babel/generator': 7.23.6
@@ -11242,8 +11722,8 @@ snapshots:
       jest: 29.7.0(@types/node@18.17.19)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3))
       jest-environment-jsdom: 29.7.0
       karma: 6.4.3
-      ng-packagr: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3))
+      ng-packagr: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -11263,12 +11743,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-angular@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.19.28)(chokidar@3.5.3)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.19.28)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(typescript@5.3.3)':
+  '@angular-devkit/build-angular@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@18.19.28)(chokidar@3.6.0)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@18.19.28)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(typescript@5.3.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1703.3(chokidar@3.5.3)
-      '@angular-devkit/build-webpack': 0.1703.3(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))
-      '@angular-devkit/core': 17.3.3(chokidar@3.5.3)
+      '@angular-devkit/architect': 0.1703.3(chokidar@3.6.0)
+      '@angular-devkit/build-webpack': 0.1703.3(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))
+      '@angular-devkit/core': 17.3.3(chokidar@3.6.0)
       '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@babel/core': 7.24.0
       '@babel/generator': 7.23.6
@@ -11336,8 +11816,8 @@ snapshots:
       jest: 29.7.0(@types/node@18.19.28)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3))
       jest-environment-jsdom: 29.7.0
       karma: 6.4.3
-      ng-packagr: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3))
+      ng-packagr: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -11357,12 +11837,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-angular@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@20.11.16)(chokidar@3.5.3)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.11.16)(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(typescript@5.3.3)':
+  '@angular-devkit/build-angular@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/localize@17.3.6(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))))(@types/express@4.17.17)(@types/node@20.12.7)(chokidar@3.6.0)(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(karma@6.4.3)(ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(typescript@5.3.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1703.3(chokidar@3.5.3)
-      '@angular-devkit/build-webpack': 0.1703.3(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))
-      '@angular-devkit/core': 17.3.3(chokidar@3.5.3)
+      '@angular-devkit/architect': 0.1703.3(chokidar@3.6.0)
+      '@angular-devkit/build-webpack': 0.1703.3(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))
+      '@angular-devkit/core': 17.3.3(chokidar@3.6.0)
       '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@babel/core': 7.24.0
       '@babel/generator': 7.23.6
@@ -11375,7 +11855,7 @@ snapshots:
       '@babel/runtime': 7.24.0
       '@discoveryjs/json-ext': 0.5.7
       '@ngtools/webpack': 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(typescript@5.3.3)(webpack@5.90.3(esbuild@0.20.1))
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
+      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.1.5(@types/node@20.12.7)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.18(postcss@8.4.35)
       babel-loader: 9.1.3(@babel/core@7.24.0)(webpack@5.90.3(esbuild@0.20.1))
@@ -11417,7 +11897,7 @@ snapshots:
       tslib: 2.6.2
       typescript: 5.3.3
       undici: 6.7.1
-      vite: 5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
+      vite: 5.1.5(@types/node@20.12.7)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
       watchpack: 2.4.0
       webpack: 5.90.3(esbuild@0.20.1)
       webpack-dev-middleware: 6.1.2(webpack@5.90.3(esbuild@0.20.1))
@@ -11425,13 +11905,13 @@ snapshots:
       webpack-merge: 5.10.0
       webpack-subresource-integrity: 5.1.0(webpack@5.90.3(esbuild@0.20.1))
     optionalDependencies:
-      '@angular/localize': 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))
+      '@angular/localize': 17.3.6(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))
       esbuild: 0.20.1
-      jest: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3))
+      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
       jest-environment-jsdom: 29.7.0
       karma: 6.4.3
-      ng-packagr: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3))
+      ng-packagr: 17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3)
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -11451,16 +11931,16 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1703.3(chokidar@3.5.3)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))':
+  '@angular-devkit/build-webpack@0.1703.3(chokidar@3.6.0)(webpack-dev-server@4.15.1(webpack@5.90.3(esbuild@0.20.1)))(webpack@5.90.3(esbuild@0.20.1))':
     dependencies:
-      '@angular-devkit/architect': 0.1703.3(chokidar@3.5.3)
+      '@angular-devkit/architect': 0.1703.3(chokidar@3.6.0)
       rxjs: 7.8.1
       webpack: 5.90.3(esbuild@0.20.1)
       webpack-dev-server: 4.15.1(webpack@5.90.3(esbuild@0.20.1))
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/core@15.0.4(chokidar@3.5.3)':
+  '@angular-devkit/core@15.0.4(chokidar@3.6.0)':
     dependencies:
       ajv: 8.11.0
       ajv-formats: 2.1.1(ajv@8.11.0)
@@ -11468,9 +11948,9 @@ snapshots:
       rxjs: 6.6.7
       source-map: 0.7.4
     optionalDependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
 
-  '@angular-devkit/core@17.3.3(chokidar@3.5.3)':
+  '@angular-devkit/core@17.3.3(chokidar@3.6.0)':
     dependencies:
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
@@ -11479,11 +11959,11 @@ snapshots:
       rxjs: 7.8.1
       source-map: 0.7.4
     optionalDependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
 
-  '@angular-devkit/schematics@15.0.4(chokidar@3.5.3)':
+  '@angular-devkit/schematics@15.0.4(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/core': 15.0.4(chokidar@3.5.3)
+      '@angular-devkit/core': 15.0.4(chokidar@3.6.0)
       jsonc-parser: 3.2.0
       magic-string: 0.26.7
       ora: 5.4.1
@@ -11491,9 +11971,9 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/schematics@17.3.3(chokidar@3.5.3)':
+  '@angular-devkit/schematics@17.3.3(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/core': 17.3.3(chokidar@3.5.3)
+      '@angular-devkit/core': 17.3.3(chokidar@3.6.0)
       jsonc-parser: 3.2.1
       magic-string: 0.30.8
       ora: 5.4.1
@@ -11557,6 +12037,12 @@ snapshots:
       '@angular/core': 17.3.3(rxjs@7.8.1)(zone.js@0.14.4)
       tslib: 2.6.2
 
+  '@angular/animations@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))':
+    dependencies:
+      '@angular/core': 17.3.6(rxjs@7.8.1)(zone.js@0.14.4)
+      tslib: 2.6.2
+    optional: true
+
   '@angular/cdk@17.3.3(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)':
     dependencies:
       '@angular/common': 17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)
@@ -11566,12 +12052,12 @@ snapshots:
     optionalDependencies:
       parse5: 7.1.2
 
-  '@angular/cli@17.3.3(chokidar@3.5.3)':
+  '@angular/cli@17.3.3(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/architect': 0.1703.3(chokidar@3.5.3)
-      '@angular-devkit/core': 17.3.3(chokidar@3.5.3)
-      '@angular-devkit/schematics': 17.3.3(chokidar@3.5.3)
-      '@schematics/angular': 17.3.3(chokidar@3.5.3)
+      '@angular-devkit/architect': 0.1703.3(chokidar@3.6.0)
+      '@angular-devkit/core': 17.3.3(chokidar@3.6.0)
+      '@angular-devkit/schematics': 17.3.3(chokidar@3.6.0)
+      '@schematics/angular': 17.3.3(chokidar@3.6.0)
       '@yarnpkg/lockfile': 1.1.0
       ansi-colors: 4.1.3
       ini: 4.1.2
@@ -11603,6 +12089,12 @@ snapshots:
       rxjs: 7.8.1
       tslib: 2.6.2
 
+  '@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)':
+    dependencies:
+      '@angular/core': 17.3.6(rxjs@7.8.1)(zone.js@0.14.4)
+      rxjs: 7.8.1
+      tslib: 2.6.2
+
   '@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)':
     dependencies:
       '@angular/compiler': 17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))
@@ -11618,11 +12110,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@angular/compiler-cli@17.3.6(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)':
+    dependencies:
+      '@angular/compiler': 17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))
+      '@babel/core': 7.23.9
+      '@jridgewell/sourcemap-codec': 1.4.15
+      chokidar: 3.6.0
+      convert-source-map: 1.9.0
+      reflect-metadata: 0.2.2
+      semver: 7.6.0
+      tslib: 2.6.2
+      typescript: 5.3.3
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))':
     dependencies:
       tslib: 2.6.2
     optionalDependencies:
       '@angular/core': 17.3.3(rxjs@7.8.1)(zone.js@0.14.4)
+
+  '@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))':
+    dependencies:
+      tslib: 2.6.2
+    optionalDependencies:
+      '@angular/core': 17.3.6(rxjs@7.8.1)(zone.js@0.14.4)
 
   '@angular/core@15.0.4(rxjs@7.8.1)(zone.js@0.14.4)':
     dependencies:
@@ -11642,6 +12155,12 @@ snapshots:
       tslib: 2.6.2
       zone.js: 0.14.4
 
+  '@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)':
+    dependencies:
+      rxjs: 7.8.1
+      tslib: 2.6.2
+      zone.js: 0.14.4
+
   '@angular/elements@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)':
     dependencies:
       '@angular/core': 17.3.3(rxjs@7.8.1)(zone.js@0.14.4)
@@ -11656,12 +12175,43 @@ snapshots:
       rxjs: 7.8.1
       tslib: 2.6.2
 
+  '@angular/forms@17.3.6(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@17.3.6(@angular/animations@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1)':
+    dependencies:
+      '@angular/common': 17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)
+      '@angular/core': 17.3.6(rxjs@7.8.1)(zone.js@0.14.4)
+      '@angular/platform-browser': 17.3.6(@angular/animations@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))
+      rxjs: 7.8.1
+      tslib: 2.6.2
+
   '@angular/language-service@17.3.3': {}
 
   '@angular/localize@17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))':
     dependencies:
       '@angular/compiler': 17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))
       '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
+      '@babel/core': 7.23.9
+      '@types/babel__core': 7.20.5
+      fast-glob: 3.3.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@angular/localize@17.3.6(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))':
+    dependencies:
+      '@angular/compiler': 17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))
+      '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
+      '@babel/core': 7.23.9
+      '@types/babel__core': 7.20.5
+      fast-glob: 3.3.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@angular/localize@17.3.6(@angular/compiler-cli@17.3.6(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))':
+    dependencies:
+      '@angular/compiler': 17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))
+      '@angular/compiler-cli': 17.3.6(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@babel/core': 7.23.9
       '@types/babel__core': 7.20.5
       fast-glob: 3.3.2
@@ -11684,6 +12234,14 @@ snapshots:
       tslib: 2.6.2
     optionalDependencies:
       '@angular/animations': 17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))
+
+  '@angular/platform-browser@17.3.6(@angular/animations@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))':
+    dependencies:
+      '@angular/common': 17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)
+      '@angular/core': 17.3.6(rxjs@7.8.1)(zone.js@0.14.4)
+      tslib: 2.6.2
+    optionalDependencies:
+      '@angular/animations': 17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))
 
   '@angular/router@17.3.3(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@17.3.3(@angular/animations@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1)':
     dependencies:
@@ -13390,9 +13948,9 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 8.3.2
 
-  '@cypress/schematic@2.5.1(@angular/cli@17.3.3(chokidar@3.5.3))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))':
+  '@cypress/schematic@2.5.1(@angular/cli@17.3.3(chokidar@3.6.0))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))':
     dependencies:
-      '@angular/cli': 17.3.3(chokidar@3.5.3)
+      '@angular/cli': 17.3.3(chokidar@3.6.0)
       '@angular/core': 17.3.3(rxjs@7.8.1)(zone.js@0.14.4)
       jsonc-parser: 3.2.0
       rxjs: 6.6.7
@@ -13418,10 +13976,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.20.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.20.2':
+    optional: true
+
   '@esbuild/android-arm64@0.19.12':
     optional: true
 
   '@esbuild/android-arm64@0.20.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.20.2':
     optional: true
 
   '@esbuild/android-arm@0.19.12':
@@ -13430,10 +13994,16 @@ snapshots:
   '@esbuild/android-arm@0.20.1':
     optional: true
 
+  '@esbuild/android-arm@0.20.2':
+    optional: true
+
   '@esbuild/android-x64@0.19.12':
     optional: true
 
   '@esbuild/android-x64@0.20.1':
+    optional: true
+
+  '@esbuild/android-x64@0.20.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.12':
@@ -13442,10 +14012,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.20.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.20.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.19.12':
     optional: true
 
   '@esbuild/darwin-x64@0.20.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.20.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.12':
@@ -13454,10 +14030,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.20.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.20.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.19.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.20.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.20.2':
     optional: true
 
   '@esbuild/linux-arm64@0.19.12':
@@ -13466,10 +14048,16 @@ snapshots:
   '@esbuild/linux-arm64@0.20.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.20.2':
+    optional: true
+
   '@esbuild/linux-arm@0.19.12':
     optional: true
 
   '@esbuild/linux-arm@0.20.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.20.2':
     optional: true
 
   '@esbuild/linux-ia32@0.19.12':
@@ -13478,10 +14066,16 @@ snapshots:
   '@esbuild/linux-ia32@0.20.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.20.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.19.12':
     optional: true
 
   '@esbuild/linux-loong64@0.20.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.20.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.12':
@@ -13490,10 +14084,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.20.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.20.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.19.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.20.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.20.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.12':
@@ -13502,10 +14102,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.20.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.20.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.19.12':
     optional: true
 
   '@esbuild/linux-s390x@0.20.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.20.2':
     optional: true
 
   '@esbuild/linux-x64@0.19.12':
@@ -13514,10 +14120,16 @@ snapshots:
   '@esbuild/linux-x64@0.20.1':
     optional: true
 
+  '@esbuild/linux-x64@0.20.2':
+    optional: true
+
   '@esbuild/netbsd-x64@0.19.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.20.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.20.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.12':
@@ -13526,10 +14138,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.20.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.20.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.19.12':
     optional: true
 
   '@esbuild/sunos-x64@0.20.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.20.2':
     optional: true
 
   '@esbuild/win32-arm64@0.19.12':
@@ -13538,16 +14156,25 @@ snapshots:
   '@esbuild/win32-arm64@0.20.1':
     optional: true
 
+  '@esbuild/win32-arm64@0.20.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.19.12':
     optional: true
 
   '@esbuild/win32-ia32@0.20.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.20.2':
+    optional: true
+
   '@esbuild/win32-x64@0.19.12':
     optional: true
 
   '@esbuild/win32-x64@0.20.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.20.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.56.0)':
@@ -13559,6 +14186,13 @@ snapshots:
     dependencies:
       eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.1.1)':
+    dependencies:
+      eslint: 9.1.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.10.0': {}
 
   '@eslint-community/regexpp@4.6.2': {}
 
@@ -13576,9 +14210,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.0.2':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.3.4(supports-color@8.1.1)
+      espree: 10.0.1
+      globals: 14.0.0
+      ignore: 5.3.1
+      import-fresh: 3.3.0
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.56.0': {}
 
   '@eslint/js@8.57.0': {}
+
+  '@eslint/js@9.1.1': {}
 
   '@fal-works/esbuild-plugin-global-externals@2.1.2': {}
 
@@ -13638,11 +14288,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@humanwhocodes/config-array@0.13.0':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.3.4(supports-color@8.1.1)
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.2': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@humanwhocodes/retry@0.2.3': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -13848,6 +14510,42 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 20.11.16
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@20.11.16)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.5
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -13989,6 +14687,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@jridgewell/source-map@0.3.6':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+    optional: true
+
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
   '@jridgewell/trace-mapping@0.3.22':
@@ -14097,6 +14801,16 @@ snapshots:
       '@angular/core': 17.3.3(rxjs@7.8.1)(zone.js@0.14.4)
       '@angular/forms': 17.3.3(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@17.3.3(@angular/animations@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1)
       '@angular/localize': 17.3.3(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))
+      '@popperjs/core': 2.11.8
+      rxjs: 7.8.1
+      tslib: 2.6.2
+
+  '@ng-bootstrap/ng-bootstrap@16.0.0(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(@angular/forms@17.3.6(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@17.3.6(@angular/animations@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1))(@angular/localize@17.3.6(@angular/compiler-cli@17.3.6(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))))(@popperjs/core@2.11.8)(rxjs@7.8.1)':
+    dependencies:
+      '@angular/common': 17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)
+      '@angular/core': 17.3.6(rxjs@7.8.1)(zone.js@0.14.4)
+      '@angular/forms': 17.3.6(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@17.3.6(@angular/animations@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1)
+      '@angular/localize': 17.3.6(@angular/compiler-cli@17.3.6(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(@angular/compiler@17.3.6(@angular/core@17.3.6(rxjs@7.8.1)(zone.js@0.14.4)))
       '@popperjs/core': 2.11.8
       rxjs: 7.8.1
       tslib: 2.6.2
@@ -14433,40 +15147,88 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.13.0':
     optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.16.4':
+    optional: true
+
   '@rollup/rollup-android-arm64@4.13.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.16.4':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.13.0':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.16.4':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.13.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.16.4':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.13.0':
     optional: true
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.16.4':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.13.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.16.4':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.13.0':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.16.4':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.13.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.16.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.16.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.13.0':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.16.4':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.13.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.16.4':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.13.0':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.16.4':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.13.0':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.16.4':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.13.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.16.4':
     optional: true
 
   '@rollup/wasm-node@4.13.0':
@@ -14477,10 +15239,10 @@ snapshots:
 
   '@rushstack/eslint-patch@1.7.2': {}
 
-  '@schematics/angular@17.3.3(chokidar@3.5.3)':
+  '@schematics/angular@17.3.3(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/core': 17.3.3(chokidar@3.5.3)
-      '@angular-devkit/schematics': 17.3.3(chokidar@3.5.3)
+      '@angular-devkit/core': 17.3.3(chokidar@3.6.0)
+      '@angular-devkit/schematics': 17.3.3(chokidar@3.6.0)
       jsonc-parser: 3.2.1
     transitivePeerDependencies:
       - chokidar
@@ -14553,13 +15315,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@stencil-community/eslint-plugin@0.7.2(@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5))(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0)(typescript@4.9.5)':
+  '@stencil-community/eslint-plugin@0.7.2(@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1(eslint@9.1.1)(typescript@4.9.5))(eslint@9.1.1)(typescript@4.9.5))(@typescript-eslint/parser@7.7.1(eslint@9.1.1)(typescript@4.9.5))(eslint-plugin-react@7.34.1(eslint@9.1.1))(eslint@9.1.1)(typescript@4.9.5)':
     dependencies:
-      '@typescript-eslint/eslint-plugin': 7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 7.5.0(eslint@8.57.0)(typescript@4.9.5)
-      eslint: 8.57.0
-      eslint-plugin-react: 7.34.1(eslint@8.57.0)
-      eslint-utils: 3.0.0(eslint@8.57.0)
+      '@typescript-eslint/eslint-plugin': 7.7.1(@typescript-eslint/parser@7.7.1(eslint@9.1.1)(typescript@4.9.5))(eslint@9.1.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 7.7.1(eslint@9.1.1)(typescript@4.9.5)
+      eslint: 9.1.1
+      eslint-plugin-react: 7.34.1(eslint@9.1.1)
+      eslint-utils: 3.0.0(eslint@9.1.1)
       jsdom: 23.2.0
       tsutils: 3.21.0(typescript@4.9.5)
       typescript: 4.9.5
@@ -14569,19 +15331,25 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@stencil/angular-output-target@0.8.4(@stencil/core@4.14.0)':
+  '@stencil/angular-output-target@0.8.4(@stencil/core@4.17.1)':
     dependencies:
-      '@stencil/core': 4.14.0
+      '@stencil/core': 4.17.1
 
   '@stencil/core@4.14.0': {}
 
-  '@stencil/react-output-target@0.5.3(@stencil/core@4.14.0)':
+  '@stencil/core@4.17.1': {}
+
+  '@stencil/react-output-target@0.5.3(@stencil/core@4.17.1)':
     dependencies:
-      '@stencil/core': 4.14.0
+      '@stencil/core': 4.17.1
 
   '@stencil/sass@3.0.11(@stencil/core@4.14.0)':
     dependencies:
       '@stencil/core': 4.14.0
+
+  '@stencil/sass@3.0.11(@stencil/core@4.17.1)':
+    dependencies:
+      '@stencil/core': 4.17.1
 
   '@stencil/store@2.0.15(@stencil/core@4.14.0)':
     dependencies:
@@ -14789,7 +15557,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@storybook/builder-vite@8.0.8(encoding@0.1.13)(typescript@5.3.3)(vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.74.1)(terser@5.29.1))':
+  '@storybook/builder-vite@8.0.8(encoding@0.1.13)(typescript@5.3.3)(vite@5.2.10(@types/node@20.12.7)(less@4.2.0)(sass@1.74.1)(terser@5.30.4))':
     dependencies:
       '@storybook/channels': 8.0.8
       '@storybook/client-logger': 8.0.8
@@ -14808,7 +15576,7 @@ snapshots:
       fs-extra: 11.1.1
       magic-string: 0.30.8
       ts-dedent: 2.2.0
-      vite: 5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.74.1)(terser@5.29.1)
+      vite: 5.2.10(@types/node@20.12.7)(less@4.2.0)(sass@1.74.1)(terser@5.30.4)
     optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -15280,9 +16048,9 @@ snapshots:
       '@types/express': 4.17.17
       file-system-cache: 2.3.0
 
-  '@storybook/web-components-vite@8.0.8(encoding@0.1.13)(lit@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)(vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.74.1)(terser@5.29.1))':
+  '@storybook/web-components-vite@8.0.8(encoding@0.1.13)(lit@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)(vite@5.2.10(@types/node@20.12.7)(less@4.2.0)(sass@1.74.1)(terser@5.30.4))':
     dependencies:
-      '@storybook/builder-vite': 8.0.8(encoding@0.1.13)(typescript@5.3.3)(vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.74.1)(terser@5.29.1))
+      '@storybook/builder-vite': 8.0.8(encoding@0.1.13)(typescript@5.3.3)(vite@5.2.10(@types/node@20.12.7)(less@4.2.0)(sass@1.74.1)(terser@5.30.4))
       '@storybook/core-server': 8.0.8(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/node-logger': 8.0.8
       '@storybook/web-components': 8.0.8(encoding@0.1.13)(lit@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -15513,6 +16281,8 @@ snapshots:
 
   '@types/json-schema@7.0.14': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/json5@0.0.29': {}
 
   '@types/lodash@4.14.194': {}
@@ -15551,6 +16321,11 @@ snapshots:
   '@types/node@20.11.16':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@20.12.7':
+    dependencies:
+      undici-types: 5.26.5
+    optional: true
 
   '@types/normalize-package-data@2.4.1': {}
 
@@ -15592,6 +16367,8 @@ snapshots:
   '@types/scheduler@0.16.3': {}
 
   '@types/semver@7.5.0': {}
+
+  '@types/semver@7.5.8': {}
 
   '@types/send@0.17.1':
     dependencies:
@@ -15703,26 +16480,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0)(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.6.2
-      '@typescript-eslint/parser': 7.5.0(eslint@8.57.0)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 7.5.0
-      '@typescript-eslint/type-utils': 7.5.0(eslint@8.57.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 7.5.0(eslint@8.57.0)(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 7.5.0
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-      graphemer: 1.4.0
-      ignore: 5.3.0
-      natural-compare: 1.4.0
-      semver: 7.6.0
-      ts-api-utils: 1.0.2(typescript@4.9.5)
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@7.5.0(@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.6.2
@@ -15740,6 +16497,26 @@ snapshots:
       ts-api-utils: 1.0.2(typescript@5.3.3)
     optionalDependencies:
       typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/eslint-plugin@7.7.1(@typescript-eslint/parser@7.7.1(eslint@9.1.1)(typescript@4.9.5))(eslint@9.1.1)(typescript@4.9.5)':
+    dependencies:
+      '@eslint-community/regexpp': 4.10.0
+      '@typescript-eslint/parser': 7.7.1(eslint@9.1.1)(typescript@4.9.5)
+      '@typescript-eslint/scope-manager': 7.7.1
+      '@typescript-eslint/type-utils': 7.7.1(eslint@9.1.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 7.7.1(eslint@9.1.1)(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 7.7.1
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 9.1.1
+      graphemer: 1.4.0
+      ignore: 5.3.1
+      natural-compare: 1.4.0
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@4.9.5)
+    optionalDependencies:
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15794,19 +16571,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 7.5.0
-      '@typescript-eslint/types': 7.5.0
-      '@typescript-eslint/typescript-estree': 7.5.0(typescript@4.9.5)
-      '@typescript-eslint/visitor-keys': 7.5.0
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@7.5.0(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.5.0
@@ -15817,6 +16581,19 @@ snapshots:
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.7.1(eslint@9.1.1)(typescript@4.9.5)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.7.1
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@4.9.5)
+      '@typescript-eslint/visitor-keys': 7.7.1
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 9.1.1
+    optionalDependencies:
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -15839,6 +16616,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.5.0
       '@typescript-eslint/visitor-keys': 7.5.0
+
+  '@typescript-eslint/scope-manager@7.7.1':
+    dependencies:
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/visitor-keys': 7.7.1
 
   '@typescript-eslint/type-utils@5.62.0(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
@@ -15888,18 +16670,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@7.5.0(eslint@8.57.0)(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 7.5.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 7.5.0(eslint@8.57.0)(typescript@4.9.5)
-      debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.57.0
-      ts-api-utils: 1.0.2(typescript@4.9.5)
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/type-utils@7.5.0(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 7.5.0(typescript@5.3.3)
@@ -15912,6 +16682,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/type-utils@7.7.1(eslint@9.1.1)(typescript@4.9.5)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@4.9.5)
+      '@typescript-eslint/utils': 7.7.1(eslint@9.1.1)(typescript@4.9.5)
+      debug: 4.3.4(supports-color@8.1.1)
+      eslint: 9.1.1
+      ts-api-utils: 1.3.0(typescript@4.9.5)
+    optionalDependencies:
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@5.62.0': {}
 
   '@typescript-eslint/types@6.21.0': {}
@@ -15919,6 +16701,8 @@ snapshots:
   '@typescript-eslint/types@7.2.0': {}
 
   '@typescript-eslint/types@7.5.0': {}
+
+  '@typescript-eslint/types@7.7.1': {}
 
   '@typescript-eslint/typescript-estree@5.62.0(typescript@5.3.3)':
     dependencies:
@@ -15994,21 +16778,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@7.5.0(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/types': 7.5.0
-      '@typescript-eslint/visitor-keys': 7.5.0
-      debug: 4.3.4(supports-color@8.1.1)
-      globby: 11.1.0
-      is-glob: 4.0.3
-      minimatch: 9.0.3
-      semver: 7.6.0
-      ts-api-utils: 1.0.2(typescript@4.9.5)
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/typescript-estree@7.5.0(typescript@5.3.3)':
     dependencies:
       '@typescript-eslint/types': 7.5.0
@@ -16021,6 +16790,21 @@ snapshots:
       ts-api-utils: 1.0.2(typescript@5.3.3)
     optionalDependencies:
       typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@7.7.1(typescript@4.9.5)':
+    dependencies:
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/visitor-keys': 7.7.1
+      debug: 4.3.4(supports-color@8.1.1)
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.4
+      semver: 7.6.0
+      ts-api-utils: 1.3.0(typescript@4.9.5)
+    optionalDependencies:
+      typescript: 4.9.5
     transitivePeerDependencies:
       - supports-color
 
@@ -16081,20 +16865,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@7.5.0(eslint@8.57.0)(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
-      '@types/json-schema': 7.0.14
-      '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 7.5.0
-      '@typescript-eslint/types': 7.5.0
-      '@typescript-eslint/typescript-estree': 7.5.0(typescript@4.9.5)
-      eslint: 8.57.0
-      semver: 7.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/utils@7.5.0(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
@@ -16104,6 +16874,20 @@ snapshots:
       '@typescript-eslint/types': 7.5.0
       '@typescript-eslint/typescript-estree': 7.5.0(typescript@5.3.3)
       eslint: 8.57.0
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/utils@7.7.1(eslint@9.1.1)(typescript@4.9.5)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.1.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.5.8
+      '@typescript-eslint/scope-manager': 7.7.1
+      '@typescript-eslint/types': 7.7.1
+      '@typescript-eslint/typescript-estree': 7.7.1(typescript@4.9.5)
+      eslint: 9.1.1
       semver: 7.6.0
     transitivePeerDependencies:
       - supports-color
@@ -16129,6 +16913,11 @@ snapshots:
       '@typescript-eslint/types': 7.5.0
       eslint-visitor-keys: 3.4.3
 
+  '@typescript-eslint/visitor-keys@7.7.1':
+    dependencies:
+      '@typescript-eslint/types': 7.7.1
+      eslint-visitor-keys: 3.4.3
+
   '@ungap/structured-clone@1.2.0': {}
 
   '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.5(@types/node@18.17.19)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))':
@@ -16139,9 +16928,9 @@ snapshots:
     dependencies:
       vite: 5.1.5(@types/node@18.19.28)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
 
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))':
+  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.1.5(@types/node@20.12.7)(less@4.2.0)(sass@1.71.1)(terser@5.29.1))':
     dependencies:
-      vite: 5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
+      vite: 5.1.5(@types/node@20.12.7)(less@4.2.0)(sass@1.71.1)(terser@5.29.1)
 
   '@web-types/lit@2.0.0-3':
     optional: true
@@ -16324,11 +17113,17 @@ snapshots:
     dependencies:
       acorn: 8.9.0
 
+  acorn-jsx@5.3.2(acorn@8.11.3):
+    dependencies:
+      acorn: 8.11.3
+
   acorn-jsx@5.3.2(acorn@8.9.0):
     dependencies:
       acorn: 8.9.0
 
   acorn-walk@8.2.0: {}
+
+  acorn@8.11.3: {}
 
   acorn@8.9.0: {}
 
@@ -16717,6 +17512,8 @@ snapshots:
   aws4@1.12.0: {}
 
   axe-core@4.7.0: {}
+
+  axe-core@4.9.0: {}
 
   axios@1.6.2(debug@4.3.4):
     dependencies:
@@ -17214,6 +18011,18 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
@@ -17557,6 +18366,22 @@ snapshots:
       - supports-color
       - ts-node
 
+  create-jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   create-require@1.1.1: {}
 
   critters@0.0.22:
@@ -17720,9 +18545,9 @@ snapshots:
 
   custom-event@1.0.1: {}
 
-  cypress-axe@1.5.0(axe-core@4.7.0)(cypress@13.7.2):
+  cypress-axe@1.5.0(axe-core@4.9.0)(cypress@13.7.2):
     dependencies:
-      axe-core: 4.7.0
+      axe-core: 4.9.0
       cypress: 13.7.2
 
   cypress-each@1.14.0: {}
@@ -18461,6 +19286,32 @@ snapshots:
       '@esbuild/win32-ia32': 0.20.1
       '@esbuild/win32-x64': 0.20.1
 
+  esbuild@0.20.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.20.2
+      '@esbuild/android-arm': 0.20.2
+      '@esbuild/android-arm64': 0.20.2
+      '@esbuild/android-x64': 0.20.2
+      '@esbuild/darwin-arm64': 0.20.2
+      '@esbuild/darwin-x64': 0.20.2
+      '@esbuild/freebsd-arm64': 0.20.2
+      '@esbuild/freebsd-x64': 0.20.2
+      '@esbuild/linux-arm': 0.20.2
+      '@esbuild/linux-arm64': 0.20.2
+      '@esbuild/linux-ia32': 0.20.2
+      '@esbuild/linux-loong64': 0.20.2
+      '@esbuild/linux-mips64el': 0.20.2
+      '@esbuild/linux-ppc64': 0.20.2
+      '@esbuild/linux-riscv64': 0.20.2
+      '@esbuild/linux-s390x': 0.20.2
+      '@esbuild/linux-x64': 0.20.2
+      '@esbuild/netbsd-x64': 0.20.2
+      '@esbuild/openbsd-x64': 0.20.2
+      '@esbuild/sunos-x64': 0.20.2
+      '@esbuild/win32-arm64': 0.20.2
+      '@esbuild/win32-ia32': 0.20.2
+      '@esbuild/win32-x64': 0.20.2
+
   escalade@3.1.1: {}
 
   escape-html@1.0.3: {}
@@ -18715,6 +19566,28 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
 
+  eslint-plugin-react@7.34.1(eslint@9.1.1):
+    dependencies:
+      array-includes: 3.1.7
+      array.prototype.findlast: 1.2.5
+      array.prototype.flatmap: 1.3.2
+      array.prototype.toreversed: 1.1.2
+      array.prototype.tosorted: 1.1.3
+      doctrine: 2.1.0
+      es-iterator-helpers: 1.0.17
+      eslint: 9.1.1
+      estraverse: 5.3.0
+      jsx-ast-utils: 3.3.5
+      minimatch: 3.1.2
+      object.entries: 1.1.7
+      object.fromentries: 2.0.7
+      object.hasown: 1.1.4
+      object.values: 1.1.7
+      prop-types: 15.8.1
+      resolve: 2.0.0-next.5
+      semver: 6.3.1
+      string.prototype.matchall: 4.0.11
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -18730,14 +19603,26 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-scope@8.0.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
   eslint-utils@3.0.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
       eslint-visitor-keys: 2.1.0
 
+  eslint-utils@3.0.0(eslint@9.1.1):
+    dependencies:
+      eslint: 9.1.1
+      eslint-visitor-keys: 2.1.0
+
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.0.0: {}
 
   eslint@8.56.0:
     dependencies:
@@ -18825,12 +19710,57 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint@9.1.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.1.1)
+      '@eslint-community/regexpp': 4.10.0
+      '@eslint/eslintrc': 3.0.2
+      '@eslint/js': 9.1.1
+      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.2.3
+      '@nodelib/fs.walk': 1.2.8
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.3
+      debug: 4.3.4(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.0.1
+      eslint-visitor-keys: 4.0.0
+      espree: 10.0.1
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.1
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.1
       es5-ext: 0.10.64
       event-emitter: 0.3.5
       type: 2.7.2
+
+  espree@10.0.1:
+    dependencies:
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
+      eslint-visitor-keys: 4.0.0
 
   espree@9.6.1:
     dependencies:
@@ -19538,6 +20468,8 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
+  globals@14.0.0: {}
+
   globalthis@1.0.3:
     dependencies:
       define-properties: 1.2.0
@@ -19613,12 +20545,12 @@ snapshots:
       kew: 0.7.0
       plugin-error: 0.1.2
 
-  gulp-postcss@10.0.0(jiti@1.20.0)(postcss@8.4.38):
+  gulp-postcss@10.0.0(jiti@1.21.0)(postcss@8.4.38):
     dependencies:
       fancy-log: 2.0.0
       plugin-error: 2.0.1
       postcss: 8.4.38
-      postcss-load-config: 5.0.2(jiti@1.20.0)(postcss@8.4.38)
+      postcss-load-config: 5.0.2(jiti@1.21.0)(postcss@8.4.38)
       vinyl-sourcemaps-apply: 0.2.1
     transitivePeerDependencies:
       - jiti
@@ -20533,6 +21465,26 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+      exit: 0.1.2
+      import-local: 3.1.0
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jest-config@29.7.0(@types/node@18.17.19)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)):
     dependencies:
       '@babel/core': 7.24.4
@@ -20813,6 +21765,70 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+
+  jest-config@29.7.0(@types/node@20.11.16)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.4)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.11.16
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.3.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
+
+  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
+    dependencies:
+      '@babel/core': 7.24.4
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.4)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.12.7
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.3.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+    optional: true
 
   jest-diff@29.7.0:
     dependencies:
@@ -21111,7 +22127,23 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+      '@jest/types': 29.6.3
+      import-local: 3.1.0
+      jest-cli: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
   jiti@1.20.0: {}
+
+  jiti@1.21.0:
+    optional: true
 
   joi@17.11.0:
     dependencies:
@@ -21822,6 +22854,10 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimatch@9.0.4:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimist-options@4.1.0:
     dependencies:
       arrify: 1.0.1
@@ -21982,7 +23018,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3):
+  ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3):
     dependencies:
       '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@rollup/plugin-json': 6.1.0(rollup@4.13.0)
@@ -22012,12 +23048,12 @@ snapshots:
     optionalDependencies:
       esbuild: 0.20.1
       rollup: 4.13.0
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3))
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3):
+  ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3):
     dependencies:
       '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@rollup/plugin-json': 6.1.0(rollup@4.13.0)
@@ -22047,11 +23083,11 @@ snapshots:
     optionalDependencies:
       esbuild: 0.20.1
       rollup: 4.13.0
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3))
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
 
-  ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3):
+  ng-packagr@17.3.0(@angular/compiler-cli@17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3))(tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)))(tslib@2.6.2)(typescript@5.3.3):
     dependencies:
       '@angular/compiler-cli': 17.3.3(@angular/compiler@17.3.3(@angular/core@17.3.3(rxjs@7.8.1)(zone.js@0.14.4)))(typescript@5.3.3)
       '@rollup/plugin-json': 6.1.0(rollup@4.13.0)
@@ -22081,7 +23117,7 @@ snapshots:
     optionalDependencies:
       esbuild: 0.20.1
       rollup: 4.13.0
-      tailwindcss: 3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3))
+      tailwindcss: 3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -22761,10 +23797,24 @@ snapshots:
       read-cache: 1.0.0
       resolve: 1.22.8
 
+  postcss-import@15.1.0(postcss@8.4.38):
+    dependencies:
+      postcss: 8.4.38
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+    optional: true
+
   postcss-js@4.0.1(postcss@8.4.33):
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.33
+
+  postcss-js@4.0.1(postcss@8.4.38):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.38
+    optional: true
 
   postcss-load-config@3.1.4(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)):
     dependencies:
@@ -22774,24 +23824,6 @@ snapshots:
       postcss: 8.4.38
       ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)):
-    dependencies:
-      lilconfig: 3.0.0
-      yaml: 2.3.4
-    optionalDependencies:
-      postcss: 8.4.33
-      ts-node: 10.9.2(@types/node@18.17.19)(typescript@5.3.3)
-    optional: true
-
-  postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)):
-    dependencies:
-      lilconfig: 3.0.0
-      yaml: 2.3.4
-    optionalDependencies:
-      postcss: 8.4.33
-      ts-node: 10.9.2(@types/node@18.19.28)(typescript@5.3.3)
-    optional: true
-
   postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.2.2)):
     dependencies:
       lilconfig: 3.0.0
@@ -22800,21 +23832,39 @@ snapshots:
       postcss: 8.4.33
       ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.2.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.33)(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.0.0
       yaml: 2.3.4
     optionalDependencies:
-      postcss: 8.4.33
-      ts-node: 10.9.2(@types/node@20.11.16)(typescript@5.3.3)
+      postcss: 8.4.38
+      ts-node: 10.9.2(@types/node@18.17.19)(typescript@5.3.3)
     optional: true
 
-  postcss-load-config@5.0.2(jiti@1.20.0)(postcss@8.4.38):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.0.0
       yaml: 2.3.4
     optionalDependencies:
-      jiti: 1.20.0
+      postcss: 8.4.38
+      ts-node: 10.9.2(@types/node@18.19.28)(typescript@5.3.3)
+    optional: true
+
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
+    dependencies:
+      lilconfig: 3.0.0
+      yaml: 2.3.4
+    optionalDependencies:
+      postcss: 8.4.38
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.3.3)
+    optional: true
+
+  postcss-load-config@5.0.2(jiti@1.21.0)(postcss@8.4.38):
+    dependencies:
+      lilconfig: 3.0.0
+      yaml: 2.3.4
+    optionalDependencies:
+      jiti: 1.21.0
       postcss: 8.4.38
 
   postcss-loader@8.1.1(postcss@8.4.35)(typescript@5.3.3)(webpack@5.90.3(esbuild@0.20.1)):
@@ -22905,6 +23955,12 @@ snapshots:
     dependencies:
       postcss: 8.4.33
       postcss-selector-parser: 6.0.15
+
+  postcss-nested@6.0.1(postcss@8.4.38):
+    dependencies:
+      postcss: 8.4.38
+      postcss-selector-parser: 6.0.15
+    optional: true
 
   postcss-normalize-charset@5.1.0(postcss@8.4.38):
     dependencies:
@@ -23326,6 +24382,8 @@ snapshots:
 
   reflect-metadata@0.2.1: {}
 
+  reflect-metadata@0.2.2: {}
+
   reflect.getprototypeof@1.0.5:
     dependencies:
       call-bind: 1.0.7
@@ -23571,14 +24629,14 @@ snapshots:
     dependencies:
       rollup-pluginutils: 2.8.2
 
-  rollup-plugin-visualizer@5.12.0(rollup@4.13.0):
+  rollup-plugin-visualizer@5.12.0(rollup@4.16.4):
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
       source-map: 0.7.4
       yargs: 17.7.2
     optionalDependencies:
-      rollup: 4.13.0
+      rollup: 4.16.4
 
   rollup-pluginutils@2.8.2:
     dependencies:
@@ -23601,6 +24659,28 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.13.0
       '@rollup/rollup-win32-ia32-msvc': 4.13.0
       '@rollup/rollup-win32-x64-msvc': 4.13.0
+      fsevents: 2.3.3
+
+  rollup@4.16.4:
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.16.4
+      '@rollup/rollup-android-arm64': 4.16.4
+      '@rollup/rollup-darwin-arm64': 4.16.4
+      '@rollup/rollup-darwin-x64': 4.16.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.16.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.16.4
+      '@rollup/rollup-linux-arm64-gnu': 4.16.4
+      '@rollup/rollup-linux-arm64-musl': 4.16.4
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.16.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.16.4
+      '@rollup/rollup-linux-s390x-gnu': 4.16.4
+      '@rollup/rollup-linux-x64-gnu': 4.16.4
+      '@rollup/rollup-linux-x64-musl': 4.16.4
+      '@rollup/rollup-win32-arm64-msvc': 4.16.4
+      '@rollup/rollup-win32-ia32-msvc': 4.16.4
+      '@rollup/rollup-win32-x64-msvc': 4.16.4
       fsevents: 2.3.3
 
   rrweb-cssom@0.6.0: {}
@@ -24437,62 +25517,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.5.3
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.2
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.20.0
-      lilconfig: 2.1.0
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.33
-      postcss-import: 15.1.0(postcss@8.4.33)
-      postcss-js: 4.0.1(postcss@8.4.33)
-      postcss-load-config: 4.0.2(postcss@8.4.33)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3))
-      postcss-nested: 6.0.1(postcss@8.4.33)
-      postcss-selector-parser: 6.0.15
-      resolve: 1.22.8
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-    optional: true
-
-  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.5.3
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.2
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.20.0
-      lilconfig: 2.1.0
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.33
-      postcss-import: 15.1.0(postcss@8.4.33)
-      postcss-js: 4.0.1(postcss@8.4.33)
-      postcss-load-config: 4.0.2(postcss@8.4.33)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3))
-      postcss-nested: 6.0.1(postcss@8.4.33)
-      postcss-selector-parser: 6.0.15
-      resolve: 1.22.8
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-    optional: true
-
   tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.2.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -24520,28 +25544,84 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.1(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3)):
+  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       didyoumean: 1.2.2
       dlv: 1.1.3
       fast-glob: 3.3.2
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.20.0
+      jiti: 1.21.0
       lilconfig: 2.1.0
       micromatch: 4.0.5
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.33
-      postcss-import: 15.1.0(postcss@8.4.33)
-      postcss-js: 4.0.1(postcss@8.4.33)
-      postcss-load-config: 4.0.2(postcss@8.4.33)(ts-node@10.9.2(@types/node@20.11.16)(typescript@5.3.3))
-      postcss-nested: 6.0.1(postcss@8.4.33)
-      postcss-selector-parser: 6.0.15
+      postcss: 8.4.38
+      postcss-import: 15.1.0(postcss@8.4.38)
+      postcss-js: 4.0.1(postcss@8.4.38)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@18.17.19)(typescript@5.3.3))
+      postcss-nested: 6.0.1(postcss@8.4.38)
+      postcss-selector-parser: 6.0.16
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+    optional: true
+
+  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.38
+      postcss-import: 15.1.0(postcss@8.4.38)
+      postcss-js: 4.0.1(postcss@8.4.38)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@18.19.28)(typescript@5.3.3))
+      postcss-nested: 6.0.1(postcss@8.4.38)
+      postcss-selector-parser: 6.0.16
+      resolve: 1.22.8
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+    optional: true
+
+  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.2
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.0
+      lilconfig: 2.1.0
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.38
+      postcss-import: 15.1.0(postcss@8.4.38)
+      postcss-js: 4.0.1(postcss@8.4.38)
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3))
+      postcss-nested: 6.0.1(postcss@8.4.38)
+      postcss-selector-parser: 6.0.16
       resolve: 1.22.8
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -24638,6 +25718,14 @@ snapshots:
       acorn: 8.9.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  terser@5.30.4:
+    dependencies:
+      '@jridgewell/source-map': 0.3.6
+      acorn: 8.11.3
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    optional: true
 
   test-exclude@6.0.0:
     dependencies:
@@ -24758,6 +25846,10 @@ snapshots:
   ts-api-utils@1.0.2(typescript@5.3.3):
     dependencies:
       typescript: 5.3.3
+
+  ts-api-utils@1.3.0(typescript@4.9.5):
+    dependencies:
+      typescript: 4.9.5
 
   ts-dedent@2.2.0: {}
 
@@ -24915,6 +26007,25 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.11.16
+      acorn: 8.9.0
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.3.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@20.12.7)(typescript@5.3.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.7
       acorn: 8.9.0
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -25403,29 +26514,29 @@ snapshots:
       sass: 1.71.1
       terser: 5.29.1
 
-  vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.71.1)(terser@5.29.1):
+  vite@5.1.5(@types/node@20.12.7)(less@4.2.0)(sass@1.71.1)(terser@5.29.1):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.38
       rollup: 4.13.0
     optionalDependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.12.7
       fsevents: 2.3.3
       less: 4.2.0
       sass: 1.71.1
       terser: 5.29.1
 
-  vite@5.1.5(@types/node@20.11.16)(less@4.2.0)(sass@1.74.1)(terser@5.29.1):
+  vite@5.2.10(@types/node@20.12.7)(less@4.2.0)(sass@1.74.1)(terser@5.30.4):
     dependencies:
-      esbuild: 0.19.12
+      esbuild: 0.20.2
       postcss: 8.4.38
-      rollup: 4.13.0
+      rollup: 4.16.4
     optionalDependencies:
-      '@types/node': 20.11.16
+      '@types/node': 20.12.7
       fsevents: 2.3.3
       less: 4.2.0
       sass: 1.74.1
-      terser: 5.29.1
+      terser: 5.30.4
 
   void-elements@2.0.1: {}
 


### PR DESCRIPTION
I've implemented path aliases and optimized the import of the package.json, so its definition does not end up in every single component output file.

Needed to update stencil to get a fix, which enables the wanted feature: https://github.com/ionic-team/stencil/issues/2319#issuecomment-2037146011