### PR TITLE
chore(component): add shadow on optional arrow for `post-tooltip` component (cherry pick #4441 to v8)

### DIFF
--- a/.changeset/eighty-ghosts-explain.md
+++ b/.changeset/eighty-ghosts-explain.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Added shadow to an optional tooltip arrow for `post-popover` component.

--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
@@ -37,6 +37,38 @@
   // Keeps the little arrow visible
   overflow: visible;
 
+  &:not(:has(.arrow)) {
+    @include elevation-mx.elevation('elevation-3');
+  }
+
+  &:has(.arrow) {
+    filter:
+      drop-shadow(1px 2px 3px hsla(216, 9%, 11%, 0.15))
+      drop-shadow(2px 4px 6px hsla(225, 17%, 9%, 0.15))
+      drop-shadow(4px 8px 12px hsla(225, 7%, 11%, 0.15));
+  }
+
+  &:has(.arrow.top) {
+    filter:
+      drop-shadow(0px -2px 3px hsla(216, 9%, 11%, 0.15))
+      drop-shadow(0px -4px 6px hsla(225, 17%, 9%, 0.15))
+      drop-shadow(0px -8px 12px hsla(225, 7%, 11%, 0.15));
+  }
+
+  &:has(.arrow.left) {
+    filter:
+      drop-shadow(-2px 0px 3px hsla(216, 9%, 11%, 0.15))
+      drop-shadow(-4px 0px 6px hsla(225, 17%, 9%, 0.15))
+      drop-shadow(-8px 0px 12px hsla(225, 7%, 11%, 0.15));
+  }
+
+  &:has(.arrow.right) {
+    filter:
+      drop-shadow(2px 0px 3px hsla(216, 9%, 11%, 0.15))
+      drop-shadow(4px 0px 6px hsla(225, 17%, 9%, 0.15))
+      drop-shadow(8px 0px 12px hsla(225, 7%, 11%, 0.15));
+  }
+
   .arrow {
     $arrow-size: 0.5825rem;
     position: absolute;


### PR DESCRIPTION
…ponent (#4441)