### PR TITLE
chore(components): update the component's package output target

### DIFF
--- a/.changeset/lovely-dancers-tap.md
+++ b/.changeset/lovely-dancers-tap.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-documentation': patch
+'@swisspost/design-system-components': patch
+---
+
+Simplify individual component imports.

--- a/.changeset/lovely-dancers-tap.md
+++ b/.changeset/lovely-dancers-tap.md
@@ -3,4 +3,4 @@
 '@swisspost/design-system-components': patch
 ---
 
-Simplify individual component imports.
+Simplified individual web component imports.

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'cypress.config.js',
     'dist',
     'loader',
+    'loaders',
     'stencil.config.ts',
     'www',
   ],

--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -1,6 +1,7 @@
 dist/
 www/
 loader/
+loaders/
 storybook-static/
 
 *~

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "dist/",
-    "loader/"
+    "loader/",
+    "loaders/"
   ],
   "publishConfig": {
     "access": "public",
@@ -26,7 +27,7 @@
     "dev": "stencil build --dev --port 9200 --serve --watch --docs --docs-readme",
     "start": "stencil build --dev --watch --docs --docs-readme",
     "build": "stencil build --docs-readme",
-    "clean": "rimraf www dist loader",
+    "clean": "rimraf www dist loader loaders",
     "test": "pnpm run unit",
     "unit": "stencil test --spec",
     "unit:watch": "stencil test --spec --watchAll --silent",

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -9,13 +9,20 @@ export const config: Config = {
   namespace: 'post-components',
   buildDist: true,
   sourceMap: false,
+  validatePrimaryPackageOutputTarget: true,
   outputTargets: [
     {
       type: 'dist',
       esmLoaderPath: '../loader',
+      isPrimaryPackageOutputTarget: true,
     },
     {
       type: 'dist-custom-elements',
+    },
+    {
+      type: 'dist-custom-elements',
+      customElementsExportBehavior: 'single-export-module',
+      dir: 'loaders',
     },
     {
       type: 'www',
@@ -75,6 +82,7 @@ export const config: Config = {
     testPathIgnorePatterns: [
       '<rootDir>/dist/',
       '<rootDir>/loader/',
+      '<rootDir>/loaders/',
       '<rootDir>/www/',
       '<rootDir>/cypress',
     ],

--- a/packages/documentation/src/stories/getting-started/packages/components/components-cdn-lazy-loaded-specific.sample.html
+++ b/packages/documentation/src/stories/getting-started/packages/components/components-cdn-lazy-loaded-specific.sample.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <script type="module">
-      import { defineCustomElement as definePostIcon } from '{cdnUrl}@{version}/dist/components/post-icon.js';
-      definePostIcon();
+      import { defineCustomElementPostIcon } from '{cdnUrl}@{version}/loaders';
+      defineCustomElementPostIcon();
     </script>
   </head>
   <body>

--- a/packages/documentation/src/stories/getting-started/packages/components/components-js-specific.sample.js
+++ b/packages/documentation/src/stories/getting-started/packages/components/components-js-specific.sample.js
@@ -1,2 +1,2 @@
-import { defineCustomElement as definePostIcon } from '@swisspost/design-system-components/dist/components/post-icon';
-definePostIcon();
+import { defineCustomElementPostIcon } from '@swisspost/design-system-components/loaders';
+defineCustomElementPostIcon();


### PR DESCRIPTION
In the end this task does not solve any bug with importing web components individually, it is just a nice-to-have simplification.