### PR TITLE
fix(documentation, components-angular): remove applyPolyfills because stencil ended IE support

### DIFF
--- a/.changeset/gold-rabbits-juggle.md
+++ b/.changeset/gold-rabbits-juggle.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components-angular': patch
+---
+
+Removed `applyPolyfills` promise before defining web-components in components.module definition, because stencil ended IE support.

--- a/packages/components-angular/projects/components/src/lib/components.module.ts
+++ b/packages/components-angular/projects/components/src/lib/components.module.ts
@@ -1,9 +1,5 @@
 import { CSP_NONCE, ENVIRONMENT_INITIALIZER, inject, NgModule } from '@angular/core';
-import {
-  applyPolyfills,
-  defineCustomElements,
-  setNonce,
-} from '@swisspost/design-system-components/loader';
+import { defineCustomElements, setNonce } from '@swisspost/design-system-components/loader';
 
 import { DIRECTIVES } from './stencil-generated';
 import { PostCardControlCheckboxValueAccessorDirective } from './custom/value-accessors/post-card-control-checkbox-value-accessor';
@@ -31,9 +27,7 @@ const DECLARATIONS = [
         if (nonce) setNonce(nonce);
 
         // Define Post components
-        applyPolyfills().then(() => {
-          defineCustomElements();
-        });
+        defineCustomElements();
       },
       multi: true,
     },

--- a/packages/documentation/.storybook/helpers/register-web-components.ts
+++ b/packages/documentation/.storybook/helpers/register-web-components.ts
@@ -1,24 +1,14 @@
 // @ts-ignore
-import {
-  applyPolyfills as headerPolyfills,
-  defineCustomElements as defineHeader,
-} from '@swisspost/internet-header/loader/index.es2017.js';
-import {
-  applyPolyfills as componentsPolyfills,
-  defineCustomElements as defineComponents,
-} from '@swisspost/design-system-components/loader';
+import { defineCustomElements as defineHeader } from '@swisspost/internet-header/loader/index.es2017.js';
+import { defineCustomElements as defineComponents } from '@swisspost/design-system-components/loader';
 import { setStencilDocJson } from '@pxtrn/storybook-addon-docs-stencil';
 import { StencilJsonDocs } from '@pxtrn/storybook-addon-docs-stencil/dist/types';
 import postComponentsDocJson from '@swisspost/design-system-components/dist/docs.json';
 import internetHeaderDocJson from '@swisspost/internet-header/dist/docs.json';
 import '../../src/shared/link-design/link-design.component';
 
-headerPolyfills().then(() => {
-  defineHeader();
-});
-componentsPolyfills().then(() => {
-  defineComponents();
-});
+defineHeader();
+defineComponents();
 
 if (postComponentsDocJson && internetHeaderDocJson) {
   let { components, ...docJsonMetaData } = postComponentsDocJson as unknown as StencilJsonDocs;

--- a/packages/documentation/.storybook/manager.ts
+++ b/packages/documentation/.storybook/manager.ts
@@ -1,11 +1,8 @@
 import { addons } from '@storybook/manager-api';
 import themes from './styles/themes';
-import { applyPolyfills as componentsPolyfills } from '@swisspost/design-system-components/loader';
 import { defineCustomElement as definePostIcon } from '@swisspost/design-system-components/dist/components/post-icon.js';
 
-componentsPolyfills().then(() => {
-  definePostIcon();
-});
+definePostIcon();
 
 if (process.env.NODE_ENV) document.documentElement.setAttribute('data-env', process.env.NODE_ENV);
 


### PR DESCRIPTION
Fixes #3129 build error.
Want to know more, follow the discussion here: https://github.com/ionic-team/stencil/issues/5780