### PR TITLE
chore: add sonarlint mapping for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,9 @@
     "editor.defaultFormatter": null,
     "editor.formatOnSave": false
   },
-  "files.eol": "\n"
+  "files.eol": "\n",
+  "sonarlint.connectedMode.project": {
+    "connectionId": "swisspost",
+    "projectKey": "swisspost_common-web-frontend"
+  }
 }


### PR DESCRIPTION
This will pull custom rules and ignored paths and other settings from sonar cloud to the vs code extension.