### PR TITLE
fix(components): switch stencil hydrated flag from `class` to `attribute`

### DIFF
--- a/packages/components/cypress/support/commands.ts
+++ b/packages/components/cypress/support/commands.ts
@@ -57,7 +57,7 @@ Cypress.Commands.add('getComponents', (id: string, story: string, ...components:
 
   components.forEach(component => {
     const alias = component.replace(/^post-/, '');
-    cy.get(`post-${alias}.hydrated`, { timeout: 30000 }).as(alias);
+    cy.get(`post-${alias}:is(.hydrated, [data-hydrated])`, { timeout: 30000 }).as(alias);
   });
 
   cy.injectAxe();
@@ -67,7 +67,7 @@ Cypress.Commands.add('getSnapshots', (story: string) => {
   cy.visit(`/iframe.html?id=snapshots--${story}`);
 
   const alias = story.replace(/^post-/, '');
-  cy.get(`post-${alias}.hydrated`, { timeout: 30000 }).as(alias);
+  cy.get(`post-${alias}:is(.hydrated, [data-hydrated])`, { timeout: 30000 }).as(alias);
 
   cy.injectAxe();
 });

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -10,6 +10,10 @@ export const config: Config = {
   buildDist: true,
   sourceMap: false,
   validatePrimaryPackageOutputTarget: true,
+  hydratedFlag: {
+    name: 'data-hydrated',
+    selector: 'attribute',
+  },
   outputTargets: [
     {
       type: 'dist',

--- a/packages/documentation/cypress/snapshots/components/accordion.snapshot.ts
+++ b/packages/documentation/cypress/snapshots/components/accordion.snapshot.ts
@@ -1,7 +1,7 @@
 describe('Accordion', () => {
   it('default', () => {
     cy.visit('/iframe.html?id=snapshots--accordion');
-    cy.get('post-accordion.hydrated', { timeout: 30000 }).should('be.visible');
+    cy.get('post-accordion[data-hydrated]', { timeout: 30000 }).should('be.visible');
     cy.percySnapshot('Accordions', { widths: [1440] });
   });
 });

--- a/packages/documentation/cypress/snapshots/components/card-control.snapshot.ts
+++ b/packages/documentation/cypress/snapshots/components/card-control.snapshot.ts
@@ -7,7 +7,7 @@ describe('CardControl', () => {
 
   it('post-card-control', () => {
     cy.visit('/iframe.html?id=snapshots--post-card-control');
-    cy.get('post-card-control.hydrated', { timeout: 30000 }).should('be.visible');
+    cy.get('post-card-control[data-hydrated]', { timeout: 30000 }).should('be.visible');
     cy.percySnapshot('Card Controls (Web Component)', { widths: [1440] });
   });
 });

--- a/packages/documentation/cypress/snapshots/components/collapsible.snapshot.ts
+++ b/packages/documentation/cypress/snapshots/components/collapsible.snapshot.ts
@@ -1,7 +1,7 @@
 describe('Collapsible', () => {
   it('default', () => {
     cy.visit('/iframe.html?id=snapshots--collapsible');
-    cy.get('post-collapsible.hydrated', { timeout: 30000 }).should('be.visible');
+    cy.get('post-collapsible[data-hydrated]', { timeout: 30000 }).should('be.visible');
     cy.wait(500); // Wait for collapse animation to run
     cy.percySnapshot('Collapsible');
   });

--- a/packages/documentation/cypress/snapshots/components/logo.snapshot.ts
+++ b/packages/documentation/cypress/snapshots/components/logo.snapshot.ts
@@ -1,7 +1,7 @@
 describe('Logo', () => {
   it('default', () => {
     cy.visit('/iframe.html?id=snapshots--post-logo');
-    cy.get('post-logo.hydrated', { timeout: 30000 }).should('be.visible');
+    cy.get('post-logo[data-hydrated]', { timeout: 30000 }).should('be.visible');
     cy.percySnapshot('Logos', { widths: [1440] });
   });
 });

--- a/packages/documentation/cypress/snapshots/components/tabs.snapshot.ts
+++ b/packages/documentation/cypress/snapshots/components/tabs.snapshot.ts
@@ -1,7 +1,7 @@
 describe('Tabs', () => {
   it('default', () => {
     cy.visit('/iframe.html?id=snapshots--tabs');
-    cy.get('post-tab-header.hydrated', { timeout: 30000 }).should('be.visible');
+    cy.get('post-tab-header[data-hydrated]', { timeout: 30000 }).should('be.visible');
     cy.percySnapshot('Tabs', { widths: [1440] });
   });
 });

--- a/packages/documentation/src/stories/components/forms/card-control/web-component/card-control.stories.ts
+++ b/packages/documentation/src/stories/components/forms/card-control/web-component/card-control.stories.ts
@@ -4,7 +4,6 @@ import { MetaComponent } from '@root/types';
 import { html, nothing } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { parse } from '@/utils/sass-export';
-import './card-control.styles.scss';
 import scss from '../card-control.module.scss';
 import { coloredBackground } from '@/shared/decorators/dark-background';
 

--- a/packages/documentation/src/stories/components/forms/card-control/web-component/card-control.styles.scss
+++ b/packages/documentation/src/stories/components/forms/card-control/web-component/card-control.styles.scss
@@ -1,9 +1,0 @@
-// This is necessary, because we overrite the css classes by a custom control
-// which removes the hydrated class from the componentn,
-// which then causes the component to be visibly hidden
-
-#story--886fabcf-148b-4054-a2ec-4869668294fb--lined-up {
-  post-card-control {
-    visibility: visible;
-  }
-}

--- a/packages/documentation/src/stories/components/popover/popover.stories.ts
+++ b/packages/documentation/src/stories/components/popover/popover.stories.ts
@@ -95,7 +95,7 @@ function render(args: Args) {
       </button>
     </div>
     <post-popover
-      class="hydrated bg-${args.backgroundColor}"
+      class="bg-${args.backgroundColor}"
       id="${args.id}"
       placement="${args.placement}"
       ?arrow="${args.arrow}"

--- a/packages/documentation/src/stories/components/tooltip/tooltip.stories.ts
+++ b/packages/documentation/src/stories/components/tooltip/tooltip.stories.ts
@@ -86,7 +86,7 @@ function render(args: Args) {
     <button class="btn btn-secondary btn-large" data-tooltip-target="${args.id}">Button</button>
     <post-tooltip
       id="${args.id}"
-      class="hydrated bg-${args.backgroundColor}"
+      class="bg-${args.backgroundColor}"
       placement="${ifDefined(args.placement)}"
       arrow="${ifDefined(args.arrow)}"
       delayed="${ifDefined(args.delayed)}"
@@ -108,7 +108,6 @@ export const NonFocusable: StoryObj = {
       <cite data-tooltip-target="${args.id}">This is a cite element with a tooltip on it.</cite>
       <post-tooltip
         id="${args.id}"
-        class="hydrated"
         background-color=" ${ifDefined(args.backgroundColor)}"
         placement="${ifDefined(args.placement)}"
       >
@@ -132,7 +131,7 @@ export const Multiple: StoryObj = {
       </button>
       <post-tooltip
         id="${args.id}"
-        class="hydrated bg-${args.background}"
+        class="bg-${args.background}"
         placement="${ifDefined(args.placement)}"
       >
         I'm the same, no matter what

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10948,7 +10948,7 @@ snapshots:
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@20.12.7)(less@4.2.0)(sass@1.77.6)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5))
       browserslist: 4.23.2
       copy-webpack-plugin: 12.0.2(webpack@5.92.1(esbuild@0.21.5))
       critters: 0.0.24
@@ -11041,7 +11041,7 @@ snapshots:
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@20.14.14)(less@4.2.0)(sass@1.77.6)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5))
       browserslist: 4.23.2
       copy-webpack-plugin: 12.0.2(webpack@5.92.1(esbuild@0.21.5))
       critters: 0.0.24
@@ -15868,7 +15868,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1):
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0


### PR DESCRIPTION
This changes how the hydrated flag is add to a web-component.
The class `hydrated` is no longer important/used and therefore also not causing the component to show up, when added statically or just before the component has been hydrated.

Developers which copied the components dom strucure from the code panel of our docs pages (for example for the components `tooltip` and `placeholder`) should remove the class `hydrated` out of there HTML, even though it's not mandatory, because the class will just not have any impact anymore.
On the other hand, if the class was used in some e2e tests of the project, it may be necessary to update those.