### PR TITLE
feat(components): make post-list a shadow component

### DIFF
--- a/.changeset/light-spiders-dress.md
+++ b/.changeset/light-spiders-dress.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': minor
+---
+
+Make `post-list` a shadow component to avoid hydration errors when SSR.

--- a/packages/components/src/components/post-list/post-list.scss
+++ b/packages/components/src/components/post-list/post-list.scss
@@ -1,27 +1,27 @@
 @use '@swisspost/design-system-styles/core' as post;
 
-post-list {
+:host {
   display: flex;
   flex-direction: column;
   gap: var(--post-list-title-gap, 0);
+}
 
-  > [role='list'] {
-    display: flex;
-    flex-direction: column;
-    gap: var(--post-list-item-gap, 0);
-  }
+:host(:where([horizontal]:not([horizontal='false']))) {
+  flex-direction: row;
+  align-items: center;
 
-  &:where([horizontal]:not([horizontal='false'])) {
+  [role='list'] {
     flex-direction: row;
     align-items: center;
-
-    > [role='list'] {
-      flex-direction: row;
-      align-items: center;
-    }
   }
+}
 
-  > .list-title.visually-hidden {
-    @include post.visually-hidden();
-  }
+.visually-hidden {
+  @include post.visually-hidden();
+}
+
+[role='list'] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--post-list-item-gap, 0);
 }

--- a/packages/components/src/components/post-list/post-list.tsx
+++ b/packages/components/src/components/post-list/post-list.tsx
@@ -10,7 +10,7 @@ import { nanoid } from 'nanoid';
 @Component({
   tag: 'post-list',
   styleUrl: 'post-list.scss',
-  shadow: false,
+  shadow: true,
 })
 export class PostList {
   @Element() host: HTMLPostListElement;
@@ -32,10 +32,8 @@ export class PostList {
 
   private titleEl: HTMLElement;
 
-  componentWillLoad() {
-    /**
-     * Get the id set on the host element or use a random id by default
-     */
+  constructor() {
+    // Get the id set on the host element or use a random id by default
     this.titleId = `title-${this.host.id || nanoid(6)}`;
   }
 
@@ -44,7 +42,12 @@ export class PostList {
   }
 
   private checkTitle() {
-    if (!this.titleEl.textContent.trim()) {
+    const slotContent = this.titleEl
+      .querySelector('slot')
+      .assignedNodes()
+      .map(node => node.textContent.trim());
+
+    if (!slotContent) {
       console.error(
         'Please provide a title to the list component. Title is mandatory for accessibility purposes.',
       );
@@ -58,10 +61,11 @@ export class PostList {
           ref={el => (this.titleEl = el)}
           id={this.titleId}
           class={`list-title${this.titleHidden ? ' visually-hidden' : ''}`}
+          part="title"
         >
           <slot></slot>
         </div>
-        <div role="list" aria-labelledby={this.titleId}>
+        <div role="list" aria-labelledby={this.titleId} part="list">
           <slot name="post-list-item"></slot>
         </div>
       </Host>

--- a/packages/components/src/components/post-list/readme.md
+++ b/packages/components/src/components/post-list/readme.md
@@ -21,6 +21,14 @@
 | `"post-list-item"` | Slot for placing post-list-item components. |
 
 
+## Shadow Parts
+
+| Part      | Description |
+| --------- | ----------- |
+| `"list"`  |             |
+| `"title"` |             |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
## 📄 Description
Makes post-list a shadow component to get rid of hydration errors when used as SSR component.
Accessibility has been tested with NVDA and VoiceOver, without issues.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
