### PR TITLE
chore(styles): update horizontal stepper styles

### DIFF
--- a/.changeset/pretty-bugs-change.md
+++ b/.changeset/pretty-bugs-change.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Updated the stepper styles: changed the colors and font-weights, as well as the current step label position on smaller screens.

--- a/packages/styles/src/components/stepper.scss
+++ b/packages/styles/src/components/stepper.scss
@@ -1,13 +1,21 @@
-@use './../mixins/size' as size-mx;
 @use './../mixins/icons' as icons-mx;
+@use './../mixins/size' as size-mx;
 @use './../mixins/utilities';
 
 @use './../variables/color';
 @use './../variables/commons';
-@use './../variables/spacing';
 @use './../variables/components/stepper';
 
 @use './../themes/bootstrap/core' as *;
+
+// for backward compatibility
+.stepper-container {
+  @include size-mx.responsive-size('big', 'margin-bottom');
+
+  > .stepper-bar {
+    display: none;
+  }
+}
 
 .stepper {
   // start a counter for the step numbers
@@ -18,13 +26,13 @@
   position: relative;
 
   // the first column is half a step wide to make sure the separators are the same size even on small screens
-  grid-template-columns: stepper.$stepper-indicator-height / 2;
+  grid-template-columns: stepper.$stepper-indicator-size / 2;
 
   // all other columns are 1 fraction of the available space ase we don't know the number of steps
   grid-auto-columns: minmax(0, 1fr);
 
   // we use a padding and negative margin on the last step for the same reason we need the first column
-  padding-inline-end: stepper.$stepper-indicator-height / 2;
+  padding-inline-end: stepper.$stepper-indicator-size / 2;
 }
 
 .stepper-item {
@@ -34,6 +42,36 @@
   &:not(:last-child) {
     grid-column: span 2;
   }
+
+  // progress bar
+  &::before,
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    inset-block-start: (stepper.$stepper-indicator-size - stepper.$stepper-bar-height) / 2;
+    height: stepper.$stepper-bar-height;
+    background-color: stepper.$stepper-bar-color;
+    inset-inline: 0 0;
+  }
+
+  &:not(:first-child, :last-child) {
+    &::before {
+      inset-inline-end: 50%;
+    }
+
+    &::after {
+      inset-inline-start: 50%;
+    }
+  }
+
+  // current and completed steps are preceded by a yellow segment (except for the first step)
+  &:not(&[aria-current='step'] ~ &, :first-child)::before,
+  // completed steps are also followed by a yellow segment (except for the last step)
+  &:not(&[aria-current='step']:not(:last-child), &[aria-current='step'] ~ &)::after {
+    background-color: stepper.$stepper-bar-fill-color;
+    z-index: 1;
+  }
 }
 
 .stepper-link {
@@ -42,6 +80,8 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  position: relative;
+  z-index: 2;
   overflow: hidden;
   text-decoration: none;
   color: stepper.$stepper-link-color;
@@ -60,7 +100,7 @@
 
   .stepper-item:last-child > & {
     margin-inline-start: auto;
-    margin-inline-end: -1 * stepper.$stepper-indicator-height / 2; // negative margin matching the container padding
+    margin-inline-end: -1 * stepper.$stepper-indicator-size / 2; // negative margin matching the container padding
     text-align: end;
   }
 
@@ -68,186 +108,162 @@
     color: stepper.$stepper-link-current-color;
     font-weight: stepper.$stepper-link-current-font-weight;
   }
+}
 
