### PR TITLE
chore: filter out integration packages for the bootstrap process

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/swisspost/design-system/issues"
   },
   "scripts": {
-    "bootstrap": "pnpm install && pnpm -r build",
+    "bootstrap": "pnpm install && pnpm -r --filter \"!*-integration\" build",
     "start": "pnpm docs:start",
     "start:clean": "pnpm bootstrap && pnpm start",
     "test": "pnpm -r test",


### PR DESCRIPTION
Since we don't have any integration checks running at the moment, we can skip building the react app on every bootstrap. Once we have integration tests, it would make sense to run them on the release preparation branches and not on every PR.