### PR TITLE
fix(component): resolve accessibility violations in the `post-language-switch` component

### DIFF
--- a/.changeset/wicked-students-cough.md
+++ b/.changeset/wicked-students-cough.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Resolved accessibility violations in the `post-header` component by adding the role="menu" to the `post-menu` component.

--- a/.changeset/wicked-students-cough.md
+++ b/.changeset/wicked-students-cough.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-components': patch
 ---
 
-Resolved accessibility violations in the `post-header` component by adding the role="menu" to the `post-menu` component.
+Resolved accessibility violations in the `post-language-switch` component by adding the role="menu" to the `post-menu` component.

--- a/packages/components/src/components/post-language-option/post-language-option.tsx
+++ b/packages/components/src/components/post-language-option/post-language-option.tsx
@@ -123,7 +123,7 @@ export class PostLanguageOption {
     };
 
     return (
-      <Host data-version={version} role={this.variant ? `${this.variant}item` : null}>
+      <Host data-version={version}>
         {this.url ? (
           <a
             aria-current={this.active ? 'page' : undefined}

--- a/packages/components/src/components/post-menu/post-menu.tsx
+++ b/packages/components/src/components/post-menu/post-menu.tsx
@@ -197,8 +197,6 @@ export class PostMenu {
       slottedElements
         // If the element is a slot, get the assigned elements
         .flatMap(el => (el instanceof HTMLSlotElement ? el.assignedElements() : el))
-        // Filter out elements that have a 'menuitem' role
-        .filter(el => el.getAttribute('role') === 'menuitem')
         // For each menu item, get any focusable children (e.g., buttons, links)
         .flatMap(el => Array.from(getFocusableChildren(el)))
     );
@@ -206,7 +204,7 @@ export class PostMenu {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={version} role="menu">
         <post-popovercontainer placement={this.placement} ref={e => (this.popoverRef = e)}>
           <div class="popover-container" part="popover-container">
             <slot></slot>


### PR DESCRIPTION
## 📄 Description

Resolved accessibility violations in the `post-language-switch` component by adding the role="menu" to the `post-menu` component.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
