### PR TITLE
fix(post-icon): add package version in CDN fallback URL for v8

### DIFF
--- a/.changeset/strange-seas-drop.md
+++ b/.changeset/strange-seas-drop.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Updated the fallback CDN URL in the `post-icon` component to include the current package version, ensuring icon requests match the used component version.
+

--- a/packages/components/cypress.config.js
+++ b/packages/components/cypress.config.js
@@ -1,5 +1,5 @@
 const { defineConfig } = require('cypress');
-const { version } = require('../../package.json');
+import { version } from '@root/package.json';
 
 module.exports = defineConfig({
   e2e: {

--- a/packages/components/cypress.config.js
+++ b/packages/components/cypress.config.js
@@ -1,5 +1,5 @@
 const { defineConfig } = require('cypress');
-const { version } = require('../../../package.json');
+const { version } = require('./package.json');
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:9001',

--- a/packages/components/cypress.config.js
+++ b/packages/components/cypress.config.js
@@ -1,6 +1,5 @@
 const { defineConfig } = require('cypress');
-import { version } from '@root/package.json';
-
+const { version } = require('../../../package.json');
 module.exports = defineConfig({
   e2e: {
     baseUrl: 'http://localhost:9001',

--- a/packages/components/cypress.config.js
+++ b/packages/components/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require('cypress');
+const { version } = require('../../package.json');
 
 module.exports = defineConfig({
   e2e: {
@@ -7,6 +8,9 @@ module.exports = defineConfig({
     includeShadowDom: true,
     viewportWidth: 1024,
     viewportHeight: 576,
+  },
+  env: {
+    PACKAGE_VERSION: version,
   },
   includeShadowDom: true,
   retries: {

--- a/packages/components/cypress/e2e/icon.cy.ts
+++ b/packages/components/cypress/e2e/icon.cy.ts
@@ -190,17 +190,14 @@ describe('Icon', () => {
       );
     });
 
-    it('should use "cdn" fallback url if no "slug" is available', () => {
-      const version = Cypress.env('PACKAGE_VERSION');
-      
+    it('should use "cdn" fallback url if no "slug" is available', () => {      
       cy.get('@meta')
         .invoke('removeAttr', 'data-post-icon-base')
         .should('not.have.attr', 'data-post-icon-base');
       cy.get('@inner').should(
         'have.css',
         'mask-image',
-        `url("https://unpkg.com/@swisspost/design-system-icons@${version}/public/post-icons/1000.svg")`,
-      );
+        `url("https://unpkg.com/@swisspost/design-system-icons@${Cypress.env('PACKAGE_VERSION')}/public/post-icons/1000.svg")`,      );
     });
   });
 

--- a/packages/components/cypress/e2e/icon.cy.ts
+++ b/packages/components/cypress/e2e/icon.cy.ts
@@ -190,7 +190,7 @@ describe('Icon', () => {
       );
     });
 
-    it('should use "cdn" fallback url if no "slug" is available', () => {      
+    it('should use "cdn" fallback url if no "slug" is available', () => {
       cy.get('@meta')
         .invoke('removeAttr', 'data-post-icon-base')
         .should('not.have.attr', 'data-post-icon-base');

--- a/packages/components/cypress/e2e/icon.cy.ts
+++ b/packages/components/cypress/e2e/icon.cy.ts
@@ -1,5 +1,3 @@
-import { version } from '@root/package.json';
-
 const POSTICON_ID = '0dcfe3c0-bfc0-4107-b43b-7e9d825b805f';
 
 describe('Icon', () => {

--- a/packages/components/cypress/e2e/icon.cy.ts
+++ b/packages/components/cypress/e2e/icon.cy.ts
@@ -1,3 +1,5 @@
+import { version } from '@root/package.json';
+
 const POSTICON_ID = '0dcfe3c0-bfc0-4107-b43b-7e9d825b805f';
 
 describe('Icon', () => {
@@ -197,7 +199,7 @@ describe('Icon', () => {
       cy.get('@inner').should(
         'have.css',
         'mask-image',
-        'url("https://unpkg.com/@swisspost/design-system-icons/public/post-icons/1000.svg")',
+        `url("https://unpkg.com/@swisspost/design-system-icons@${version}/public/post-icons/1000.svg")`,
       );
     });
   });

--- a/packages/components/cypress/e2e/icon.cy.ts
+++ b/packages/components/cypress/e2e/icon.cy.ts
@@ -191,6 +191,8 @@ describe('Icon', () => {
     });
 
     it('should use "cdn" fallback url if no "slug" is available', () => {
+      const version = Cypress.env('PACKAGE_VERSION');
+      
       cy.get('@meta')
         .invoke('removeAttr', 'data-post-icon-base')
         .should('not.have.attr', 'data-post-icon-base');

--- a/packages/components/src/components/post-icon/post-icon.tsx
+++ b/packages/components/src/components/post-icon/post-icon.tsx
@@ -8,7 +8,7 @@ type UrlDefinition = {
   definesSlug: boolean;
 };
 
-const CDN_URL = 'https://unpkg.com/@swisspost/design-system-icons/public/post-icons';
+const CDN_URL = `https://unpkg.com/@swisspost/design-system-icons@${version}/public/post-icons`;
 const ANIMATION_NAMES = [
   'cylon',
   'cylon-vertical',


### PR DESCRIPTION
## 📄 Description

Updated the fallback CDN URL in the `post-icon` component for release/v8 branch.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
