### PR TITLE
fix(styles): update the not-defined selector to render ssr components already before js is enabled

### DIFF
--- a/.changeset/short-rockets-cry.md
+++ b/.changeset/short-rockets-cry.md
@@ -1,5 +1,5 @@
 ---
-'@swisspost/design-system-styles': minor
+'@swisspost/design-system-styles': patch
 ---
 
 Updated the `not-defined` selector, so ssr components can be rendered without js being ready on a page. Only client side rendered web-components will stay invisible, until they are hydrated.

--- a/.changeset/short-rockets-cry.md
+++ b/.changeset/short-rockets-cry.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-styles': patch
 ---
 
-Updated the `not-defined` selector, so ssr components can be rendered without js being ready on a page. Only client side rendered web-components will stay invisible, until they are hydrated.
+Updated the `not-defined` selector to ensure server-side rendered components are visible on the client-side even before JavaScript initializes, while client-side rendered web components remain hidden until fully hydrated.

--- a/.changeset/short-rockets-cry.md
+++ b/.changeset/short-rockets-cry.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': minor
+---
+
+Updated the `not-defined` selector, so ssr components can be rendered without js being ready on a page. Only client side rendered web-components will stay invisible, until they are hydrated.

--- a/packages/styles/src/templates/_not-defined.template.scss
+++ b/packages/styles/src/templates/_not-defined.template.scss
@@ -2,7 +2,7 @@
   Initial visibility of the components is set to hidden to prevent 'flickering' effect due to stencil js/scss delay.
 */
 :where(
-/* WEB_COMPONENT_NAMES */
-  ):not(:defined) {
+    /* WEB_COMPONENT_NAMES */
+  ):not([data-hydrated]) {
   visibility: hidden;
 }


### PR DESCRIPTION
## 📄 Description

SSR components, which are hydrated on the server already, will be visible from the very beginning (even before JS is ready), while client side components will only become visible, as soon as they have been hydrated by JS on the client.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
