### PR TITLE
fix: patch font tokens

### DIFF
--- a/.changeset/warm-seals-glow.md
+++ b/.changeset/warm-seals-glow.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-tokens': patch
+'@swisspost/design-system-styles': patch
+---
+
+Removed a mention of Frutiger Neue in the tokens file.

--- a/packages/tokens/tokensstudio-generated/tokens.json
+++ b/packages/tokens/tokensstudio-generated/tokens.json
@@ -485,8 +485,8 @@
           }
         },
         "font-family": {
-          "frutiger": {
-            "value": "Frutiger Neue for Post",
+          "swisspostsans": {
+            "value": "Swiss Post Sans",
             "type": "fontFamilies"
           }
         },
@@ -1856,7 +1856,7 @@
         },
         "font-family": {
           "default": {
-            "value": "{post.core.font-family.frutiger}",
+            "value": "{post.core.font-family.swisspostsans}",
             "type": "fontFamilies"
           }
         },
@@ -2319,7 +2319,7 @@
         },
         "font-family": {
           "default": {
-            "value": "{post.core.font-family.frutiger}",
+            "value": "{post.core.font-family.swisspostsans}",
             "type": "fontFamilies"
           }
         },
@@ -2776,7 +2776,7 @@
         },
         "font-family": {
           "default": {
-            "value": "{post.core.font-family.frutiger}",
+            "value": "{post.core.font-family.swisspostsans}",
             "type": "fontFamilies"
           }
         },


### PR DESCRIPTION
## 📄 Description

This cleans up a remaining definition for Frutiger in the tokens file. The definition was not used.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
