### PR TITLE
fix: set fixed style version

### DIFF
--- a/.changeset/proud-spiders-move.md
+++ b/.changeset/proud-spiders-move.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Fix styles version for outdated v7 so the internet-header package only gets updates from the current version.

--- a/packages/internet-header/package.json
+++ b/packages/internet-header/package.json
@@ -43,7 +43,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@swisspost/design-system-styles": "workspace:7.4.12",
+    "@swisspost/design-system-styles": "7.4.12",
     "body-scroll-lock": "4.0.0-beta.0",
     "iframe-resizer": "4.4.2",
     "jquery": "3.7.1",


### PR DESCRIPTION
## 📄 Description

If the style version is not fixed, the internet-header package will get published with an outdated styles dependency because it's major version is not aligned with the other packages.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
