### PR TITLE
fix(styles): remove button link padding

### DIFF
--- a/packages/styles/src/components/button.scss
+++ b/packages/styles/src/components/button.scss
@@ -98,15 +98,15 @@ tokens.$default-map: components.$post-button;
   }
 }
 
-// Tertiary with no padding
-.btn-link {
-  padding-inline-start: 0;
-  padding-inline-end: 0;
-}
-
 // Size variants, default is md
 @each $size in button.$btn-non-default-sizes {
   .btn-#{$size} {
     @include button-mx.button-size($size);
   }
+}
+
+// Tertiary with no padding (overrides the padding defined by the sizing classes above)
+.btn-link {
+  padding-inline-start: 0;
+  padding-inline-end: 0;
 }


### PR DESCRIPTION
The `.btn-link` currently has an inline padding when used in combination with an `.btn-sm` or `.btn-lg` class. 