### PR TITLE
feat: allow to include the navigation bar in a single line header

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "header:snapshots": "start-server-and-test docs:headless 9001 'pnpm --filter internet-header snapshots'",
     "intranet-header": "pnpm intranet-header:start",
     "intranet-header:start": "pnpm --filter design-system-intranet-header-workspace start",
+    "intranet-header:build": "pnpm --filter design-system-intranet-header-workspace build",
     "icons": "pnpm icons:start",
     "icons:start": "pnpm --filter design-system-icons dev",
     "icons:test": "pnpm --filter design-system-icons test",

--- a/packages/demo/src/app/app-routing.module.ts
+++ b/packages/demo/src/app/app-routing.module.ts
@@ -54,6 +54,7 @@ import { LayoutContainerComponent } from './layout-container/layout-container.co
 import { IntranetHeaderDemoRegularComponent } from './intranet-layout/components/intranet-header-demo-regular/intranet-header-demo-regular.component';
 import { IntranetHeaderDemoBigSidebarComponent } from './intranet-layout/components/intranet-header-demo-big-sidebar/intranet-header-demo-big-sidebar.component';
 import { IntranetHeaderDemoSmallSidebarComponent } from './intranet-layout/components/intranet-header-demo-small-sidebar/intranet-header-demo-small-sidebar.component';
+import { IntranetHeaderDemoCondensedComponent } from './intranet-layout/components/intranet-header-demo-condensed/intranet-header-demo-condensedomponent.component';
 /* tslint:enable:max-line-length */
 
 const routes: Routes = [
@@ -165,6 +166,10 @@ const routes: Routes = [
       {
         path: 'intranet-layout-sidebar-small-sidebar',
         component: IntranetHeaderDemoSmallSidebarComponent,
+      },
+      {
+        path: 'intranet-layout-condensed',
+        component: IntranetHeaderDemoCondensedComponent,
       },
     ],
   },

--- a/packages/demo/src/app/intranet-layout/components/intranet-header-demo-condensed/intranet-header-demo-condensed.component.html
+++ b/packages/demo/src/app/intranet-layout/components/intranet-header-demo-condensed/intranet-header-demo-condensed.component.html
@@ -1,0 +1,15 @@
+<sp-intranet-header siteTitle="Condensed" [condenseHeader]="true">
+  <li class="nav-item"><a href="/postweb" class="col-auto py-3 px-5 nav-link">Home</a></li>
+  <li class="nav-item">
+    <a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">
+      Post Informatik
+    </a>
+  </li>
+  <li class="nav-item"><a class="col-auto py-3 px-5 nav-link">HR-Portal</a></li>
+  <li class="nav-item">
+    <a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a>
+  </li>
+  <li class="nav-item">
+    <a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a>
+  </li>
+</sp-intranet-header>

--- a/packages/demo/src/app/intranet-layout/components/intranet-header-demo-condensed/intranet-header-demo-condensedomponent.component.ts
+++ b/packages/demo/src/app/intranet-layout/components/intranet-header-demo-condensed/intranet-header-demo-condensedomponent.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-intranet-header',
+  templateUrl: './intranet-header-demo-condensed.component.html',
+  styleUrls: ['../../intranet-layout.component.css'],
+})
+export class IntranetHeaderDemoCondensedComponent {}

--- a/packages/demo/src/app/intranet-layout/intranet-components.module.ts
+++ b/packages/demo/src/app/intranet-layout/intranet-components.module.ts
@@ -8,6 +8,7 @@ import { HighlightProvider } from '../common/highlight.provider';
 import { IntranetHeaderDemoRegularComponent } from './components/intranet-header-demo-regular/intranet-header-demo-regular.component';
 import { IntranetHeaderDemoBigSidebarComponent } from './components/intranet-header-demo-big-sidebar/intranet-header-demo-big-sidebar.component';
 import { IntranetHeaderDemoSmallSidebarComponent } from './components/intranet-header-demo-small-sidebar/intranet-header-demo-small-sidebar.component';
