### PR TITLE
fix: remove yellow background on html

### DIFF
--- a/.changeset/lovely-cooks-serve.md
+++ b/.changeset/lovely-cooks-serve.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Got rid of the page wide yellow background as it can cause yellow flashing between page loads

--- a/packages/styles/src/elements/body.scss
+++ b/packages/styles/src/elements/body.scss
@@ -9,14 +9,6 @@ tokens.$default-map: elements.$post-body;
 // Resets type
 @use '../components/fonts';
 
-html {
-  // This in combination with the default background color on the body creates a nice effect when overscrolling
-  // in Safari and Chrome on a Mac because the header and the footer are yellow, the yellow surface stretches
-  // beyond the body. If this is not yellow, overscrolling reveals a white background and the header
-  // suddenly seems in the middle of the page.
-  background-color: color.$yellow;
-}
-
 body {
   font-family: type.$font-family-sans-serif;
   font-size: tokens.get('body-font-size');


### PR DESCRIPTION
Looks good on a mac, not such a good idea for everything else.