### PR TITLE
chore: add members as codeowners of the docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Maintainers have to sign off PRs to main as required in branch protection rules
+packages/documentation @swisspost/design-system-members
 * @swisspost/design-system-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 #
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Maintainers have to sign off PRs to main as required in branch protection rules
 packages/documentation @swisspost/design-system-members
+# Maintainers have to sign off PRs to main as required in branch protection rules
 * @swisspost/design-system-maintainers


### PR DESCRIPTION
Adding members as codeowners of everything conflicts a bit with the rule of 1 review necessary for merging a PR (it's not possible to specify which team needs to review before a merge can happen). Having the members reviewing documentation updates as well should already be an improvement.