### PR TITLE
chore: group only patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "labels": ["📦 {{{parentDir}}}"],
+  "labels": ["⛓️ dependencies"],
   "packageRules": [
     {
       "extends": [
@@ -14,18 +14,19 @@
       "groupName": "Angular"
     },
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchPackageNames": [
-        "*",
-        "!typescript",
-        "!bootstrap",
-        "!sass",
-        "!@storybook/*",
-        "!@angular/*",
-        "!@stencil/*"
-      ]
+      {
+        "matchUpdateTypes": ["patch"],
+        "groupName": "all patch dependencies",
+        "groupSlug": "all-patch",
+        "matchPackageNames": [
+          "*",
+          "!typescript",
+          "!bootstrap",
+          "!@storybook/*",
+          "!@angular/*",
+          "!@stencil/*"
+        ]
+      },
     },
     {
       "matchUpdateTypes": ["minor", "patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -14,19 +14,17 @@
       "groupName": "Angular"
     },
     {
-      {
-        "matchUpdateTypes": ["patch"],
-        "groupName": "all patch dependencies",
-        "groupSlug": "all-patch",
-        "matchPackageNames": [
-          "*",
-          "!typescript",
-          "!bootstrap",
-          "!@storybook/*",
-          "!@angular/*",
-          "!@stencil/*"
-        ]
-      },
+      "matchUpdateTypes": ["patch"],
+      "groupName": "all patch dependencies",
+      "groupSlug": "all-patch",
+      "matchPackageNames": [
+        "*",
+        "!typescript",
+        "!bootstrap",
+        "!@storybook/*",
+        "!@angular/*",
+        "!@stencil/*"
+      ]
     },
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## 📄 Description

As the system dependencies grow, it becomes less and less likely, that a grouped minor and patch update PR can be merged without issues. This change would only group patch updates into one PR and submit minor updates individually, keeping the existing exclusion rules in place.

It also updates the label assigned to renovate PRs to not mess with our package labels.