### PR TITLE
chore(workflows): downgrade netlify-cli to v16 for demo app deployments

### DIFF
--- a/.github/actions/deploy-to-netlify/action.yaml
+++ b/.github/actions/deploy-to-netlify/action.yaml
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Install netlify-cli
       shell: bash
-      run: pnpm i -g netlify-cli@17
+      run: pnpm i -g netlify-cli@16
 
     - name: Deploy preview environment to netlify
       id: netlify_deploy

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -32,8 +32,6 @@ jobs:
           name: design-system-demo
           folder: build-output
 
-      - run: ls -R
-
       - name: Deploy demo app to netlify
         uses: ./.github/actions/deploy-to-netlify
         id: deploy

--- a/.github/workflows/release-demo.yaml
+++ b/.github/workflows/release-demo.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install netlify cli
         if: steps.check.outputs.changed == 'true'
-        run: pnpm -g i netlify-cli@17
+        run: pnpm -g i netlify-cli@16
 
       # Publish demo only if changesets published any packages
       - name: Publish demo app to netlify
@@ -56,6 +56,4 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        run: |
-          netlify link --filter @swisspost/design-system-demo --id $NETLIFY_SITE_ID
-          netlify deploy --filter @swisspost/design-system-demo --build false --dir packages/demo/dist/demo --prod
+        run: netlify deploy --filter @swisspost/design-system-demo --build false --dir packages/demo/dist/demo --prod


### PR DESCRIPTION
Deployments of Angular SPAs are not working correctly with netlify-cli@17.
Downgrading to v16 seems to work.