### PR TITLE
chore(styles): fix lint errors

### DIFF
--- a/packages/styles/gulpfile.js
+++ b/packages/styles/gulpfile.js
@@ -172,9 +172,10 @@ gulp.task('generate-not-defined-components-scss', done => {
       return;
     }
 
-    const kebabCaseNames = Array.from(data.matchAll(/export \{ (\w+) \} from/g), m =>
-      m[1].replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase(),
-    ).join(',\n  ');
+    const kebabCaseNames = Array.from(
+      data.matchAll(/export \{ (\w+) \} from/g),
+      m => '    ' + m[1].replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase(),
+    ).join(',\n');
 
     const templatePath = path.join(__dirname, 'src/templates/_not-defined.template.scss');
     fs.readFile(templatePath, 'utf8', (err, data) => {

--- a/packages/styles/src/components/header/index.scss
+++ b/packages/styles/src/components/header/index.scss
@@ -4,7 +4,6 @@
 @use '../../functions/tokens';
 @use '../../tokens/elements';
 @use '../../mixins/button' as button-mx;
-
 @use 'mixins' as *;
 
 tokens.$default-map: elements.$post-link;
@@ -20,8 +19,7 @@ post-header {
     var(--global-header-reduced-height) + var(--main-navigation-height)
   );
   --header-height: calc(
-    var(--header-expanded-height) -
-      min(
+    var(--header-expanded-height) - min(
         var(--header-scroll-top, 0px),
         calc(var(--header-expanded-height) - var(--header-reduced-height))
       )

--- a/packages/styles/src/templates/_not-defined.template.scss
+++ b/packages/styles/src/templates/_not-defined.template.scss
@@ -2,7 +2,7 @@
   Initial visibility of the components is set to hidden to prevent 'flickering' effect due to stencil js/scss delay.
 */
 :where(
-  /* WEB_COMPONENT_NAMES */
-):not(:defined) {
+/* WEB_COMPONENT_NAMES */
+  ):not(:defined) {
   visibility: hidden;
 }


### PR DESCRIPTION
## 📄 Description

This fixes a lint error caused by the _not-defined template and gulp task not adding the correct tabs for formatting.
Additionaly it fixes an error caused by an extra newline in the header/index.scss