### PR TITLE
chore(styles): move sizing utilities to utilities index

### DIFF
--- a/packages/styles/src/components/_index.scss
+++ b/packages/styles/src/components/_index.scss
@@ -38,7 +38,6 @@
 @use 'product-card';
 @use 'progress';
 @use 'skiplinks';
-@use 'sizing';
 @use 'spinner';
 @use 'stepper';
 @use 'subnavigation';

--- a/packages/styles/src/utilities/_index.scss
+++ b/packages/styles/src/utilities/_index.scss
@@ -8,6 +8,7 @@
 @use './variables' as *;
 @use './not-defined' as *;
 
+@use '../components/sizing';
 @use './temp/legacy';
 
 @each $breakpoint, $device-size in breakpoints.$grid-breakpoints {


### PR DESCRIPTION
This enables more comprehensive utilities import because sizing utilities were part of the components and not the utilities import.