### PR TITLE
chore: replace tj-actions/changed-files by step-security/changed-files

### DIFF
--- a/.github/workflows/fetch-icons.yaml
+++ b/.github/workflows/fetch-icons.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Get Changes
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: step-security/changed-files@v45
         with:
           files: ./packages/icons/public/post-icons/**
 


### PR DESCRIPTION
## 📄 Description

This PR replaces the compromised tj-actions/changed-files by its uncompromised equivalent provided by step-security in the icon workflow.

## 🚀 Demo

https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
