### PR TITLE
fix(styles): remove placeholder mixin

### DIFF
--- a/.changeset/chilled-crabs-march.md
+++ b/.changeset/chilled-crabs-march.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': minor
+---
+
+Removed the `@mixin placeholder` as using the `::placeholder` CSS selector is now widely available.

--- a/.changeset/thin-monkeys-chew.md
+++ b/.changeset/thin-monkeys-chew.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Removed the usage of the deprecated pseudo-element `::input-placeholder`. This fixes an issue with CSS validation tools that don't allow deprecated selectors.

--- a/packages/documentation/src/stories/misc/migration-guide/migrationv8-9.component.ts
+++ b/packages/documentation/src/stories/misc/migration-guide/migrationv8-9.component.ts
@@ -117,6 +117,16 @@ export class MigrationV89Component extends LitElement {
                     <li><code>$form-check-feedback-margin-top</code></li>
                   </ul>
                 </li>
+                <li class="mb-16">
+                  <p>
+                    Removed the <code>@mixin placeholder()</code>
+                    <span class="tag tag-sm tag-danger">breaking</span>
+                  </p>
+                  <p class="info">
+                    The CSS selector <code>::placeholder</code> can be used instead as it is now
+                    widely available.
+                  </p>
+                </li>
               </ul>
 
               <h5>Grid</h5>
@@ -557,7 +567,7 @@ export class MigrationV89Component extends LitElement {
                 </li>
                 <li class="mb-16">
                   <p>
-                    The following z-index scss variables have been removed, as they were set on  
+                    The following z-index scss variables have been removed, as they were set on
                     elements that are now using popover which place them in the top layer.
                     <span class="tag tag-sm tag-danger">breaking</span>
                   </p>

--- a/packages/styles/src/components/form-input.scss
+++ b/packages/styles/src/components/form-input.scss
@@ -231,6 +231,7 @@ input.form-control {
 
     &::placeholder {
       color: transparent;
+      opacity: 0;
     }
 
     &:focus,
@@ -249,10 +250,6 @@ input.form-control {
           color: tokens.get('input-color-selected-fg');
         }
       }
-    }
-
-    &::placeholder {
-      opacity: 0;
     }
 
     &:focus::placeholder {

--- a/packages/styles/src/components/form-input.scss
+++ b/packages/styles/src/components/form-input.scss
@@ -251,15 +251,13 @@ input.form-control {
       }
     }
 
-    @include forms-mx.placeholder {
+    &::placeholder {
       opacity: 0;
     }
 
-    &:focus {
-      @include forms-mx.placeholder {
-        color: tokens.get('input-color-helptext-fg');
-        opacity: 1;
-      }
+    &:focus::placeholder {
+      color: tokens.get('input-color-helptext-fg');
+      opacity: 1;
     }
 
     &:disabled ~ label {
@@ -292,10 +290,8 @@ input.form-control {
   }
 
   @include utilities.high-contrast-mode() {
-    > input {
-      @include forms-mx.placeholder() {
-        opacity: 0;
-      }
+    > input::placeholder {
+      opacity: 0;
     }
   }
 }

--- a/packages/styles/src/components/form-textarea.scss
+++ b/packages/styles/src/components/form-textarea.scss
@@ -141,15 +141,13 @@ textarea.form-control {
       }
     }
 
-    @include forms-mx.placeholder {
+    &::placeholder {
       opacity: 0;
     }
 
-    &:focus {
-      @include forms-mx.placeholder {
-        color: tokens.get('textarea-placeholder-fg');
-        opacity: 1;
-      }
+    &:focus::placeholder {
+      color: tokens.get('textarea-placeholder-fg');
+      opacity: 1;
     }
 
     &:disabled ~ label {

--- a/packages/styles/src/components/form-textarea.scss
+++ b/packages/styles/src/components/form-textarea.scss
@@ -131,6 +131,7 @@ textarea.form-control {
 
     &::placeholder {
       color: transparent;
+      opacity: 0;
     }
 
     &:focus,
@@ -139,10 +140,6 @@ textarea.form-control {
         font-size: tokens.get('textarea-label-filled-font-size');
         padding-block-start: tokens.get('textarea-label-filled-padding-block-start');
       }
-    }
-
-    &::placeholder {
-      opacity: 0;
     }
 
     &:focus::placeholder {

--- a/packages/styles/src/components/timepicker.scss
+++ b/packages/styles/src/components/timepicker.scss
@@ -2,7 +2,6 @@
 
 @use './../mixins/utilities';
 @use './../mixins/icons' as icon-mixins;
-@use './../mixins/forms' as form-mixins;
 @use './../mixins/button' as button-mixins;
 
 @use './../variables/type';
@@ -28,7 +27,8 @@
   .form-control-lg {
     width: 6rem;
     padding: 1rem 1.375rem;
-    @include form-mixins.placeholder {
+
+    &::placeholder {
       color: color.$gray-60;
     }
   }

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -6,20 +6,6 @@
 @use './../functions/utilities' as utilities-fx;
 @use './../variables/color';
 
-// Placeholder in input fields
-@mixin placeholder() {
-  &::placeholder {
-    @content;
-  }
-
-  // For very old Edge
-  /* stylelint-disable */
-  &::input-placeholder {
-    @content;
-  }
-  /* stylelint-enable */
-}
-
 /* Deprecated use the one in utilities.scss */
 @mixin focus-outline {
   outline: none;

--- a/packages/styles/tests/mixins/forms.test.scss
+++ b/packages/styles/tests/mixins/forms.test.scss
@@ -1,9 +1,5 @@
 @use 'src/mixins/forms';
 
 body {
-  @include forms.placeholder() {
-    color: red;
-  }
-
   @include forms.focus-outline();
 }

--- a/packages/styles/tests/mixins/index.test.scss
+++ b/packages/styles/tests/mixins/index.test.scss
@@ -4,9 +4,6 @@
 body {
   @include mixins.hover-animation(10px, 500px, 500px);
   @include mixins.hover-animation-svg-icon(red, 2021);
-  @include mixins.placeholder() {
-    color: red;
-  }
   @include mixins.focus-outline();
 
   @include mixins.font-curve('tiny');


### PR DESCRIPTION
## 📄 Description

There was an invalid `::input-placeholder` on the placeholder mixin which I removed. The remaining `::placeholder` seemed sufficent as it is widely available. Therefore the `@mixin placeholder()` did not seem relevant anymore as it only contained the `::placeholder` CSS selector so I removed it as well.