-  // stepper indicator
-  &::before {
-    counter-increment: step-index;
-    content: counter(step-index);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    z-index: 1;
-    height: stepper.$stepper-indicator-height;
-    width: stepper.$stepper-indicator-height;
-    box-sizing: border-box;
-    margin-block-end: stepper.$stepper-link-gap;
-    color: stepper.$stepper-indicator-color;
-    background-color: stepper.$stepper-indicator-bg;
-    border: stepper.$stepper-indicator-border-width solid stepper.$stepper-indicator-border-color;
-    border-radius: 50%;
-    font-weight: stepper.$stepper-indicator-font-weight;
-    text-indent: initial;
+// step indicator
+.stepper-link::before {
+  counter-increment: step-index;
+  content: counter(step-index);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  height: stepper.$stepper-indicator-size;
+  width: stepper.$stepper-indicator-size;
+  box-sizing: border-box;
+  margin-block-end: stepper.$stepper-link-gap;
+  color: stepper.$stepper-indicator-color;
+  background-color: stepper.$stepper-indicator-bg;
+  border: stepper.$stepper-indicator-border-width solid stepper.$stepper-indicator-border-color;
+  border-radius: 50%;
+  font-weight: stepper.$stepper-indicator-font-weight;
+  text-indent: initial;
+  transition: stepper.$stepper-indicator-transition;
 
-    .stepper-item:not(:first-child, :last-child) > & {
-      margin-inline: auto;
-    }
-
-    .stepper-item:last-child > & {
-      margin-inline-start: auto;
-    }
-
-    // completed steps with check mark
-    .stepper-item:not(
-        .stepper-item[aria-current='step'],
-        .stepper-item[aria-current='step'] ~ .stepper-item
-      )
-      > & {
-      background-image: stepper.$stepper-indicator-check-icon;
-      background-size: stepper.$stepper-indicator-check-icon-size;
-      background-position: center;
-      color: transparent;
-    }
-
-    // future steps with grey background
-    .stepper-item[aria-current='step'] ~ .stepper-item > & {
-      color: stepper.$stepper-indicator-future-color;
-      background-color: stepper.$stepper-indicator-future-bg;
-    }
+  .stepper-item:not(:first-child, :last-child) > & {
+    margin-inline: auto;
   }
 
-  // progress bar
-  &::after {
+  .stepper-item:last-child > & {
+    margin-inline-start: auto;
+  }
+
+  .stepper-item:not([aria-current='step'], .stepper-item[aria-current='step'] ~ *) > & {
+    color: transparent;
+  }
+
+  .stepper-item[aria-current='step'] ~ .stepper-item > & {
+    color: stepper.$stepper-indicator-future-color;
+    background-color: stepper.$stepper-indicator-future-bg;
+  }
+}
+
+// check icon
+.stepper-link::after {
+  @include icons-mx.icon(2105);
+  display: block;
+  position: absolute;
+  top: (stepper.$stepper-indicator-size - stepper.$stepper-indicator-check-icon-size) / 2;
+  z-index: 1;
+  height: stepper.$stepper-indicator-check-icon-size;
+  width: stepper.$stepper-indicator-check-icon-size;
+  transition: stepper.$stepper-indicator-transition;
+  color: stepper.$stepper-indicator-color;
+
+  .stepper-item:first-child > & {
+    left: (stepper.$stepper-indicator-size - stepper.$stepper-indicator-check-icon-size) / 2;
+  }
+
+  .stepper-item:not(:first-child, :last-child) > & {
+    left: calc(50% - #{stepper.$stepper-indicator-check-icon-size / 2});
+  }
+
+  .stepper-item:last-child > & {
+    right: (stepper.$stepper-indicator-size - stepper.$stepper-indicator-check-icon-size) / 2;
+  }
+
+  // show only for completed steps
+  .stepper-item:not([aria-current='step'], .stepper-item[aria-current='step'] ~ *) > & {
     content: '';
-    display: block;
-    position: absolute;
-    inset-block-start: (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) / 2;
-    inset-inline-start: 0;
-    height: stepper.$stepper-bar-height;
-    width: 100%;
+  }
+}
 
-    // completed steps with filled bar
-    .stepper-item[aria-current='step']:last-child > &,
-    .stepper-item:not(
-        .stepper-item[aria-current='step'],
-        .stepper-item[aria-current='step'] ~ .stepper-item
-      )
-      > & {
-      background-color: stepper.$stepper-bar-fill-color;
-    }
-
-    // current step with half-filled bar
-    .stepper-item[aria-current='step']:not(:first-child, :last-child) > & {
-      background: linear-gradient(
-        90deg,
-        stepper.$stepper-bar-fill-color 50%,
-        stepper.$stepper-bar-color 50%
-      );
-    }
-
-    // future steps with unfilled bar
-    .stepper-item[aria-current='step']:first-child > &,
-    .stepper-item[aria-current='step'] ~ .stepper-item > & {
-      background-color: stepper.$stepper-bar-color;
-    }
+// hover/focus state
+.stepper-link:is(a[href]) {
+  @include utilities.focus-style {
+    border-radius: commons.$border-radius;
   }
 
-  // focus/hover states
-  &:is(a[href]) {
-    @include utilities.focus-style {
-      border-radius: commons.$border-radius;
+  @include utilities.focus-hover-style-custom() {
+    color: stepper.$stepper-link-color;
+
+    .stepper-item[aria-current='step'] > & {
+      color: stepper.$stepper-link-current-color;
     }
 
-    @include utilities.focus-hover-style-custom('::before') {
-      &,
-      .stepper-item[aria-current='step'] ~ .stepper-item > & {
-        color: stepper.$stepper-indicator-hover-color;
-        background-color: stepper.$stepper-indicator-hover-bg;
-      }
+    // step indicator
+    &::before,
+    .stepper-item[aria-current='step'] ~ .stepper-item > &::before {
+      color: stepper.$stepper-indicator-hover-color;
+      background-color: stepper.$stepper-indicator-hover-bg;
+    }
 
-      .stepper-item:not(
-          .stepper-item[aria-current='step'],
-          .stepper-item[aria-current='step'] ~ .stepper-item
-        )
-        > & {
-        background-image: stepper.$stepper-indicator-check-icon-white;
-      }
+    // check icon
+    &::after {
+      color: stepper.$stepper-indicator-hover-color;
     }
   }
 }
 
+// smaller screens
 @include media-breakpoint-down(rg) {
-  .stepper-item {
-    .stepper-link {
-      white-space: nowrap;
-      width: 100%;
-    }
+  .stepper-item[aria-current='step'] {
+    // using "display: contents" on the stepper-item and stepper-link so that label, indicator and progress bar can be directly placed in the grid
+    display: contents;
 
-    &[aria-current='step'] {
-      // using "display: contents" on the stepper-item and stepper-link so that label, indicator and progress bar can be directly placed in the grid
+    > .stepper-link {
       display: contents;
-
-      > .stepper-link {
-        display: contents;
-
-        &::before {
-          margin-inline-end: 0 !important;
-        }
-
-        &::after {
-          grid-row: -1;
-          margin-block-start: (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) / 2;
-          margin-block-end: -1 * (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) /
-            2;
-          position: static;
-        }
-      }
-
-      &:not(:first-child) > .stepper-link {
-        &::before {
-          transform: translateX(50%);
-        }
-
-        &::after {
-          width: 201%;
-          transform: translateX(-50%);
-        }
-      }
-
-      &:not(:last-child) > .stepper-link {
-        &::before {
-          grid-row: -1;
-        }
-      }
-
-      &:last-child > .stepper-link {
-        &::before {
-          position: absolute;
-          inset-block-start: 0;
-          inset-inline-end: stepper.$stepper-indicator-height / 2;
-        }
-      }
     }
 
-    &:not(&[aria-current='step']) {
+    // progress bar
+    &::before {
       grid-row: -1;
-      justify-self: stretch;
+      margin-block-start: (stepper.$stepper-indicator-size - stepper.$stepper-bar-height) / 2;
+      position: static;
+    }
 
-      // hide completed and future step labels
-      > .stepper-link {
-        -webkit-line-clamp: initial;
-        line-height: 0;
-        text-indent: 100%;
-      }
+    &:not(:last-child) > .stepper-link::before {
+      grid-row: -1;
+    }
+
+    &:not(:first-child, :last-child)::after {
+      inset-inline-start: 0;
     }
   }
-}
 
-// for backward compatibility
-.stepper-container {
-  @include size-mx.responsive-size('big', 'margin-bottom');
+  .stepper-item:not([aria-current='step']) {
+    grid-row: -1;
+    justify-self: stretch;
 
-  > .stepper-bar {
-    display: none;
+    // hide completed and future step labels
+    > .stepper-link {
+      -webkit-line-clamp: initial;
+      line-height: 0;
+      text-indent: 100%;
+    }
+  }
+
+  .stepper-link {
+    white-space: nowrap;
+    width: 100%;
+  }
+
+  // step indicator
+  .stepper-link::before {
+    .stepper-item[aria-current='step']:first-child > & {
+      order: -1;
+    }
+
+    .stepper-item[aria-current='step']:not(:first-child, :last-child) > & {
+      margin-inline-start: 0;
+      transform: translateX(-50%);
+    }
+
+    .stepper-item[aria-current='step']:last-child > & {
+      position: absolute;
+      z-index: 2;
+      inset-block-start: 0;
+      inset-inline-end: 0;
+    }
   }
 }

--- a/packages/styles/src/components/stepper.scss
+++ b/packages/styles/src/components/stepper.scss
@@ -2,225 +2,225 @@
 @use './../mixins/icons' as icons-mx;
 @use './../mixins/utilities';
 
-@use './../variables/spacing';
 @use './../variables/color';
+@use './../variables/commons';
+@use './../variables/spacing';
 @use './../variables/components/stepper';
 
 @use './../themes/bootstrap/core' as *;
 
-.stepper-container {
-  @include size-mx.responsive-size('big', 'margin-bottom');
-  position: relative;
-}
-
-.stepper-bar {
-  height: stepper.$stepper-bar-height;
-  margin-top: stepper.$stepper-indicator-height * 0.5;
-  margin-bottom: -1 * (stepper.$stepper-bar-height + stepper.$stepper-indicator-height) * 0.5;
-
-  .progress-bar {
-    background-color: color.$yellow;
-  }
-}
-
 .stepper {
+  // start a counter for the step numbers
   counter-reset: step-index;
 
-  list-style: none;
-  padding: 0 (0.5 * stepper.$stepper-indicator-height);
-  margin: 0;
+  @include utilities.reset-list;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(#{0.5 * stepper.$stepper-indicator-height}, 1fr));
-  justify-items: center;
+
+  // the first column is half a step wide to make sure the separators are the same size even on small screens
+  grid-template-columns: stepper.$stepper-indicator-height / 2;
+
+  // all other columns are 1 fraction of the available space ase we don't know the number of steps
+  grid-auto-columns: minmax(0, 1fr);
+
+  // we use a padding and negative margin on the last step for the same reason we need the first column
+  padding-inline-end: stepper.$stepper-indicator-height / 2;
 }
 
 .stepper-item {
-  counter-increment: step-index;
+  grid-row: 1;
   position: relative;
-  display: flex;
-  flex-direction: column;
-  transition: color 250ms;
 
-  // Stepper indicator styles
+  &:not(:last-child) {
+    grid-column: span 2;
+  }
+}
+
+.stepper-link {
+  text-decoration: none;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  color: stepper.$stepper-link-color;
+  width: fit-content;
+  line-height: stepper.$stepper-link-line-height;
+
+  // not adding ellipsis if the like doesn't have a title for accessibility reasons
+  &:not([title]) {
+    -webkit-line-clamp: none;
+  }
+
+  .stepper-item:not(:first-child, :last-child) > & {
+    margin-inline: auto;
+    text-align: center;
+  }
+
+  .stepper-item:last-child > & {
+    margin-inline-start: auto;
+    margin-inline-end: -1 * stepper.$stepper-indicator-height / 2; // negative margin matching the container padding
+    text-align: end;
+  }
+
+  .stepper-item[aria-current='step'] > & {
+    color: stepper.$stepper-link-current-color;
+    font-weight: stepper.$stepper-link-current-font-weight;
+  }
+
+  // stepper indicator
   &::before {
-    content: '';
-    pointer-events: none;
+    counter-increment: step-index;
+    content: counter(step-index);
     display: flex;
     align-items: center;
     justify-content: center;
     height: stepper.$stepper-indicator-height;
     width: stepper.$stepper-indicator-height;
-    margin-bottom: -1 * stepper.$stepper-indicator-height;
+    box-sizing: border-box;
+    margin-block-end: stepper.$stepper-link-gap;
     color: stepper.$stepper-indicator-color;
     background-color: stepper.$stepper-indicator-bg;
     border: stepper.$stepper-indicator-border-width solid stepper.$stepper-indicator-border-color;
     border-radius: 50%;
-    font-size: stepper.$stepper-indicator-font-size;
     font-weight: stepper.$stepper-indicator-font-weight;
-    transition: background 250ms;
+    text-indent: initial;
+
+    .stepper-item:not(:first-child, :last-child) > & {
+      margin-inline: auto;
+    }
+
+    .stepper-item:last-child > & {
+      margin-inline-start: auto;
+    }
+
+    // completed steps with check mark
+    .stepper-item:not(
+        .stepper-item[aria-current='step'],
+        .stepper-item[aria-current='step'] ~ .stepper-item
+      )
+      > & {
+      background-image: stepper.$stepper-indicator-check-icon;
+      background-size: stepper.$stepper-indicator-check-icon-size;
+      background-position: center;
+      color: transparent;
+    }
+
+    // future steps with grey background
+    .stepper-item[aria-current='step'] ~ .stepper-item > & {
+      color: stepper.$stepper-indicator-future-color;
+      background-color: stepper.$stepper-indicator-future-bg;
+    }
   }
 
-  &[aria-current] ~ ::before {
-    color: stepper.$stepper-indicator-future-color;
-    background-color: stepper.$stepper-indicator-future-bg;
-  }
-
-  &:is(:focus-visible, :focus-within)::before {
-    outline: stepper.$stepper-indicator-hover-outline;
-  }
-
-  // Check icon (for completed steps only)
+  // progress bar
   &::after {
-    @include icons-mx.icon(2105);
     content: '';
-    position: absolute;
     display: block;
-    top: 0.5 * (stepper.$stepper-indicator-height - stepper.$stepper-indicator-check-icon-size);
-    height: stepper.$stepper-indicator-check-icon-size;
-    width: stepper.$stepper-indicator-check-icon-size;
-  }
+    position: absolute;
+    inset-block-start: (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) / 2;
+    inset-inline-start: 0;
+    height: stepper.$stepper-bar-height;
+    width: 100%;
+    z-index: -1;
 
-  &[aria-current],
-  &[aria-current] ~ & {
-    pointer-events: none;
-
-    &::before {
-      content: counter(step-index);
+    // completed steps with filled bar
+    .stepper-item:not(
+        .stepper-item[aria-current='step'],
+        .stepper-item[aria-current='step'] ~ .stepper-item
+      )
+      > & {
+      background-color: stepper.$stepper-bar-fill-color;
     }
 
-    &::after {
-      content: unset;
+    // current step with half-filled bar
+    .stepper-item[aria-current='step'] > & {
+      background: linear-gradient(
+        90deg,
+        stepper.$stepper-bar-fill-color 50%,
+        stepper.$stepper-bar-color 50%
+      );
     }
-  }
 
-  // First stepper item - left aligned
-  &:first-child {
-    justify-self: start;
-    align-items: start;
-    transform: translateX(#{-0.5 * stepper.$stepper-indicator-height});
-
-    &::after {
-      left: 0.5 * (stepper.$stepper-indicator-height - stepper.$stepper-indicator-check-icon-size);
-    }
-  }
-
-  // Last stepper item - right aligned
-  &:last-child {
-    justify-self: end;
-    align-items: end;
-    text-align: right;
-    margin-right: -0.5 * stepper.$stepper-indicator-height;
-
-    &::after {
-      right: 0.5 * (stepper.$stepper-indicator-height - stepper.$stepper-indicator-check-icon-size);
+    // future steps with unfilled bar
+    .stepper-item:is(.stepper-item[aria-current='step'] ~ .stepper-item) > & {
+      background-color: stepper.$stepper-bar-color;
     }
   }
 
-  // Other stepper items - centered
-  &:not(:first-child):not(:last-child) {
-    grid-column-end: span 2;
-    align-items: center;
-
-    &::after {
-      left: calc(50% - #{0.5 * stepper.$stepper-indicator-check-icon-size});
+  // focus/hover states
+  &:is(a[href]) {
+    @include utilities.focus-style {
+      border-radius: commons.$border-radius;
     }
-  }
 
-  &:hover {
-    color: stepper.$stepper-indicator-hover-color;
+    @include utilities.focus-hover-style-custom('::before') {
+      &,
+      .stepper-item[aria-current='step'] ~ .stepper-item > & {
+        color: #fff;
+        background-color: #000;
+      }
 
-    &::before {
-      background-color: stepper.$stepper-indicator-hover-bg;
+      .stepper-item:not(
+          .stepper-item[aria-current='step'],
+          .stepper-item[aria-current='step'] ~ .stepper-item
+        )
+        > & {
+        background-image: stepper.$stepper-indicator-hover-check-icon;
+      }
     }
-  }
-}
-
-.stepper-link {
-  z-index: 1;
-  padding-top: stepper.$stepper-indicator-height + stepper.$stepper-link-gap;
-  text-decoration: none;
-  color: stepper.$stepper-link-color;
-  transition: color 250ms;
-  text-align: center;
-
-  .stepper-item[aria-current] > & {
-    color: stepper.$stepper-link-current-color;
-    font-size: stepper.$stepper-link-current-font-size;
-    font-weight: stepper.$stepper-link-current-font-weight;
-  }
-
-  @at-root a:hover#{&},
-    :focus-visible#{&} {
-    color: stepper.$stepper-link-hover-color;
-  }
-
-  &:focus-visible {
-    outline: none;
   }
 }
 
 @include media-breakpoint-down(rg) {
   .stepper-item {
-    &:not([aria-current]) .stepper-link {
-      overflow: hidden;
+    .stepper-link {
       white-space: nowrap;
-      text-indent: 100%;
-      width: stepper.$stepper-indicator-height;
+      width: 100%;
+    }
+
+    &[aria-current='step'] {
+      // using "display: contents" on the stepper-item and stepper-link so that label, indicator and progress bar can be directly placed in the grid
+      display: contents;
+
+      > .stepper-link {
+        display: contents;
+
+        &::before {
+          grid-row: -1;
+          transform: translateX(50%);
+          margin-inline-end: 0 !important;
+        }
+
+        &::after {
+          grid-row: -1;
+          width: 201%;
+          transform: translateX(-50%);
+          margin-block-start: (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) / 2;
+          margin-block-end: -1 * (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) /
+            2;
+          position: static;
+        }
+      }
+    }
+
+    &:not(&[aria-current='step']) {
+      grid-row: -1;
+      justify-self: stretch;
+
+      // hide completed and future step labels
+      > .stepper-link {
+        -webkit-line-clamp: none;
+        line-height: 0;
+        text-indent: 100%;
+      }
     }
   }
 }
 
-@include utilities.high-contrast-mode() {
-  .stepper-bar {
-    background-color: CanvasText;
-    border: 0 none;
+// for backward compatibility
+.stepper-container {
+  @include size-mx.responsive-size('big', 'margin-bottom');
 
-    .progress-bar {
-      background-color: Highlight;
-    }
-  }
-
-  .stepper-item {
-    &::before {
-      width: calc(#{stepper.$stepper-indicator-height} + 2 * #{spacing.$size-line});
-      height: calc(#{stepper.$stepper-indicator-height} + 2 * #{spacing.$size-line});
-      line-height: calc(#{stepper.$stepper-indicator-height} + 2 * #{spacing.$size-line});
-      color: ButtonText;
-      background-color: ButtonFace;
-      border: 0;
-      outline: spacing.$size-line solid VisitedText;
-      outline-offset: -3 * spacing.$size-line;
-      margin-top: -1 * spacing.$size-line;
-    }
-
-    &[aria-current] ~ &::before {
-      outline-color: ButtonBorder;
-    }
-
-    &[aria-current]::before {
-      outline-color: Highlight;
-    }
-
-    &:is(:focus-visible, :focus-within)::before {
-      border: spacing.$size-line solid Highlight;
-      line-height: stepper.$stepper-indicator-height;
-      outline-color: VisitedText;
-    }
-
-    &[aria-current] ~ &:is(:focus-visible, :focus-within)::before {
-      outline-color: ButtonBorder;
-    }
-  }
-
-  .stepper-link {
-    color: VisitedText;
-
-    .stepper-item[aria-current] ~ .stepper-item > & {
-      color: CanvasText;
-    }
-
-    .stepper-item[aria-current] > & {
-      color: Highlight;
-    }
+  > .stepper-bar {
+    display: none;
   }
 }

--- a/packages/styles/src/components/stepper.scss
+++ b/packages/styles/src/components/stepper.scss
@@ -66,9 +66,9 @@
   }
 
   // current and completed steps are preceded by a yellow segment (except for the first step)
-  &:not(&[aria-current='step'] ~ &, :first-child)::before,
+  &:not(&[aria-current='step'] ~ *, :first-child)::before,
   // completed steps are also followed by a yellow segment (except for the last step)
-  &:not(&[aria-current='step']:not(:last-child), &[aria-current='step'] ~ &)::after {
+  &:not([aria-current='step']:not(:last-child), &[aria-current='step'] ~ *)::after {
     background-color: stepper.$stepper-bar-fill-color;
     z-index: 1;
   }
@@ -264,6 +264,85 @@
       z-index: 2;
       inset-block-start: 0;
       inset-inline-end: 0;
+    }
+  }
+}
+
+@include utilities.high-contrast-mode {
+  .stepper-item {
+    &::before,
+    &::after {
+      background-color: CanvasText;
+    }
+
+    &:not(&[aria-current='step'] ~ &, :first-child)::before,
+    &:not([aria-current='step']:not(:last-child), &[aria-current='step'] ~ *)::after {
+      background-color: Highlight;
+    }
+  }
+
+  .stepper-link {
+    &::before {
+      forced-color-adjust: none;
+    }
+
+    .stepper-item[aria-current='step'] > & {
+      &::before {
+        background-color: Canvas;
+        color: CanvasText;
+      }
+    }
+
+    .stepper-item[aria-current='step'] ~ .stepper-item > &,
+    .stepper-item:not([aria-current='step']) > & {
+      &::before {
+        color: Canvas;
+        border-color: Canvas;
+        background-color: CanvasText;
+      }
+    }
+
+    &::after {
+      color: Canvas;
+    }
+  }
+
+  .stepper-link:is(a[href]) {
+    .stepper-item[aria-current='step'] > & {
+      @include utilities.focus-hover-style-custom() {
+        &::before {
+          border-color: Highlight;
+        }
+      }
+    }
+
+    .stepper-item[aria-current='step'] ~ .stepper-item > & {
+      &::before {
+        color: Canvas;
+      }
+
+      @include utilities.focus-hover-style-custom() {
+        &::before {
+          background-color: Highlight;
+          color: HighlightText;
+        }
+      }
+    }
+
+    .stepper-item:not([aria-current='step']) > & {
+      &::before {
+        background-color: LinkText;
+      }
+
+      @include utilities.focus-hover-style-custom() {
+        &::before {
+          background-color: Highlight;
+        }
+
+        &::after {
+          color: HighlightText;
+        }
+      }
     }
   }
 }

--- a/packages/styles/src/components/stepper.scss
+++ b/packages/styles/src/components/stepper.scss
@@ -15,6 +15,7 @@
 
   @include utilities.reset-list;
   display: grid;
+  position: relative;
 
   // the first column is half a step wide to make sure the separators are the same size even on small screens
   grid-template-columns: stepper.$stepper-indicator-height / 2;
@@ -49,7 +50,7 @@
 
   // not adding ellipsis if the like doesn't have a title for accessibility reasons
   &:not([title]) {
-    -webkit-line-clamp: none;
+    -webkit-line-clamp: initial;
   }
 
   .stepper-item:not(:first-child, :last-child) > & {
@@ -75,6 +76,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    position: relative;
+    z-index: 1;
     height: stepper.$stepper-indicator-height;
     width: stepper.$stepper-indicator-height;
     box-sizing: border-box;
@@ -122,9 +125,9 @@
     inset-inline-start: 0;
     height: stepper.$stepper-bar-height;
     width: 100%;
-    z-index: -1;
 
     // completed steps with filled bar
+    .stepper-item[aria-current='step']:last-child > &,
     .stepper-item:not(
         .stepper-item[aria-current='step'],
         .stepper-item[aria-current='step'] ~ .stepper-item
@@ -134,7 +137,7 @@
     }
 
     // current step with half-filled bar
-    .stepper-item[aria-current='step'] > & {
+    .stepper-item[aria-current='step']:not(:first-child, :last-child) > & {
       background: linear-gradient(
         90deg,
         stepper.$stepper-bar-fill-color 50%,
@@ -143,7 +146,8 @@
     }
 
     // future steps with unfilled bar
-    .stepper-item:is(.stepper-item[aria-current='step'] ~ .stepper-item) > & {
+    .stepper-item[aria-current='step']:first-child > &,
+    .stepper-item[aria-current='step'] ~ .stepper-item > & {
       background-color: stepper.$stepper-bar-color;
     }
   }
@@ -157,8 +161,8 @@
     @include utilities.focus-hover-style-custom('::before') {
       &,
       .stepper-item[aria-current='step'] ~ .stepper-item > & {
-        color: #fff;
-        background-color: #000;
+        color: stepper.$stepper-indicator-hover-color;
+        background-color: stepper.$stepper-indicator-hover-bg;
       }
 
       .stepper-item:not(
@@ -166,7 +170,7 @@
           .stepper-item[aria-current='step'] ~ .stepper-item
         )
         > & {
-        background-image: stepper.$stepper-indicator-hover-check-icon;
+        background-image: stepper.$stepper-indicator-check-icon-white;
       }
     }
   }
@@ -187,19 +191,40 @@
         display: contents;
 
         &::before {
-          grid-row: -1;
-          transform: translateX(50%);
           margin-inline-end: 0 !important;
         }
 
         &::after {
           grid-row: -1;
-          width: 201%;
-          transform: translateX(-50%);
           margin-block-start: (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) / 2;
           margin-block-end: -1 * (stepper.$stepper-indicator-height - stepper.$stepper-bar-height) /
             2;
           position: static;
+        }
+      }
+
+      &:not(:first-child) > .stepper-link {
+        &::before {
+          transform: translateX(50%);
+        }
+
+        &::after {
+          width: 201%;
+          transform: translateX(-50%);
+        }
+      }
+
+      &:not(:last-child) > .stepper-link {
+        &::before {
+          grid-row: -1;
+        }
+      }
+
+      &:last-child > .stepper-link {
+        &::before {
+          position: absolute;
+          inset-block-start: 0;
+          inset-inline-end: stepper.$stepper-indicator-height / 2;
         }
       }
     }
@@ -210,7 +235,7 @@
 
       // hide completed and future step labels
       > .stepper-link {
-        -webkit-line-clamp: none;
+        -webkit-line-clamp: initial;
         line-height: 0;
         text-indent: 100%;
       }

--- a/packages/styles/src/components/stepper.scss
+++ b/packages/styles/src/components/stepper.scss
@@ -24,6 +24,7 @@
   @include utilities.reset-list;
   display: grid;
   position: relative;
+  overflow: hidden;
 
   // the first column is half a step wide to make sure the separators are the same size even on small screens
   grid-template-columns: stepper.$stepper-indicator-size / 2;
@@ -39,7 +40,12 @@
   grid-row: 1;
   position: relative;
 
+  &:not(:first-child) {
+    padding-inline-start: stepper.$stepper-link-spacing / 2;
+  }
+
   &:not(:last-child) {
+    padding-inline-end: stepper.$stepper-link-spacing / 2;
     grid-column: span 2;
   }
 
@@ -207,6 +213,11 @@
 
 // smaller screens
 @include media-breakpoint-down(rg) {
+  .stepper-item:first-child,
+  .stepper-item:last-child {
+    padding-inline: 0;
+  }
+
   .stepper-item[aria-current='step'] {
     // using "display: contents" on the stepper-item and stepper-link so that label, indicator and progress bar can be directly placed in the grid
     display: contents;

--- a/packages/styles/src/components/stepper.scss
+++ b/packages/styles/src/components/stepper.scss
@@ -36,11 +36,13 @@
 }
 
 .stepper-link {
-  text-decoration: none;
+  // -webkit-box is needed for line-clamp: https://caniuse.com/css-line-clamp
+  // stylelint-disable-next-line value-no-vendor-prefix
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   overflow: hidden;
+  text-decoration: none;
   color: stepper.$stepper-link-color;
   width: fit-content;
   line-height: stepper.$stepper-link-line-height;

--- a/packages/styles/src/mixins/_utilities.scss
+++ b/packages/styles/src/mixins/_utilities.scss
@@ -136,6 +136,16 @@
   }
 }
 
+@mixin focus-hover-style-custom($additional-selector: '') {
+  @include focus-style-custom($additional-selector) {
+    @content;
+  }
+
+  &:hover#{$additional-selector} {
+    @content;
+  }
+}
+
 @mixin disabled-style($additional-selector: '') {
   &:disabled#{$additional-selector} {
     pointer-events: none;

--- a/packages/styles/src/variables/components/_stepper.scss
+++ b/packages/styles/src/variables/components/_stepper.scss
@@ -7,28 +7,38 @@
 
 $stepper-bar-height: spacing.$size-micro;
 
+$stepper-bar-color: color.$gray-40;
+$stepper-bar-fill-color: color.$yellow;
+
 $stepper-indicator-height: spacing.$size-bigger-big;
 $stepper-indicator-border-width: spacing.$size-micro;
 $stepper-indicator-border-color: color.$white;
-$stepper-indicator-font-size: type.$font-size-regular;
-$stepper-indicator-font-weight: type.$font-weight-base;
+$stepper-indicator-font-weight: type.$font-weight-bold;
 $stepper-indicator-bg: color.$yellow;
 $stepper-indicator-color: color.$black;
+
+$stepper-indicator-check-icon: url('#{icon-fn.get-colored-svg-url('2105', $stepper-indicator-color)}');
 $stepper-indicator-check-icon-size: spacing.$size-large;
+
+$stepper-indicator-future-bg: color.$gray-60;
+$stepper-indicator-future-color: color.$white;
+
 $stepper-indicator-hover-color: color.$white;
 $stepper-indicator-hover-bg: color.$black;
 $stepper-indicator-hover-outline: forms.$input-focus-outline-thickness solid
   var(--post-contrast-color);
-$stepper-indicator-future-bg: color.$gray-60;
-$stepper-indicator-future-color: color.$white;
 
+$stepper-indicator-hover-check-icon: url('#{icon-fn.get-colored-svg-url('2105',$stepper-indicator-hover-color)}');
+
+$stepper-link-line-height: type.$line-height-sm;
 $stepper-link-gap: spacing.$size-mini;
 $stepper-link-color: color.$gray-60;
-$stepper-link-hover-color: color.$black;
-$stepper-link-current-color: color.$black;
-$stepper-link-current-font-size: type.$font-size-regular;
+
+$stepper-link-current-color: color.$gray-80;
 $stepper-link-current-font-weight: type.$font-weight-bold;
 
+$stepper-link-hover-color: color.$black;
+
 // DEPRECATED
-$stepper-indicator-check-icon: url('#{icon-fn.get-colored-svg-url('2105', $stepper-indicator-color)}');
-$stepper-indicator-hover-check-icon: url('#{icon-fn.get-colored-svg-url('2105',$stepper-indicator-hover-color)}');
+$stepper-indicator-font-size: type.$font-size-16;
+$stepper-link-current-font-size: type.$font-size-16;

--- a/packages/styles/src/variables/components/_stepper.scss
+++ b/packages/styles/src/variables/components/_stepper.scss
@@ -1,7 +1,7 @@
-@use './forms';
 @use './../type';
 @use './../color';
 @use './../spacing';
+@use './../animation';
 
 @use './../../functions/icons' as icon-fn;
 
@@ -9,18 +9,19 @@ $stepper-bar-height: spacing.$size-micro;
 $stepper-bar-color: color.$gray-40;
 $stepper-bar-fill-color: color.$yellow;
 
-$stepper-indicator-height: spacing.$size-bigger-big;
+$stepper-indicator-size: spacing.$size-bigger-big;
 $stepper-indicator-border-width: spacing.$size-micro;
 $stepper-indicator-border-color: rgb(var(--post-bg-rgb, 255 255 255));
 $stepper-indicator-font-weight: type.$font-weight-bold;
 $stepper-indicator-bg: color.$yellow;
 $stepper-indicator-color: color.$black;
-$stepper-indicator-check-icon: url('#{icon-fn.get-colored-svg-url('2105', $stepper-indicator-color)}');
-$stepper-indicator-check-icon-white: url('#{icon-fn.get-colored-svg-url('2105',color.$white)}');
-$stepper-indicator-check-icon-size: spacing.$size-large;
+$stepper-indicator-check-size: spacing.$size-large;
+$stepper-indicator-transition:
+  color animation.$transition-base-timing,
+  background-color animation.$transition-base-timing;
 
-$stepper-indicator-hover-color: color.$white;
-$stepper-indicator-hover-bg: color.$black;
+$stepper-indicator-hover-color: var(--post-contrast-color-inverted);
+$stepper-indicator-hover-bg: var(--post-contrast-color);
 
 $stepper-indicator-future-bg: color.$gray-60;
 $stepper-indicator-future-color: color.$white;
@@ -33,8 +34,11 @@ $stepper-link-current-color: var(--post-gray-80);
 $stepper-link-current-font-weight: type.$font-weight-bold;
 
 // DEPRECATED
-$stepper-link-hover-color: color.$black;
-$stepper-indicator-hover-outline: forms.$input-focus-outline-thickness solid
-  var(--post-contrast-color);
+$stepper-link-hover-color: $stepper-link-color;
+$stepper-indicator-hover-outline: spacing.$size-line solid var(--post-focus-color);
 $stepper-indicator-font-size: type.$font-size-16;
 $stepper-link-current-font-size: type.$font-size-16;
+$stepper-indicator-check-icon: url('#{icon-fn.get-colored-svg-url('2105', $stepper-indicator-color)}');
+$stepper-indicator-hover-check-icon: url('#{icon-fn.get-colored-svg-url('2105',$stepper-indicator-hover-color)}');
+$stepper-indicator-height: $stepper-indicator-size;
+$stepper-indicator-check-icon-size: $stepper-indicator-check-size;

--- a/packages/styles/src/variables/components/_stepper.scss
+++ b/packages/styles/src/variables/components/_stepper.scss
@@ -6,39 +6,35 @@
 @use './../../functions/icons' as icon-fn;
 
 $stepper-bar-height: spacing.$size-micro;
-
 $stepper-bar-color: color.$gray-40;
 $stepper-bar-fill-color: color.$yellow;
 
 $stepper-indicator-height: spacing.$size-bigger-big;
 $stepper-indicator-border-width: spacing.$size-micro;
-$stepper-indicator-border-color: color.$white;
+$stepper-indicator-border-color: rgb(var(--post-bg-rgb, 255 255 255));
 $stepper-indicator-font-weight: type.$font-weight-bold;
 $stepper-indicator-bg: color.$yellow;
 $stepper-indicator-color: color.$black;
-
 $stepper-indicator-check-icon: url('#{icon-fn.get-colored-svg-url('2105', $stepper-indicator-color)}');
+$stepper-indicator-check-icon-white: url('#{icon-fn.get-colored-svg-url('2105',color.$white)}');
 $stepper-indicator-check-icon-size: spacing.$size-large;
+
+$stepper-indicator-hover-color: color.$white;
+$stepper-indicator-hover-bg: color.$black;
 
 $stepper-indicator-future-bg: color.$gray-60;
 $stepper-indicator-future-color: color.$white;
 
-$stepper-indicator-hover-color: color.$white;
-$stepper-indicator-hover-bg: color.$black;
-$stepper-indicator-hover-outline: forms.$input-focus-outline-thickness solid
-  var(--post-contrast-color);
-
-$stepper-indicator-hover-check-icon: url('#{icon-fn.get-colored-svg-url('2105',$stepper-indicator-hover-color)}');
-
 $stepper-link-line-height: type.$line-height-sm;
 $stepper-link-gap: spacing.$size-mini;
-$stepper-link-color: color.$gray-60;
+$stepper-link-color: var(--post-gray-60);
 
-$stepper-link-current-color: color.$gray-80;
+$stepper-link-current-color: var(--post-gray-80);
 $stepper-link-current-font-weight: type.$font-weight-bold;
 
-$stepper-link-hover-color: color.$black;
-
 // DEPRECATED
+$stepper-link-hover-color: color.$black;
+$stepper-indicator-hover-outline: forms.$input-focus-outline-thickness solid
+  var(--post-contrast-color);
 $stepper-indicator-font-size: type.$font-size-16;
 $stepper-link-current-font-size: type.$font-size-16;

--- a/packages/styles/src/variables/components/_stepper.scss
+++ b/packages/styles/src/variables/components/_stepper.scss
@@ -28,6 +28,7 @@ $stepper-indicator-future-color: color.$white;
 
 $stepper-link-line-height: type.$line-height-sm;
 $stepper-link-gap: spacing.$size-mini;
+$stepper-link-spacing: spacing.$size-regular;
 $stepper-link-color: var(--post-gray-60);
 
 $stepper-link-current-color: var(--post-gray-80);


### PR DESCRIPTION
I updated the styles quite drastically so that the stepper is CSS only and doesn't require the ngb progress bar to work.
I also used multiple CSS tricks to accommodate the current markup and avoid a major change, the code could be further simplified for the v8.