+import { IntranetHeaderDemoCondensedComponent } from './components/intranet-header-demo-condensed/intranet-header-demo-condensedomponent.component';
 
 @NgModule({
   imports: [CommonModule, RouterModule, NgbModule, SwissPostIntranetHeaderModule, HighlightModule],
@@ -16,11 +17,13 @@ import { IntranetHeaderDemoSmallSidebarComponent } from './components/intranet-h
     IntranetHeaderDemoRegularComponent,
     IntranetHeaderDemoBigSidebarComponent,
     IntranetHeaderDemoSmallSidebarComponent,
+    IntranetHeaderDemoCondensedComponent,
   ],
   exports: [
     IntranetHeaderDemoRegularComponent,
     IntranetHeaderDemoBigSidebarComponent,
     IntranetHeaderDemoSmallSidebarComponent,
+    IntranetHeaderDemoCondensedComponent,
   ],
   providers: [HighlightProvider.Config],
 })

--- a/packages/demo/src/app/intranet-layout/intranet-layout.component.html
+++ b/packages/demo/src/app/intranet-layout/intranet-layout.component.html
@@ -301,6 +301,21 @@
           </td>
           <td>The website/application name, shown next to the Logo.</td>
         </tr>
+        <tr>
+          <td>
+            <code>condenseHeader</code>
+          </td>
+          <td>
+            <code>boolean</code>
+          </td>
+          <td>
+            <code>false</code>
+          </td>
+          <td>
+            Arranges the header in a single line, displaying the title, menu items, and settings
+            (such as language options).
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>
@@ -379,6 +394,28 @@
   <code
     class="block"
     [highlight]="codeTemplateBig"
+    [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
+  ></code>
+
+  <h4 class="bold mt-5">Condensed Intranet-Header (single-line)</h4>
+</div>
+
+<div class="header-showcase-container p-huge-r">
+  <div class="header-showcase-page">
+    <iframe
+      title="Intranet-header 'postweb' example with top navigation and with sidenav"
+      src="/#/samples/intranet-layout-condensed"
+      class="w-100"
+      style="min-height: 500px"
+    ></iframe>
+  </div>
+</div>
+
+<div class="container">
+  <span class="spacer"></span>
+  <code
+    class="block"
+    [highlight]="codeTemplateCondensed"
     [languages]="['html', 'scss', 'css', 'typescript', 'javascript']"
   ></code>
 </div>

--- a/packages/demo/src/app/intranet-layout/intranet-layout.component.ts
+++ b/packages/demo/src/app/intranet-layout/intranet-layout.component.ts
@@ -6,6 +6,8 @@ const CODE_TEMPLATE_SMALL =
   require('!!raw-loader!./components/intranet-header-demo-small-sidebar/intranet-header-demo-small-sidebar.component.html').default;
 const CODE_TEMPLATE_BIG =
   require('!!raw-loader!./components/intranet-header-demo-big-sidebar/intranet-header-demo-big-sidebar.component.html').default;
+const CODE_TEMPLATE_CONDENSED =
+  require('!!raw-loader!./components/intranet-header-demo-condensed/intranet-header-demo-condensed.component.html').default;
 
 @Component({
   selector: 'app-intranet-layout',
@@ -30,4 +32,5 @@ export class IntranetLayoutComponent {
   codeTemplateSmall = CODE_TEMPLATE_SMALL;
   codeTemplateBig = CODE_TEMPLATE_BIG;
   codeTemplateReg = CODE_TEMPLATE_REG;
+  codeTemplateCondensed = CODE_TEMPLATE_CONDENSED;
 }

--- a/packages/documentation/src/stories/components/intranet-header/intranet-header-single-line.sample.html
+++ b/packages/documentation/src/stories/components/intranet-header/intranet-header-single-line.sample.html
@@ -1,0 +1,17 @@
+<section class="layout-container header-big">
+  <sp-intranet-header siteTitle="Condensed" [condenseHeader]="true">
+    <li class="nav-item"><a href="/postweb" class="col-auto py-3 px-5 nav-link">Home</a></li>
+    <li class="nav-item">
+      <a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">
+        Post Informatik
+      </a>
+    </li>
+    <li class="nav-item"><a class="col-auto py-3 px-5 nav-link">HR-Portal</a></li>
+    <li class="nav-item">
+      <a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a>
+    </li>
+    <li class="nav-item">
+      <a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a>
+    </li>
+  </sp-intranet-header>
+</section>

--- a/packages/documentation/src/stories/components/intranet-header/intranet-header.docs.mdx
+++ b/packages/documentation/src/stories/components/intranet-header/intranet-header.docs.mdx
@@ -5,6 +5,7 @@ import SampleNavigationBar from './intranet-header-navigation-bar.sample.html?ra
 import SampleSideNavigation from './intranet-header-side-navigation.sample.html?raw';
 import SampleSideUserMenuDropdown from './intranet-header-user-menu-dropdown.sample.html?raw';
 import SamplePostweb from './intranet-header-postweb.sample.html?raw';
+import SampleNavigationBarSingleLine from './intranet-header-single-line.sample.html?raw';
 import PostComponentDemoLink from '@/shared/post-component-demo-link.mdx';
 
 <Meta of={IntranetHeaderStories} />
@@ -49,6 +50,11 @@ For installation and usage see the <a href="/?path=/docs/7068be42-1a20-4a34-9e79
   <PostTabHeader panel="headerPostweb">"Postweb" intranet header</PostTabHeader>
   <PostTabPanel name="headerPostweb">
     <Source code={SamplePostweb} language="html" />
+  </PostTabPanel>
+
+  <PostTabHeader panel="headerSingleLine">Condensed intranet header (single-line)</PostTabHeader>
+  <PostTabPanel name="headerSingleLine">
+    <Source code={SampleNavigationBarSingleLine} language="html" />
   </PostTabPanel>
 </PostTabs>
 

--- a/packages/documentation/src/stories/components/intranet-header/intranet-header.stories.ts
+++ b/packages/documentation/src/stories/components/intranet-header/intranet-header.stories.ts
@@ -180,6 +180,20 @@ const meta: MetaComponent = {
         },
       },
     },
+    condenseHeader: {
+      name: 'condenseHeader',
+      description:
+        'Arranges the header in a single line, displaying the title, menu items, and settings (such as language options)',
+      control: 'boolean',
+      table: {
+        defaultValue: {
+          summary: 'false',
+        },
+        type: {
+          summary: 'boolean',
+        },
+      },
+    },
   },
 };
 

