### PR TITLE
chore(workflow): reference GitHub Actions by hash instead of version (v7)

### DIFF
--- a/.github/actions/artifact-download/action.yaml
+++ b/.github/actions/artifact-download/action.yaml
@@ -32,7 +32,7 @@ runs:
   using: composite
   steps:
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@v6
+      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11
       with:
         name: ${{ inputs.name }}
         run_id: ${{ github.event.workflow_run.id }}

--- a/.github/actions/artifact-upload/action.yaml
+++ b/.github/actions/artifact-upload/action.yaml
@@ -31,7 +31,7 @@ runs:
       run: cd ${{ inputs.folder }} && zip artifacts.zip . -r
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.folder }}/artifacts.zip

--- a/.github/actions/preview/message/create/action.yaml
+++ b/.github/actions/preview/message/create/action.yaml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       with:
         github-token: ${{ inputs.access-token }}
         script: |

--- a/.github/actions/preview/message/update/action.yaml
+++ b/.github/actions/preview/message/update/action.yaml
@@ -15,7 +15,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
       env:
         ISSUE_NUMBER: ${{ inputs.issue-number }}
         PREVIEW_URL: ${{ inputs.preview-url }}

--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -43,7 +43,7 @@ runs:
           }
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
       with:
         # If input.pnpm_version is NOT defined,
         # the action automatically uses the "packageManager" field from the package.json file
@@ -53,7 +53,7 @@ runs:
         version: ${{ inputs.pnpm_version || null }}
 
     - name: Install node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
       with:
         node-version: ${{ inputs.node_version || fromJSON(steps.wanted-versions.outputs.result).node }}
         cache: ${{ inputs.use_cache == 'true' && 'pnpm' || '' }}

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Create preview message
         uses: ./.github/actions/preview/message/create

--- a/.github/workflows/build-documentation.yaml
+++ b/.github/workflows/build-documentation.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Create preview message
         uses: ./.github/actions/preview/message/create

--- a/.github/workflows/build-tokens.yaml
+++ b/.github/workflows/build-tokens.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup
         uses: ./.github/actions/setup-pnpm
@@ -24,7 +24,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')

--- a/.github/workflows/deploy-demo.yaml
+++ b/.github/workflows/deploy-demo.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup
         uses: ./.github/actions/setup-pnpm

--- a/.github/workflows/deploy-documentation.yaml
+++ b/.github/workflows/deploy-documentation.yaml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup pnpm & node
         uses: ./.github/actions/setup-pnpm
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get netlify config
         id: netlify-config
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             return `# Deployed Documentation Preview

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           use_cache: false
 
       - name: Cache cypress
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
         with:
           path: /home/runner/.cache/Cypress
           key: ${{ runner.os }}-cypress-${{ hashFiles('./pnpm-lock.yaml') }}
@@ -47,7 +47,7 @@ jobs:
         run: pnpm e2e:ci
 
       - name: Upload screenshots
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: failure()
         with:
           name: cypress-snapshots

--- a/.github/workflows/fetch-icons.yaml
+++ b/.github/workflows/fetch-icons.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
 
       - name: Get Changes
         id: changed-files
-        uses: step-security/changed-files@v45
+        uses: step-security/changed-files@3dbe17c78367e7d60f00d78ae6781a35be47b4a1
         with:
           files: ./packages/icons/public/post-icons/**
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-title-lint.yaml
+++ b/.github/workflows/pr-title-lint.yaml
@@ -1,6 +1,6 @@
 name: "Lint PR title"
 
-on: 
+on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
@@ -9,6 +9,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-demo.yaml
+++ b/.github/workflows/release-demo.yaml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Check if version has changed
         id: check # This will be the reference for getting the outputs.
-        uses: EndBug/version-check@v2 # You can choose the version/branch you prefer.
+        uses: EndBug/version-check@36ff30f37c7deabe56a30caa043d127be658c425 # You can choose the version/branch you prefer.
         with:
           file-name: ./packages/demo/package.json
           diff-search: true

--- a/.github/workflows/release-documentation.yaml
+++ b/.github/workflows/release-documentation.yaml
@@ -17,11 +17,11 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Detect Version Change
         id: check
-        uses: EndBug/version-check@v2
+        uses: EndBug/version-check@36ff30f37c7deabe56a30caa043d127be658c425
         with:
           file-name: ./packages/documentation/package.json
           diff-search: true
@@ -29,7 +29,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             return `# Version Change Detection
@@ -46,7 +46,7 @@ jobs:
     if: needs.detect-version-change.outputs.changed == 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup pnpm & node
         uses: ./.github/actions/setup-pnpm
