### PR TITLE
chore: fix pnpm start command

### DIFF
--- a/packages/documentation/vite.config.js
+++ b/packages/documentation/vite.config.js
@@ -21,5 +21,6 @@ export default {
       '@storybook/theming',
       '@storybook/addon-links',
     ],
+    exclude: ['@swisspost/design-system-styles'],
   },
 };

--- a/packages/styles/gulpfile.js
+++ b/packages/styles/gulpfile.js
@@ -151,7 +151,7 @@ gulp.task('build-components', () => {
  */
 gulp.task('sass:dev', () => {
   return gulp
-    .src('./src/post-*.scss')
+    .src('./src/*.scss')
     .pipe(
       gulpSass({
         includePaths: options.includePaths,

--- a/packages/styles/gulpfile.js
+++ b/packages/styles/gulpfile.js
@@ -151,7 +151,7 @@ gulp.task('build-components', () => {
  */
 gulp.task('sass:dev', () => {
   return gulp
-    .src('./src/*.scss', { since: gulp.lastRun('sass:dev') })
+    .src('./src/post-*.scss')
     .pipe(
       gulpSass({
         includePaths: options.includePaths,
@@ -180,7 +180,7 @@ gulp.task('sass:tests', () => {
 gulp.task(
   'watch',
   gulp.series('temporarily-copy-token-files', () => {
-    return gulp.watch('./src/**/*.scss', gulp.series('copy'));
+    return gulp.watch('./src/**/*.scss', gulp.series('copy', 'sass:dev'));
   }),
 );
 


### PR DESCRIPTION
This change excludes `@swisspost/design-system-styles` from the vite optmizeDeps workflow for the documentation package. This seems to get rid of some of the "can't import dynamic dependency" issues.

Reloading after a style change is still pretty slow, but also a lot of unnecessry recompiles are happening. The potential for improvement is quite big here.