### PR TITLE
chore: fix gulp sass tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -24,7 +24,10 @@ jobs:
 
       # Install packages changed since main, as well as their dependants and dependencies
       - name: Install dependencies
-        run: pnpm --filter "...[origin/main]" install
+        run: pnpm --filter "...[origin/main]..." install
+
+      - name: Build dependencies
+        run: pnpm --filter "...[origin/main]..." install
 
       - name: Run unit tests
         run: pnpm --filter "...[origin/main]" unit

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm --filter "...[origin/main]..." install
 
       - name: Build dependencies
-        run: pnpm --filter "...[origin/main]..." install
+        run: pnpm --filter "...[origin/main]..." build
 
       - name: Run unit tests
         run: pnpm --filter "...[origin/main]" unit

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,12 +22,8 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup-pnpm
 
-      # Install packages changed since main, as well as their dependants and dependencies
-      - name: Install dependencies
-        run: pnpm --filter "...[origin/main]..." install
-
-      - name: Build dependencies
-        run: pnpm --filter "...[origin/main]..." build
+      - name: Install dependencies and build packages
+        run: pnpm bootstrap
 
       - name: Run unit tests
         run: pnpm --filter "...[origin/main]" unit

--- a/packages/styles/gulpfile.js
+++ b/packages/styles/gulpfile.js
@@ -168,14 +168,17 @@ gulp.task('sass:dev', () => {
 /**
  * Compile scss tests
  */
-gulp.task('sass:tests', () => {
-  return gulp.src('./tests/**/*.scss').pipe(
-    gulpSass.sync({
-      includePaths: options.includePaths,
-      quietDeps: true,
-    }),
-  );
-});
+gulp.task(
+  'sass:tests',
+  gulp.series('temporarily-copy-token-files', () => {
+    return gulp.src('./tests/**/*.scss').pipe(
+      gulpSass.sync({
+        includePaths: options.includePaths,
+        quietDeps: true,
+      }),
+    );
+  }),
+);
 
 /**
  * Watch task for scss development


### PR DESCRIPTION
This PR is copying temporary token files before running the tests. This should fix the failing unit test runs.