### PR TITLE
fix: release workflow publish with provenance

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,5 +3,3 @@ registry=https://registry.npmjs.org/
 strict-peer-dependencies=false
 # Install new dependencies with exact version to let renovate handle the update
 save-exact=true
-# Publish packages with provenance
-provenance=true

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "tokens:lint": "pnpm --filter design-system-tokens lint",
     "tokens:lint:fix": "pnpm --filter design-system-tokens lint:fix",
     "tokens:usage": "node ./utilities/token-checker.cjs",
-    "changeset:publish": "pnpm changeset publish",
+    "changeset:publish": "pnpm changeset publish --provenance",
     "changeset:version": "pnpm changeset version && pnpm install --lockfile-only"
   },
   "devDependencies": {


### PR DESCRIPTION
Regarding the [docs](https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions) this should be enough to publish packages with provenance.
But it could also be a configuration problem in the SWISSPOSTDEVS_ACCESS_TOKEN, which is used to call the changesets/action in our release workflow.

@gfellerph Let's try this first, before we switch to the GITHUB_TOKEN.
In case this will not work as well, I'll remove the provenance settings for the moment, so the release is not blocked anymore.