--- a/packages/intranet-header-workspace/projects/intranet-header-showcase/src/app.module.ts
+++ b/packages/intranet-header-workspace/projects/intranet-header-showcase/src/app.module.ts
@@ -8,12 +8,17 @@ import { SamplesSidebarComponent } from './samples/sidebar/sidebar.component';
 import { SwissPostIntranetHeaderModule } from '@swisspost/design-system-intranet-header';
 import { SamplesIndexComponent } from './samples/samples-index.component';
 import { SamplesSidebarWithSearchbarComponent } from './samples/sidebar-with-searchbar/sidebar-with-searchbar.component';
+import { SamplesNavigationCondensedHeaderComponent } from './samples/samples-navigation-condensed-header/samples-navigation-condensed-header.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'index', pathMatch: 'full' },
   { path: 'index', component: SamplesIndexComponent },
 
   { path: 'samples-navigation', component: SamplesNavigationComponent },
+  {
+    path: 'samples-navigation-with-condensed-header',
+    component: SamplesNavigationCondensedHeaderComponent,
+  },
   { path: 'samples-sidebar', component: SamplesSidebarComponent },
   { path: 'samples-sidebar-with-searchbar', component: SamplesSidebarWithSearchbarComponent },
 ];
@@ -22,6 +27,7 @@ const routes: Routes = [
   declarations: [
     AppComponent,
     SamplesNavigationComponent,
+    SamplesNavigationCondensedHeaderComponent,
     SamplesSidebarComponent,
     SamplesSidebarWithSearchbarComponent,
   ],

--- a/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-index.component.ts
+++ b/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-index.component.ts
@@ -5,6 +5,7 @@ import { Component } from '@angular/core';
   template: `
     <ul>
       <li><a href="samples-navigation">Samples navigation</a></li>
+      <li><a href="samples-navigation-with-condensed-header">Samples navigation with condensed header</a></li>
       <li><a href="samples-sidebar">Samples sidebar</a></li>
       <li><a href="samples-sidebar-with-searchbar">Samples sidebar with searchbar</a></li>
     </ul>

--- a/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-navigation-condensed-header/samples-navigation-condensed-header.component.html
+++ b/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-navigation-condensed-header/samples-navigation-condensed-header.component.html
@@ -1,0 +1,17 @@
+<section class="preview">
+  <sp-intranet-header siteTitle="Condensed" searchUrl="/" [condenseHeader]="true">
+    <li class="nav-item"><a href="/postweb" class="col-auto py-3 px-5 nav-link">Home</a></li>
+    <li class="nav-item">
+      <a href="/postweb/post-informatik" class="col-auto py-3 px-5 nav-link" target="_self">
+        Post Informatik
+      </a>
+    </li>
+    <li class="nav-item"><a class="col-auto py-3 px-5 nav-link">HR-Portal</a></li>
+    <li class="nav-item">
+      <a href="/postweb/service-portal" class="col-auto py-3 px-5 nav-link">Service-Portal</a>
+    </li>
+    <li class="nav-item">
+      <a href="/postweb/die-post" class="col-auto py-3 px-5 nav-link">Die Post</a>
+    </li>
+  </sp-intranet-header>
+</section>

--- a/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-navigation-condensed-header/samples-navigation-condensed-header.component.spec.ts
+++ b/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-navigation-condensed-header/samples-navigation-condensed-header.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SamplesNavigationCondensedHeaderComponent } from './samples-navigation-condensed-header.component';
+
+describe('SamplesNavigationCondensedHeaderComponent', () => {
+  let component: SamplesNavigationCondensedHeaderComponent;
+  let fixture: ComponentFixture<SamplesNavigationCondensedHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SamplesNavigationCondensedHeaderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SamplesNavigationCondensedHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-navigation-condensed-header/samples-navigation-condensed-header.component.ts
+++ b/packages/intranet-header-workspace/projects/intranet-header-showcase/src/samples/samples-navigation-condensed-header/samples-navigation-condensed-header.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-samples-navigation-condensed-header',
+  templateUrl: './samples-navigation-condensed-header.component.html',
+  styleUrl: './samples-navigation-condensed-header.component.scss',
+})
+export class SamplesNavigationCondensedHeaderComponent {}

--- a/packages/intranet-header-workspace/projects/intranet-header-showcase/tsconfig.app.json
+++ b/packages/intranet-header-workspace/projects/intranet-header-showcase/tsconfig.app.json
@@ -5,5 +5,6 @@
     "outDir": "../../out-tsc/app",
     "types": []
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
 }

--- a/packages/intranet-header-workspace/projects/intranet-header/src/lib/swisspost-intranet-header.component.html
+++ b/packages/intranet-header-workspace/projects/intranet-header/src/lib/swisspost-intranet-header.component.html
@@ -2,32 +2,39 @@
   <div class="nav-down">
     <div class="intranet-header">
       <div class="d-flex align-items-center flex-nowrap">
-        <div class="bg-logo d-sm-block">
+        <div id="logo" class="bg-logo d-sm-block">
           <a [href]="this.logoUrl" class="navbar-brand header-logo">
             <span class="visually-hidden">{{ getPostLogoText() }}</span>
           </a>
         </div>
-        <div class="title flex-shrink-1 px-4">
+        <div
+          class="title px-4"
+          id="title"
+          [ngClass]="{ 'flex-shrink-1': !condenseHeader, 'flex-shrink-0': condenseHeader }"
+        >
           <h1 class="m-0 font-weight-bold">{{ siteTitle }}</h1>
         </div>
-        <div *ngIf="showIntranetSearch" class="col search-textbox d-none d-md-block">
-          <form [action]="searchUrl">
-            <div class="input-group mx-auto">
-              <input
-                type="text"
-                name="k"
-                class="form-control"
-                placeholder="{{ getPlaceholderSearchIntranet() }}"
-              />
-              <div class="input-group-append d-flex align-items-center">
-                <button class="btn pr-4" type="submit">
-                  <span><em class="pi pi-2069"></em></span>
-                </button>
-              </div>
-            </div>
-          </form>
+
+        <nav
+          *ngIf="condenseHeader && hasNavbar"
+          class="justify-content-start top-navigation condense m-0 d-md-flex"
+          [ngClass]="{ 'd-none': !openedMenu }"
+        >
+          <ng-container *ngTemplateOutlet="navbar"></ng-container>
+          <div *ngIf="showIntranetSearch" class="col search-textbox d-md-none">
+            <ng-template [ngTemplateOutlet]="intranetSearch"></ng-template>
+          </div>
+        </nav>
+        <div
+          *ngIf="showIntranetSearch"
+          id="intranetSearch"
+          class="col search-textbox d-none d-md-block"
+          [ngClass]="{ 'col-3': condenseHeader }"
+        >
+          <ng-template [ngTemplateOutlet]="intranetSearch"></ng-template>
         </div>
         <div
+          id="optionHeaderContent"
           *ngIf="optionHeaderContent"
           class="settings ms-auto flex-shrink-0 d-flex align-self-stretch"
         >
@@ -97,7 +104,7 @@
           </div>
         </div>
         <button
-          *ngIf="hasNavbar === true"
+          *ngIf="hasNavbar === true || condenseHeader"
           (click)="toggleMenu()"
           id="nav-toggler"
           class="btn btn-lg btn-tertiary px-3 border-left rounded-0 flex-shrink-0 align-self-stretch d-md-none"
@@ -107,32 +114,47 @@
       </div>
     </div>
     <nav
-      *ngIf="hasNavbar === true"
+      *ngIf="hasNavbar === true && !condenseHeader"
       class="row justify-content-center top-navigation m-0 d-md-flex"
       [ngClass]="{ 'd-none': !openedMenu }"
     >
-      <div class="navbar-collapse" id="navbarsDefault">
-        <ul id="nav" class="navbar-nav mx-auto justify-content-center">
-          <ng-content></ng-content>
-        </ul>
-      </div>
+      <ng-container *ngTemplateOutlet="navbar"></ng-container>
     </nav>
-    <div *ngIf="showIntranetSearch" class="search-textbox d-md-none">
-      <form [action]="this.searchUrl">
-        <div class="input-group mx-auto">
-          <input
-            type="text"
-            name="k"
-            class="form-control"
-            placeholder="{{ getPlaceholderSearchIntranet() }}"
-          />
-          <div class="input-group-append d-flex align-items-center">
-            <button class="btn pr-4" type="submit">
-              <span><em class="pi pi-2069"></em></span>
-            </button>
-          </div>
-        </div>
-      </form>
+    <div
+      *ngIf="(showIntranetSearch && condenseHeader && !openedMenu) || !condenseHeader"
+      class="search-textbox d-md-none"
+    >
+      <ng-template [ngTemplateOutlet]="intranetSearch"></ng-template>
     </div>
   </div>
 </header>
+
+<ng-template #navbar>
+  <div class="navbar-collapse" id="navbarsDefault">
+    <ul
+      id="nav"
+      class="navbar-nav justify-content-center"
+      [ngClass]="{ 'mx-auto': !condenseHeader }"
+    >
+      <ng-content></ng-content>
+    </ul>
+  </div>
+</ng-template>
+
+<ng-template #intranetSearch>
+  <form [action]="searchUrl">
+    <div class="input-group mx-auto">
+      <input
+        type="text"
+        name="k"
+        class="form-control"
+        placeholder="{{ getPlaceholderSearchIntranet() }}"
+      />
+      <div class="input-group-append d-flex align-items-center">
+        <button class="btn pr-4" type="submit">
+          <span><em class="pi pi-2069"></em></span>
+        </button>
+      </div>
+    </div>
+  </form>
+</ng-template>

--- a/packages/intranet-header-workspace/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
+++ b/packages/intranet-header-workspace/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
@@ -38,6 +38,7 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
   @Input() logoUrl: string = '';
   @Input() searchUrl: string = '';
   @Input() hideCurrentUserId: boolean = false;
+  @Input() condenseHeader: boolean = false;
 
   @ViewChild('domWrapper') dom!: ElementRef;
   @ViewChild('optionDropdown') optionDropdown!: NgbDropdown;
@@ -79,6 +80,11 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
   private moreElement!: HTMLElement;
   private navElement!: HTMLElement;
   private navItems!: Array<HTMLElement>;
+  private logoElement!: HTMLElement;
+  private titleElement!: HTMLElement;
+  private optionHeaderContentElement!: HTMLElement;
+  private intranetSearchElement!: HTMLElement;
+  private profileMenuElement!: HTMLElement;
   private navChanges!: MutationObserver;
 
   constructor(
@@ -141,6 +147,12 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
       }" id="more">
                                     <span class="nav-link col-auto py-3 px-4"></span>
                                 </li>`;
+      this.logoElement = this.dom.nativeElement.querySelector('#logo');
+      this.titleElement = this.dom.nativeElement.querySelector('#title');
+      this.optionHeaderContentElement =
+        this.dom.nativeElement.querySelector('#optionHeaderContent');
+      this.profileMenuElement = this.dom.nativeElement.querySelector('#profileMenu');
+      this.intranetSearchElement = this.dom.nativeElement.querySelector('#intranetSearch');
       this.navElement = this.dom.nativeElement.querySelector('#nav');
       if (this.navElement == null) {
         return;
@@ -279,19 +291,19 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
     const listMargin = 40;
     const navItemWidth = navItems.reduce((acc, el) => acc + el.scrollWidth, listMargin);
 
-    // Get document width
-    const documentWidth = document.documentElement.scrollWidth;
+    // Get available width for the navigation bar
+    const availableNavWidth = this.getAvailableNavWidth();
 
     // Display the more element if necessary, hide it otherwise
-    this.moreElement.style.display = navItemWidth > documentWidth ? '' : 'none';
+    this.moreElement.style.display = navItemWidth > availableNavWidth ? '' : 'none';
 
     // If the navbar is too wide, turn the nav items into overflow items one by one
-    if (navItemWidth > documentWidth) {
+    if (navItemWidth > availableNavWidth) {
       let navWidth = navItemWidth + this.moreElement.scrollWidth;
       let lastNavItem: HTMLElement;
       let greaterWidth = 0;
 
-      while (navWidth > documentWidth) {
+      while (navWidth > availableNavWidth) {
         lastNavItem = navItems[navItems.length - 1];
 
         if (lastNavItem === undefined) {
@@ -331,6 +343,23 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
 
   public isLanguageActive(lang: string) {
     return this.lang.toLowerCase() === lang.toLowerCase();
+  }
+
+  private getAvailableNavWidth(): number {
+    if (!this.condenseHeader) {
+      return document.documentElement.scrollWidth;
+    }
+
+    const elements = [
+      this.logoElement,
+      this.titleElement,
+      this.optionHeaderContentElement,
+      this.profileMenuElement,
+      this.intranetSearchElement,
+    ];
+    const totalWidth = elements.reduce((sum, element) => sum + (element?.scrollWidth || 0), 0);
+
+    return document.documentElement.scrollWidth - totalWidth;
   }
 
   private createSafeAvatarUrl(): SafeUrl {

--- a/packages/styles/src/components/intranet-header/_top-navigation.scss
+++ b/packages/styles/src/components/intranet-header/_top-navigation.scss
@@ -72,15 +72,37 @@
   }
 }
 
+.top-navigation.condense {
+  position: absolute;
+  top: 64px;
+  border-bottom: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
+  width: 100%;
+
+  .nav-item > .nav-link {
+    border-top: 0;
+  }
+}
+
 @include media-breakpoint-down(rg) {
   .top-navigation #navbarsDefault {
     border-top: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
+  }
+
+  .top-navigation.condense #navbarsDefault {
+    border-top: 0;
   }
 }
 
 @include media-breakpoint-up(md) {
   .top-navigation {
     border-top: commons.$border-width solid rgba(var(--post-contrast-color-rgb), 0.2);
+  }
+
+  .top-navigation.condense {
+    position: relative;
+    top: 0;
+    border-top: 0;
+    border-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Allow the option to include the navigation bar in a single line as a condensed header. Instead of 2 lines only one (the top one) will contains the logo, title and navigation bar, as well as the settings. As discussed with Debray Alize and Gfeller Philipp.

Team NES
Langhard Matthias
Pedroso Yohandris