### PR TITLE
chore: update tokens workflow

### DIFF
--- a/.github/workflows/create-token-pr.yaml
+++ b/.github/workflows/create-token-pr.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
 
       - name: Configure GitHub User
         run: |
@@ -44,8 +45,6 @@ jobs:
         run: |
           git checkout -b ${{ steps.pr-branch.outputs.name }} ${{ github.ref_name }}
           git push --set-upstream origin ${{ steps.pr-branch.outputs.name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
 
       # If the PR branch exits, update it with the tokens branch
       - name: Update PR Branch with Tokens Branch
@@ -53,16 +52,12 @@ jobs:
         run: |
           git checkout ${{ steps.pr-branch.outputs.name }}
           git merge ${{ github.ref_name }} -X theirs --no-edit
-        env:
-          GITHUB_TOKEN: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
 
       # Always update the PR branch with the main branch
       - name: Update PR Branch with main
         run: |
           git merge origin/main -X ours --no-edit
           git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
 
       # Check if a PR already exist
       - name: Get PR
@@ -73,13 +68,9 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
 
       # If the PR does not exit, create it
       - name: Create PR
         if: steps.pr.outputs.exists == 'false'
         run: |
           gh pr create --title "chore(tokens): :art: update tokens" --body "Merge this PR to update the tokens in the main branch." --base main
-        env:
-          GITHUB_TOKEN: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}


### PR DESCRIPTION
The issue seem to be linked to the token used by the workflow: https://github.com/orgs/community/discussions/37103.
`actions/checkout` sets up the repository so it always uses the GITHUB_TOKEN which never triggers subsequent workflows.