### PR TITLE
chore: separate important packages from group update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,10 +15,37 @@
     },
     {
       "matchPackagePatterns": ["*"],
-      "excludePackageNames": ["typescript", "bootstrap"],
+      "excludePackageNames": [
+        "typescript",
+        "bootstrap",
+        "sass",
+        "@storybook/*",
+        "@angular/*",
+        "@stencil/*"
+      ],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchPackagePatterns": ["@storybook/*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Storybook"
+    },
+    {
+      "matchPackagePatterns": ["@stencil/*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Stencil"
+    },
+    {
+      "matchPackagePatterns": ["sass"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Sass"
+    },
+    {
+      "matchPackagePatterns": ["@angular/*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Angular"
     },
     {
       "matchFiles": ["packages/migrations/package.json"],


### PR DESCRIPTION
Renovate, in it's current config, is updating all minor and patch updates in one group. This gets a little overwhelming at times. This PR creates some more groups for the most important dependencies so that they can be tackled one after the other.