### PR TITLE
fix(intranet-header): update avatar url, used to load a users profile picture form the intranet backend

### DIFF
--- a/.changeset/brave-beds-punch.md
+++ b/.changeset/brave-beds-punch.md
@@ -1,0 +1,10 @@
+---
+'@swisspost/design-system-intranet-header': patch
+'@swisspost/design-system-documentation': patch
+'@swisspost/design-system-demo': patch
+---
+
+Updated the avatar url, used to load a users profile picture form the intranet backend.
+
+! The required input value has recently changed !
+Due to the technical conversion of the intranet backend from Sitecore to Sharepoint, the value required for the property to display a user image has changed. Previously the user ID was required, now this property expects the user-specific e-mail address.

--- a/packages/demo/src/app/intranet-layout/intranet-layout.component.html
+++ b/packages/demo/src/app/intranet-layout/intranet-layout.component.html
@@ -152,13 +152,23 @@
             <code>''</code>
           </td>
           <td>
-            The user ID of the currently logged on user.
+            The email address of the currently logged on user.
             <br />
             Used to show the users profile image.
             <br />
             The default value of
             <code>'user'</code>
             is used to show the fallback-image.
+
+            <div class="mt-3 alert alert-warning">
+              <div class="alert-heading">The required input value has recently changed</div>
+              <p>
+                Due to the technical conversion of the intranet backend from Sitecore to Sharepoint,
+                the value required for the property to display a user image has changed. Previously
+                the user ID was required, now this property expects the user-specific e-mail
+                address.
+              </p>
+            </div>
           </td>
         </tr>
         <tr>

--- a/packages/documentation/src/stories/components/intranet-header/intranet-header.stories.ts
+++ b/packages/documentation/src/stories/components/intranet-header/intranet-header.stories.ts
@@ -30,8 +30,12 @@ const meta: MetaComponent = {
     currentUserId: {
       name: 'currentUserId',
       description:
-        "The ID of the currently logged-in user, used to display the user's profile picture." +
-        '<p class="alert alert-info alert-sm">By default, a fallback image is displayed.</p>',
+        "The email address of the currently logged on user, used to display the user's profile picture." +
+        '<p class="alert alert-info alert-sm">By default, a fallback image is displayed.</p>' +
+        '<div class="mt-3 alert alert-warning alert-sm">' +
+        '<div class="alert-heading">The required input value has recently changed</div>' +
+        '<p>Due to the technical conversion of the intranet backend from Sitecore to Sharepoint, the value required for the property to display a user image has changed. Previously the user ID was required, now this property expects the user-specific e-mail address.</p>' +
+        '</div>',
       control: 'text',
       table: {
         defaultValue: {

--- a/packages/intranet-header-workspace/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
+++ b/packages/intranet-header-workspace/projects/intranet-header/src/lib/swisspost-intranet-header.component.ts
@@ -347,7 +347,9 @@ export class SwissPostIntranetHeaderComponent implements OnInit, OnChanges, Afte
   private createSafeAvatarUrl(): SafeUrl {
     return this.currentUserId === ''
       ? userImage
-      : `https://web.post.ch/UserProfileImage/${encodeURIComponent(this.currentUserId)}.png`;
+      : `https://postchag.sharepoint.com/_layouts/15/userphoto.aspx?size=S&username=${encodeURIComponent(
+          this.currentUserId,
+        )}`;
   }
 
   private updateMoreElementText() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10952,7 +10952,7 @@ snapshots:
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@20.12.7)(less@4.2.0)(sass@1.77.6)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5))
       browserslist: 4.23.2
       copy-webpack-plugin: 12.0.2(webpack@5.92.1(esbuild@0.21.5))
       critters: 0.0.24
@@ -11045,7 +11045,7 @@ snapshots:
       '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@20.14.14)(less@4.2.0)(sass@1.77.6)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5))
       browserslist: 4.23.2
       copy-webpack-plugin: 12.0.2(webpack@5.92.1(esbuild@0.21.5))
       critters: 0.0.24
@@ -15872,7 +15872,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1):
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1(esbuild@0.21.5)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0


### PR DESCRIPTION
! The required input value has recently changed !
Due to the technical conversion of the intranet backend from Sitecore to Sharepoint, the value required for the property to display a user image has changed. Previously the user ID was required, now this property expects the user-specific e-mail address.