### PR TITLE
fix: netlify deploy command

### DIFF
--- a/.github/workflows/release-documentation.yaml
+++ b/.github/workflows/release-documentation.yaml
@@ -75,7 +75,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ fromJSON(steps.netlify-config.outputs.result).siteId }}
         run: |
           echo "site-url=https://${{ fromJSON(steps.netlify-config.outputs.result).siteUrl }}" >> $GITHUB_OUTPUT
-          netlify deploy --filter @swisspost/design-system-documentation --build false --dir packages/documentation/storybook-static --prod
+          netlify deploy --filter @swisspost/design-system-documentation --dir packages/documentation/storybook-static --prod
 
       - name: Create Summary
         id: summary

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -402,7 +402,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
           netlify link --filter @swisspost/design-system-documentation --name ${{ fromJSON(needs.collect-release-data.outputs.release-data).old.siteUrl }}
-          netlify deploy --filter @swisspost/design-system-documentation --build false --dir packages/documentation/storybook-static --prod
+          netlify deploy --filter @swisspost/design-system-documentation --dir packages/documentation/storybook-static --prod
 
       - name: Update Changeset config.json
         uses: actions/github-script@v7


### PR DESCRIPTION
The netlify cli command `netlify deploy` lets you decide if you want to build your package before deployment before the deployment happens or not.
Until now, we had to add `--build false` to this command to omit the build step (because we had either a prebuilt artefact or we had specific build steps in our workflows before the deployment steps anyway.

Since a week or so, this behavior changed in the netlify cli (without any update from our side).
See the "Publish documentation to netlify" step in the "Release Documentation" workflow of yesterdays release: https://github.com/swisspost/design-system/actions/runs/12745852862/job/35520700904
This also resulted in a failure in all of our preview deployment workflows, because there, we do not install node_modules before starting the deployment, but instead use the downloaded artifact of the build output from the previous workflow.
And the build can not be performed, without the node_modules...

From now on, `build: false` seems to be the default value in the cli and the flag `--build false` leads to an activation of the build step in the cli, because it completely ignores the `false` and only considers the `--build` flag, which equals to `build: true`.

Fixing this in the workflow "deploy-documentation" workflow has been done (also for testing) in https://github.com/swisspost/design-system/pull/4433
Check if preview deployment works again [here](https://github.com/swisspost/design-system/actions/workflows/deploy-documentation.yaml).

