### PR TITLE
fix(workflow): replace deprecated sonarcloud-action with sonarqube-scan-action

### DIFF
--- a/.github/workflows/sonar-analysis.yaml
+++ b/.github/workflows/sonar-analysis.yaml
@@ -31,7 +31,7 @@ jobs:
         run: pnpm install
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
The problem: 
![image](https://github.com/user-attachments/assets/b791aedb-d354-48b5-8e29-b06ef2cd4ea0)

After the solution implemented by this PR, both warnings are not present anymore:
![image](https://github.com/user-attachments/assets/81acc47b-f041-4e31-b60e-82b53d25679c)


