### PR TITLE
fix(documentation): fix import of PostIcon type in icon stories

### DIFF
--- a/packages/documentation/src/stories/foundations/icons/icon.stories.ts
+++ b/packages/documentation/src/stories/foundations/icons/icon.stories.ts
@@ -3,7 +3,7 @@ import { Args, StoryContext, StoryFn, StoryObj } from '@storybook/web-components
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { spreadArgs } from '@/utils';
-import { Components } from '@swisspost/design-system-components/src';
+import { PostIcon } from '@swisspost/design-system-components/dist/components/post-icon';
 import { MetaComponent } from '@root/types';
 
 const meta: MetaComponent = {
@@ -62,7 +62,7 @@ const meta: MetaComponent = {
 };
 
 export default meta;
-type Story = StoryObj<Components.PostIcon>;
+type Story = StoryObj<PostIcon>;
 
 function normalizeArgs(args: Args) {
   // remove attribute with falsy values


### PR DESCRIPTION
## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
