### PR TITLE
feat(components): make post-linkarea a shadow component

### DIFF
--- a/.changeset/hungry-ways-deliver.md
+++ b/.changeset/hungry-ways-deliver.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-components': minor
 ---
 
-Made `post-linkarea` a shadow component to avoid hydration errors.
+Made `post-linkarea` a shadow component to avoid hydration errors when used in a server-side rendered environment.

--- a/.changeset/hungry-ways-deliver.md
+++ b/.changeset/hungry-ways-deliver.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': minor
+---
+
+Made `post-linkarea` a shadow component to avoid hydration errors.

--- a/packages/components/src/components/post-linkarea/post-linkarea.scss
+++ b/packages/components/src/components/post-linkarea/post-linkarea.scss
@@ -1,4 +1,4 @@
-post-linkarea {
+:host {
   display: contents;
   cursor: pointer;
 }

--- a/packages/components/src/components/post-linkarea/post-linkarea.tsx
+++ b/packages/components/src/components/post-linkarea/post-linkarea.tsx
@@ -9,6 +9,7 @@ type InteractiveElement = HTMLAnchorElement;
 @Component({
   tag: 'post-linkarea',
   styleUrl: 'post-linkarea.scss',
+  shadow: true,
 })
 export class PostLinkarea {
   @Element() host: HTMLPostLinkareaElement;
@@ -28,9 +29,10 @@ export class PostLinkarea {
       new MouseEvent('click', { ctrlKey, shiftKey, altKey, metaKey }),
     );
   }
+
   render() {
     return (
-      <Host data-version={version} onClick={e => this.dispatchClick(e)} tabindex="0">
+      <Host data-version={version} onClick={(e: MouseEvent) => this.dispatchClick(e)} tabindex="0">
         <slot></slot>
       </Host>
     );


### PR DESCRIPTION
## 📄 Description

Make post-linkarea a shadow component to avoid hydration errors.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
