### PR TITLE
chore: release react components

### DIFF
--- a/.changeset/shaggy-experts-give.md
+++ b/.changeset/shaggy-experts-give.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components-react': patch
+---
+
+Initial release!

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,15 +1,24 @@
 {
   "name": "@swisspost/design-system-components-react",
   "version": "9.0.0-next.1",
+  "description": "Design System React Components for easy integration with the React ecosystem",
+  "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/swisspost/design-system.git"
+  },
+  "homepage": "https://design-system.post.ch",
+  "bugs": {
+    "url": "https://github.com/swisspost/design-system/issues"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "private": true,
   "files": [
     "dist"
   ],
   "publishConfig": {
-    "access": "restricted",
+    "access": "public",
     "linkDirectory": true
   },
   "scripts": {


### PR DESCRIPTION
This PR sets the react components package to public, which will release it to npm under the version 9.0.0-next.X.