### PR TITLE
fix(components-angular): add components package as peer dependency in components-angular package

### DIFF
--- a/.changeset/thirty-lemons-remember.md
+++ b/.changeset/thirty-lemons-remember.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components-angular': patch
+---
+
+Added `@swisspost/design-system-components` package as a peer dependency as recommended by stenciljs. This way, installing `@swisspost/design-system-components` package as a direct dependency should not be necessary anymore in consumer projects.

--- a/packages/components-angular/projects/components/package.json
+++ b/packages/components-angular/projects/components/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "@angular/common": "^16.0.0 || ^17.0.0",
     "@angular/core": "^16.0.0 || ^17.0.0",
-    "@swisspost/design-system-components": "workspace:^7.1.0"
+    "@swisspost/design-system-components": "workspace:7.1.0"
   },
   "sideEffects": false
 }

--- a/packages/components-angular/projects/components/package.json
+++ b/packages/components-angular/projects/components/package.json
@@ -20,12 +20,10 @@
   "dependencies": {
     "tslib": "2.6.2"
   },
-  "devDependencies": {
-    "@swisspost/design-system-components": "workspace:7.1.0"
-  },
   "peerDependencies": {
     "@angular/common": "^16.0.0 || ^17.0.0",
-    "@angular/core": "^16.0.0 || ^17.0.0"
+    "@angular/core": "^16.0.0 || ^17.0.0",
+    "@swisspost/design-system-components": "workspace:^7.1.0"
   },
   "sideEffects": false
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,7 +241,7 @@ importers:
         specifier: ^16.0.0 || ^17.0.0
         version: 17.2.3(rxjs@7.8.1)(zone.js@0.14.5)
       '@swisspost/design-system-components':
-        specifier: workspace:^7.1.0
+        specifier: workspace:7.1.0
         version: link:../../../components
       tslib:
         specifier: 2.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,13 +240,12 @@ importers:
       '@angular/core':
         specifier: ^16.0.0 || ^17.0.0
         version: 17.2.3(rxjs@7.8.1)(zone.js@0.14.5)
+      '@swisspost/design-system-components':
+        specifier: workspace:^7.1.0
+        version: link:../../../components
       tslib:
         specifier: 2.6.2
         version: 2.6.2
-    devDependencies:
-      '@swisspost/design-system-components':
-        specifier: workspace:7.1.0
-        version: link:../../../components
     publishDirectory: ../../dist/components
 
   packages/components-react:
@@ -18175,7 +18174,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      hasown: 2.0.2
+      hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -23784,7 +23783,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.10(esbuild@0.20.1)(webpack@5.90.3(esbuild@0.20.1)):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.22
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1


### PR DESCRIPTION
Installing @swisspost/design-system-components as a direct dependency in all the consumer projects, should not be necessary anymore.