@@ -62,7 +62,7 @@ jobs:
 
       - name: Get Netlify Config
         id: netlify-config
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')
@@ -79,7 +79,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             return `# Deployed Documentation

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Checkout the Branch which was pushed ('main' or 'release/v*')
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node & pnpm
         uses: ./.github/actions/setup-pnpm
@@ -34,7 +34,7 @@ jobs:
       #  - no new changesets (the preview PR got merged into github.ref branch): publish packages
       - name: Changeset Magic
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc
         env:
           GITHUB_TOKEN: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           PUBLISHED: ${{ steps.changesets.outputs.published }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
@@ -76,7 +76,7 @@ jobs:
     steps:
       # Checkout the Branch which has been pushed ('main' or 'release/v*')
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Setup Node & pnpm
         uses: ./.github/actions/setup-pnpm
@@ -93,7 +93,7 @@ jobs:
       # Read the status Files and collect release data on the @swisspost/design-system-styles package
       - name: Collect Release Data
         id: release-data
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')
@@ -128,25 +128,25 @@ jobs:
 
       - name: Check if changset-release/main Branch exists
         id: changeset-branch-exists
-        uses: GuillaumeFalourd/branch-exists@v1
+        uses: GuillaumeFalourd/branch-exists@009290475dc3d75b5d7ec680c0c5b614b0d9855d
         with:
           branch: changeset-release/main
 
       - name: Check if release/v* Branch exists
         id: release-branch-exists
-        uses: GuillaumeFalourd/branch-exists@v1
+        uses: GuillaumeFalourd/branch-exists@009290475dc3d75b5d7ec680c0c5b614b0d9855d
         with:
           branch: ${{ fromJSON(steps.release-data.outputs.result).branchName }}
 
       - name: Check if changeset-release/release/v* Branch exists
         id: release-changeset-branch-exists
-        uses: GuillaumeFalourd/branch-exists@v1
+        uses: GuillaumeFalourd/branch-exists@009290475dc3d75b5d7ec680c0c5b614b0d9855d
         with:
           branch: changeset-release/${{ fromJSON(steps.release-data.outputs.result).branchName }}
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           REF_NAME: ${{ github.ref_name }}
           RELEASE_DATA: ${{ steps.release-data.outputs.result }}
@@ -182,7 +182,7 @@ jobs:
     steps:
       # Checkout the changeset Branch
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
           ref: changeset-release/${{ github.ref_name }}
@@ -199,7 +199,7 @@ jobs:
       - name: Update or create Documentation _redirects
         id: update-redirects
         if: fromJSON(needs.collect-release-data.outputs.release-data).isMajor == true
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')
@@ -221,7 +221,7 @@ jobs:
             return true
 
       - name: Update Documentation versions.json
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')
@@ -260,7 +260,7 @@ jobs:
         run: rm -f monorepo.json
 
       - name: Commit Changes and Push Branch
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
         with:
           author_name: Swiss Post Bot
           author_email: 103635272+swisspost-bot@users.noreply.github.com
@@ -269,7 +269,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           REF_NAME: ${{ github.ref_name }}
           RELEASE_DATA: ${{ needs.collect-release-data.outputs.release-data }}
@@ -301,7 +301,7 @@ jobs:
     steps:
       # Checkout the commit with the release.old.version tag (e.g. @swisspost/design-system-styles@5.3.2)
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
           ref: '@swisspost/design-system-styles@${{ fromJSON(needs.collect-release-data.outputs.release-data).old.version }}'
@@ -351,7 +351,7 @@ jobs:
           netlify deploy --filter @swisspost/design-system-documentation --build false --dir packages/documentation/storybook-static --prod
 
       - name: Update Changeset config.json
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')
@@ -365,7 +365,7 @@ jobs:
             }, null, 2) + '\n')
 
       - name: Update Documentation netlify.config.json
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             const fs = require('fs')
@@ -379,7 +379,7 @@ jobs:
 
       # Commit the changes to a new release/v* branch
       - name: Commit Changes and Push Release Branch
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5
         with:
           author_name: Swiss Post Bot
           author_email: 103635272+swisspost-bot@users.noreply.github.com
@@ -389,7 +389,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           RELEASE_DATA: ${{ needs.collect-release-data.outputs.release-data }}
         with:
@@ -417,7 +417,7 @@ jobs:
     if: github.ref_name == 'main' && (needs.collect-release-data.outputs.release-branch-exists == 'true' || needs.collect-release-data.outputs.release-changeset-branch-exists == 'true') && fromJSON(needs.collect-release-data.outputs.release-data) != null && fromJSON(needs.collect-release-data.outputs.release-data).isMajor == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           token: ${{ secrets.SWISSPOSTDEVS_ACCESS_TOKEN }}
 
@@ -431,7 +431,7 @@ jobs:
 
       - name: Create Summary
         id: summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         env:
           RELEASE_DATA: ${{ needs.collect-release-data.outputs.release-data }}
         with:

--- a/.github/workflows/snapshot-tests.yaml
+++ b/.github/workflows/snapshot-tests.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sonar-analysis.yaml
+++ b/.github/workflows/sonar-analysis.yaml
@@ -20,7 +20,7 @@ jobs:
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
@@ -31,7 +31,7 @@ jobs:
         run: pnpm install
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
         with:
           days-before-stale: 90
           days-before-close: -1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## 📄 Description

This PR updates all GitHub Actions references in workflows and custom actions to use commit hashes instead of version tags for release/v7. It also addresses replacing the deprecated sonarcloud-action with sonarqube-scan-action for Sonar workflow.

Changes

1. Replaced version tags (e.g., @v4, @v7) with specific commit hashes in multiple workflows and action files.
2. Ensured that actions/checkout, actions/upload-artifact, actions/github-script, and other third-party actions reference their exact commit SHA.
3. Replaced deprecated sonarcloud-action with sonarqube-scan-action.

## 🚀 Demo

With the PR I have replaced deprecated sonarcloud-action with sonarqube-scan-action to address the warning
![image](https://github.com/user-attachments/assets/7c661347-315a-4056-a387-a2c0a07a0605)

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
