### PR TITLE
revert: reset the netlify config to point to the next netlify page again

### DIFF
--- a/packages/documentation/netlify.config.json
+++ b/packages/documentation/netlify.config.json
@@ -1,4 +1,4 @@
 {
-  "siteId": "916313b9-cc34-4291-bb7f-6463df07598d",
-  "siteUrl": "temp-next-design-system-post.netlify.app"
+  "siteId": "edc7287b-ec63-423c-84aa-c2a1cffbcf87",
+  "siteUrl": "swisspost-design-system-next.netlify.app"
 }


### PR DESCRIPTION
Since netlify unblocked our next url again, we can revert the netlify.config.json back to what we had before we switched to the temp url.