### PR TITLE
chore(documentation): reset tabs story-container selectors

### DIFF
--- a/packages/documentation/src/stories/components/tabs/tabs.stories.ts
+++ b/packages/documentation/src/stories/components/tabs/tabs.stories.ts
@@ -63,9 +63,7 @@ export const Async: Story = {
     story => {
       let tabIndex = 0;
       const addTab = () => {
-        const tabs = document
-          .querySelector('story-container')
-          ?.shadowRoot?.querySelector('post-tabs');
+        const tabs = document.querySelector('post-tabs');
 
         tabIndex++;
         const newTab = `
@@ -77,22 +75,16 @@ export const Async: Story = {
       };
 
       const removeActiveTab = () => {
-        const headers: NodeListOf<HTMLPostTabHeaderElement> | undefined = document
-          .querySelector('story-container')
-          ?.shadowRoot?.querySelectorAll('post-tab-header');
+        const headers: NodeListOf<HTMLPostTabHeaderElement> | undefined =
+          document.querySelectorAll('post-tab-header');
 
         const activeHeader: HTMLPostTabHeaderElement | undefined = Array.from(headers ?? []).find(
-          () =>
-            document
-              .querySelector('story-container')
-              ?.shadowRoot?.querySelectorAll('post-tab-header.active'),
+          () => document.querySelectorAll('post-tab-header.active'),
         );
         activeHeader?.remove();
 
         const activePanel: HTMLPostTabPanelElement | null =
-          document
-            .querySelector('story-container')
-            ?.shadowRoot?.querySelector(`post-tab-panel[name=${activeHeader?.panel}]`) ?? null;
+          document.querySelector(`post-tab-panel[name=${activeHeader?.panel}]`) ?? null;
         activePanel?.remove();
       };
 


### PR DESCRIPTION
We resetted the story-container implementation, because it caused a lot of problems in stories, where we make usage of `document`, etc.

depends on #3512