### PR TITLE
fix: header overflow container styles

### DIFF
--- a/packages/documentation/src/stories/modules/header/header.styles.scss
+++ b/packages/documentation/src/stories/modules/header/header.styles.scss
@@ -4,6 +4,7 @@
 
     .virtual-body {
       max-height: 600px;
+      overflow: auto;
     }
   }
 }


### PR DESCRIPTION
Improves overflow container styling on the header docs. The header no longer scrolls out of view unexpectedly.