### PR TITLE
chore: set a fixed netlify cli version

### DIFF
--- a/.github/actions/setup-netlify-cli/action.yaml
+++ b/.github/actions/setup-netlify-cli/action.yaml
@@ -12,4 +12,4 @@ runs:
   steps:
     - name: Install netlify-cli
       shell: bash
-      run: pnpm i -g netlify-cli@17
+      run: pnpm i -g netlify-cli@17.36.1


### PR DESCRIPTION
Our last successful deploys were on the 20th of September. On that day, netlify released a patch update that seems to have broken the deploy command if netlify builds are disabled (https://github.com/netlify/cli/blob/main/CHANGELOG.md#17362-2024-09-20). Trying to fix the issue by setting netlify version to a version before that.

Submited an issue for netlify cli: https://github.com/netlify/cli/issues/6841