### PR TITLE
fix(components): error in console on tooltip exit

### DIFF
--- a/.changeset/chilly-seals-serve.md
+++ b/.changeset/chilly-seals-serve.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed bug in console upon exiting tooltip.

--- a/packages/components/src/components/post-tooltip/post-tooltip.tsx
+++ b/packages/components/src/components/post-tooltip/post-tooltip.tsx
@@ -244,11 +244,9 @@ export class PostTooltip {
 
   /**
    * Pointer or focus left the tooltip, initiate the hiding process
-   * Re-enable pointer events when the tooltip is no longer in focus or hovered
    */
   private handleInterestLost() {
     globalHideTooltip(this);
-    this.host.style.pointerEvents = 'auto';
   }
 
   render() {


### PR DESCRIPTION
Pointer events is not set to none on the host and button is clickable after the tooltip disappears so this bit of code does not seem useful.