### PR TITLE
docs: remove audience navigation

### DIFF
--- a/packages/components/src/components/post-header/post-header.tsx
+++ b/packages/components/src/components/post-header/post-header.tsx
@@ -95,7 +95,6 @@ export class PostHeader {
             <div class="logo">
               <slot name="post-logo"></slot>
             </div>
-            {this.device === 'desktop' && <slot name="audience-navigation"></slot>}
           </div>
           <div class="global-sub">
             {this.device === 'desktop' && <slot name="meta-navigation"></slot>}
@@ -116,9 +115,6 @@ export class PostHeader {
         </div>
 
         <div class={mainNavClasses.join(' ')}>
-          {(this.device === 'mobile' || this.device === 'tablet') && (
-            <slot name="audience-navigation"></slot>
-          )}
           <slot name="post-mainnavigation"></slot>
           {(this.device === 'mobile' || this.device === 'tablet') && (
             <slot name="meta-navigation"></slot>

--- a/packages/documentation/src/stories/components/header/components/header.markup.ts
+++ b/packages/documentation/src/stories/components/header/components/header.markup.ts
@@ -4,13 +4,6 @@ export default html`<post-header>
   <!-- Logo -->
   <post-logo>Homepage</post-logo>
 
-  <!-- Audience Navigation -->
-  <ul class="list-inline" slot="audience-navigation">
-    <li><a href="">Privatkunden</a></li>
-    <li><a href="">Geschäftskunden</a></li>
-    <li><a href="">Behörden</a></li>
-  </ul>
-
   <!-- Meta navigation -->
   <ul class="list-inline" slot="meta-navigation">
     <li><a href="">Über uns</a></li>


### PR DESCRIPTION
This navigation will not be needed for cargo and is currently undergoing a redesign. Therefore it will not be part of the first implementation of the header.