### PR TITLE
fix(internet-header): show user info overflow

### DIFF
--- a/.changeset/brave-files-judge.md
+++ b/.changeset/brave-files-judge.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fixed display issue with long user/company names being cut off in the user dropdown.

--- a/packages/internet-header/src/components/post-klp-login-widget/post-klp-login-widget.scss
+++ b/packages/internet-header/src/components/post-klp-login-widget/post-klp-login-widget.scss
@@ -66,7 +66,7 @@
 
   align-items: flex-start;
   width: 224px;
-  height: 78px;
+  min-height: 78px;
   padding: 16px 0px;
   line-height: 46px;
   flex-direction: column;

--- a/packages/internet-header/src/components/post-klp-login-widget/widget-styles.scss
+++ b/packages/internet-header/src/components/post-klp-login-widget/widget-styles.scss
@@ -28,7 +28,7 @@
   position: relative;
   display: inline-flex;
   width: 296px;
-  height: 40px;
+  min-height: 40px;
   margin: 0;
   padding: 0;
   list-style-type: none;
@@ -139,7 +139,7 @@
 li.name-and-surname {
   display: flex;
   min-width: 296px;
-  height: 78px;
+  min-height: 78px;
   padding-top: 0;
   vertical-align: middle;
   border-bottom: 1px solid rgba(0, 0, 0, 0.2);
@@ -237,7 +237,7 @@ li.name-and-surname span.infoHidden {
   display: flex;
   align-items: center;
   width: 224px;
-  height: 78px;
+  min-height: 78px;
   padding: 16px 0;
   line-height: 46px;
 }


### PR DESCRIPTION
Before: 
![image](https://github.com/swisspost/design-system/assets/33580481/7ad12ee9-92aa-4792-9a99-3e80f705cb9b)

After: 
![image](https://github.com/swisspost/design-system/assets/33580481/9f26d150-5237-4f10-be49-072b654f2695)
