### PR TITLE
chore(components): fixed popover not opening when clicking on elemets nested in trigger (v9)

### DIFF
--- a/.changeset/lazy-tables-agree.md
+++ b/.changeset/lazy-tables-agree.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Adapted the trigger of the `post-popover` component to be able to handle nested elements.

--- a/packages/components/cypress/e2e/popover.cy.ts
+++ b/packages/components/cypress/e2e/popover.cy.ts
@@ -16,6 +16,42 @@ describe('popover', { baseUrl: null, includeShadowDom: true }, () => {
       // Void click light dismiss does not work in cypress for closing
     });
 
+    it('should show up when clicking on a nested element inside the trigger', () => {
+      // Modify trigger by adding a nested span
+      cy.get('@trigger').then($trigger => {
+        const originalText = $trigger.text();
+        $trigger.html(`<span class="nested-element">${originalText}</span>`);
+      });
+
+      cy.get('@popover').should('not.be.visible');
+      cy.get('@trigger').should('have.attr', 'aria-expanded', 'false');
+      cy.get('.nested-element').click();
+      cy.get('@popover').should('be.visible');
+      cy.get('@trigger').should('have.attr', 'aria-expanded', 'true');
+      cy.get('.btn-close').click();
+      cy.get('@popover').should('not.be.visible');
+      cy.get('@trigger').should('have.attr', 'aria-expanded', 'false');
+    });
+
+    it('should show up when clicking on a deeply nested element inside the trigger', () => {
+      // Set up a trigger with a deeply nested structure
+      cy.get('@trigger').then($trigger => {
+        const originalText = $trigger.text();
+        $trigger.html(`
+          <div class="level-1">
+            <div class="level-2">
+              <span class="level-3">${originalText}</span>
+            </div>
+          </div>
+        `);
+      });
+
+      cy.get('@popover').should('not.be.visible');
+      cy.get('.level-3').click();
+      cy.get('@popover').should('be.visible');
+      cy.get('@trigger').should('have.attr', 'aria-expanded', 'true');
+    });
+
     it('should close on X click', () => {
       cy.get('@trigger').click();
       cy.get('@popover').should('be.visible');

--- a/packages/components/src/components/post-popover/post-popover.tsx
+++ b/packages/components/src/components/post-popover/post-popover.tsx
@@ -11,12 +11,18 @@ let popoverInstances = 0;
 const popoverTargetAttribute = 'data-popover-target';
 
 const globalToggleHandler = (e: PointerEvent | KeyboardEvent) => {
-  const target = e.target as HTMLElement;
-  if (!target || !('getAttribute' in target)) return;
-  const popoverTarget = target.getAttribute(popoverTargetAttribute);
+  let currentElement = e.target as HTMLElement;
+
+  // Traverse up the DOM tree to find if any parent has the popover target attribute
+  while (currentElement && !currentElement.getAttribute(popoverTargetAttribute)) {
+    if (currentElement === document.body || !currentElement.parentElement) break;
+    currentElement = currentElement.parentElement;
+  }
+
+  const popoverTarget = currentElement?.getAttribute(popoverTargetAttribute);
   if (!popoverTarget || ('key' in e && e.key !== 'Enter')) return;
   const popover = document.getElementById(popoverTarget) as HTMLPostPopoverElement;
-  popover?.toggle(target);
+  popover?.toggle(currentElement);
 };
 
 // Initialize a mutation observer for patching accessibility features


### PR DESCRIPTION

## 📄 Description

Changed the globalToggleHandler method of the `post-popover` component. Before it only checked if the event target had the 'data-popover-target' attribute. When for example an icon is nested in the trigger, this would result to false and the popover would not open. In the new implementation instead of just checking the e.target we traverse the DOM tree upwards searching for an element with the 'data-popover-target' attribute. Now clicking on an icon nested in the popover trigger, the popover will be opened/closed as expected.

## 🚀 Demo

https://github.com/user-attachments/assets/e5448e03-75c9-42cb-af49-fe726b4f1e44


---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
