### PR TITLE
feat(components): add post-megadropdown-toplevel-item component

### DIFF
--- a/.changeset/wet-pens-sing.md
+++ b/.changeset/wet-pens-sing.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-documentation': minor
+'@swisspost/design-system-components': minor
+---
+
+Added the component `post-mainnavigation-toplevel-item`, which introduces a consistent way to work around the layout shift in the mainnavigation, when font-weight changes from regular to bold.

--- a/packages/components/cypress/fixtures/post-mainnavigation-overflow.test.html
+++ b/packages/components/cypress/fixtures/post-mainnavigation-overflow.test.html
@@ -1,172 +1,164 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
-    <link rel="stylesheet" href="../../node_modules/@swisspost/design-system-styles/elements.css" />
-    <link
-      rel="stylesheet"
-      href="../../node_modules/@swisspost/design-system-styles/components/header/index.css"
-    />
-    <script src="../../dist/post-components/post-components.esm.js" type="module"></script>
-  </head>
-  <body>
-    <post-header>
-      <!-- Logo -->
-      <post-logo slot="post-logo">Homepage</post-logo>
 
-      <!-- Meta navigation -->
-      <ul class="list-inline" slot="meta-navigation">
-        <li><a href="">Jobs</a></li>
-        <li><a href="">Über uns</a></li>
-      </ul>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Document</title>
+  <link rel="stylesheet" href="../../node_modules/@swisspost/design-system-styles/elements.css" />
+  <link rel="stylesheet" href="../../node_modules/@swisspost/design-system-styles/components/header/index.css" />
+  <script src="../../dist/post-components/post-components.esm.js" type="module"></script>
+</head>
 
-      <!-- Menu button for mobile -->
-      <post-togglebutton slot="post-togglebutton">
-        <span class="visually-hidden-sm">Menu</span>
-        <post-icon aria-hidden="true" name="burger" data-showWhen="untoggled"></post-icon>
-        <post-icon aria-hidden="true" name="closex" data-showWhen="toggled"></post-icon>
-      </post-togglebutton>
+<body>
+  <post-header>
+    <!-- Logo -->
+    <post-logo slot="post-logo">Homepage</post-logo>
 
-      <!-- Language switch -->
-      <post-language-switch
-        caption="Change the language"
-        description="The currently selected language is English."
-        name="language-switch-example"
-        slot="post-language-switch"
-      >
-        <post-language-option active="false" code="de" name="Deutsch">DE</post-language-option>
-        <post-language-option active="false" code="fr" name="French">FR</post-language-option>
-        <post-language-option active="false" code="it" name="Italiano">IT</post-language-option>
-        <post-language-option active="true" code="en" name="English">EN</post-language-option>
-      </post-language-switch>
+    <!-- Meta navigation -->
+    <ul class="list-inline" slot="meta-navigation">
+      <li><a href="">Jobs</a></li>
+      <li><a href="">Über uns</a></li>
+    </ul>
 
-      <!-- Application title (optional) -->
-      <h1 slot="title">Application title</h1>
+    <!-- Menu button for mobile -->
+    <post-togglebutton slot="post-togglebutton">
+      <span class="visually-hidden-sm">Menu</span>
+      <post-icon aria-hidden="true" name="burger" data-showWhen="untoggled"></post-icon>
+      <post-icon aria-hidden="true" name="closex" data-showWhen="toggled"></post-icon>
+    </post-togglebutton>
 
-      <!-- Custom content (optional) -->
-      <ul class="list-inline">
-        <li>
-          <a href="#">
-            <span class="visually-hidden-sm">Search</span>
-            <post-icon aria-hidden="true" name="search"></post-icon>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <span class="visually-hidden-sm">Login</span>
-            <post-icon aria-hidden="true" name="login"></post-icon>
-          </a>
-        </li>
-      </ul>
+    <!-- Language switch -->
+    <post-language-switch caption="Change the language" description="The currently selected language is English."
+      name="language-switch-example" slot="post-language-switch">
+      <post-language-option active="false" code="de" name="Deutsch">DE</post-language-option>
+      <post-language-option active="false" code="fr" name="French">FR</post-language-option>
+      <post-language-option active="false" code="it" name="Italiano">IT</post-language-option>
+      <post-language-option active="true" code="en" name="English">EN</post-language-option>
+    </post-language-switch>
 
-      <!-- Main navigation -->
-      <post-mainnavigation caption="Hauptnavigation">
-        <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
-        </button>
+    <!-- Application title (optional) -->
+    <h1 slot="title">Application title</h1>
 
-        <post-list title-hidden="">
-          <h2>Main Navigation</h2>
+    <!-- Custom content (optional) -->
+    <ul class="list-inline">
+      <li>
+        <a href="#">
+          <span class="visually-hidden-sm">Search</span>
+          <post-icon aria-hidden="true" name="search"></post-icon>
+        </a>
+      </li>
+      <li>
+        <a href="#">
+          <span class="visually-hidden-sm">Login</span>
+          <post-icon aria-hidden="true" name="login"></post-icon>
+        </a>
+      </li>
+    </ul>
 
-          <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="item-1">Item 1</post-megadropdown-trigger>
-            <post-megadropdown id="item-1">
-              <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
-                Back
-              </button>
-              <post-closebutton slot="close-button">Schliessen</post-closebutton>
-              <h2 slot="megadropdown-title">Briefe title</h2>
-              <post-list>
-                <h3>Briefe senden</h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Briefe Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-              <post-list>
-                <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Pakete Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-            </post-megadropdown>
-          </post-list-item>
+    <!-- Main navigation -->
+    <post-mainnavigation caption="Hauptnavigation">
+      <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
+        <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+      </button>
 
-          <!-- Link only level 1 -->
-          <post-list-item slot="post-list-item"><a href="/item-2">Item 2</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-3">Item 3</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-4">Item 4</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-5">Item 5</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-6">Item 6</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-7">Item 7</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-8">Item 8</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-9">Item 9</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-10">Item 10</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-11">Item 11</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-12">Item 12</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-13">Item 13</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-14">Item 14</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-15">Item 15</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-16">Item 16</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-17">Item 17</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-18">Item 18</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/item-19">Item 19</a></post-list-item>
+      <post-list title-hidden="">
+        <h2>Main Navigation</h2>
 
-          <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="item-20">Item 20</post-megadropdown-trigger>
-            <post-megadropdown id="item-20">
-              <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
-                Back
-              </button>
-              <post-closebutton slot="close-button">Schliessen</post-closebutton>
-              <h2 slot="megadropdown-title">Pakete title</h2>
-              <post-list>
-                <h3>Pakete senden</h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Pakete Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-              <post-list>
-                <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Pakete Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-            </post-megadropdown>
-          </post-list-item>
-        </post-list>
-      </post-mainnavigation>
-    </post-header>
-  </body>
+        <post-list-item slot="post-list-item">
+          <post-megadropdown-trigger for="item-1"><post-mainnavigation-toplevel-item>Item
+              1</post-mainnavigation-toplevel-item></post-megadropdown-trigger>
+          <post-megadropdown id="item-1">
+            <button slot="back-button" class="btn btn-tertiary btn-sm">
+              <post-icon name="arrowright"></post-icon>
+              Back
+            </button>
+            <post-closebutton slot="close-button">Schliessen</post-closebutton>
+            <h2 slot="megadropdown-title">Briefe title</h2>
+            <post-list>
+              <h3>Briefe senden</h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Briefe Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+            <post-list>
+              <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+          </post-megadropdown>
+        </post-list-item>
+
+        <!-- Link only level 1 -->
+        <post-list-item slot="post-list-item"><a href="/item-2"><post-mainnavigation-toplevel-item>Item
+              2</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-3"><post-mainnavigation-toplevel-item>Item
+              3</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-4"><post-mainnavigation-toplevel-item>Item
+              4</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-5"><post-mainnavigation-toplevel-item>Item
+              5</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-6"><post-mainnavigation-toplevel-item>Item
+              6</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-7"><post-mainnavigation-toplevel-item>Item
+              7</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-8"><post-mainnavigation-toplevel-item>Item
+              8</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-9"><post-mainnavigation-toplevel-item>Item
+              9</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-10"><post-mainnavigation-toplevel-item>Item
+              10</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-11"><post-mainnavigation-toplevel-item>Item
+              11</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-12"><post-mainnavigation-toplevel-item>Item
+              12</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-13"><post-mainnavigation-toplevel-item>Item
+              13</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-14"><post-mainnavigation-toplevel-item>Item
+              14</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-15"><post-mainnavigation-toplevel-item>Item
+              15</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-16"><post-mainnavigation-toplevel-item>Item
+              16</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-17"><post-mainnavigation-toplevel-item>Item
+              17</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-18"><post-mainnavigation-toplevel-item>Item
+              18</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a href="/item-19"><post-mainnavigation-toplevel-item>Item
+              19</post-mainnavigation-toplevel-item></a></post-list-item>
+
+        <post-list-item slot="post-list-item">
+          <post-megadropdown-trigger for="item-20"><post-mainnavigation-toplevel-item>Item
+              20</post-mainnavigation-toplevel-item></post-megadropdown-trigger>
+          <post-megadropdown id="item-20">
+            <button slot="back-button" class="btn btn-tertiary btn-sm">
+              <post-icon name="arrowright"></post-icon>
+              Back
+            </button>
+            <post-closebutton slot="close-button">Schliessen</post-closebutton>
+            <h2 slot="megadropdown-title">Pakete title</h2>
+            <post-list>
+              <h3>Pakete senden</h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+            <post-list>
+              <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+          </post-megadropdown>
+        </post-list-item>
+      </post-list>
+    </post-mainnavigation>
+  </post-header>
+</body>
+
 </html>

--- a/packages/components/cypress/fixtures/post-mainnavigation.test.html
+++ b/packages/components/cypress/fixtures/post-mainnavigation.test.html
@@ -1,132 +1,132 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
-    <link rel="stylesheet" href="../../node_modules/@swisspost/design-system-styles/elements.css" />
-    <link
-      rel="stylesheet"
-      href="../../node_modules/@swisspost/design-system-styles/components/header/index.css"
-    />
-    <script src="../../dist/post-components/post-components.esm.js" type="module"></script>
-  </head>
-  <body>
-    <post-header>
-      <!-- Logo -->
-      <post-logo slot="post-logo">Homepage</post-logo>
 
-      <!-- Meta navigation -->
-      <ul class="list-inline" slot="meta-navigation">
-        <li><a href="">Jobs</a></li>
-        <li><a href="">Über uns</a></li>
-      </ul>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Document</title>
+  <link rel="stylesheet" href="../../node_modules/@swisspost/design-system-styles/elements.css" />
+  <link rel="stylesheet" href="../../node_modules/@swisspost/design-system-styles/components/header/index.css" />
+  <script src="../../dist/post-components/post-components.esm.js" type="module"></script>
+</head>
 
-      <!-- Menu button for mobile -->
-      <post-togglebutton slot="post-togglebutton">
-        <span class="visually-hidden-sm">Menu</span>
-        <post-icon aria-hidden="true" name="burger" data-showWhen="untoggled"></post-icon>
-        <post-icon aria-hidden="true" name="closex" data-showWhen="toggled"></post-icon>
-      </post-togglebutton>
+<body>
+  <post-header>
+    <!-- Logo -->
+    <post-logo slot="post-logo">Homepage</post-logo>
 
-      <!-- Language switch -->
-      <post-language-switch
-        caption="Change the language"
-        description="The currently selected language is English."
-        name="language-switch-example"
-        slot="post-language-switch"
-      >
-        <post-language-option active="false" code="de" name="Deutsch">DE</post-language-option>
-        <post-language-option active="false" code="fr" name="French">FR</post-language-option>
-        <post-language-option active="false" code="it" name="Italiano">IT</post-language-option>
-        <post-language-option active="true" code="en" name="English">EN</post-language-option>
-      </post-language-switch>
+    <!-- Meta navigation -->
+    <ul class="list-inline" slot="meta-navigation">
+      <li><a href="">Jobs</a></li>
+      <li><a href="">Über uns</a></li>
+    </ul>
 
-      <!-- Application title (optional) -->
-      <h1 slot="title">Application title</h1>
+    <!-- Menu button for mobile -->
+    <post-togglebutton slot="post-togglebutton">
+      <span class="visually-hidden-sm">Menu</span>
+      <post-icon aria-hidden="true" name="burger" data-showWhen="untoggled"></post-icon>
+      <post-icon aria-hidden="true" name="closex" data-showWhen="toggled"></post-icon>
+    </post-togglebutton>
 
-      <!-- Custom content (optional) -->
-      <ul class="list-inline">
-        <li>
-          <a href="#">
-            <span class="visually-hidden-sm">Search</span>
-            <post-icon aria-hidden="true" name="search"></post-icon>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <span class="visually-hidden-sm">Login</span>
-            <post-icon aria-hidden="true" name="login"></post-icon>
-          </a>
-        </li>
-      </ul>
+    <!-- Language switch -->
+    <post-language-switch caption="Change the language" description="The currently selected language is English."
+      name="language-switch-example" slot="post-language-switch">
+      <post-language-option active="false" code="de" name="Deutsch">DE</post-language-option>
+      <post-language-option active="false" code="fr" name="French">FR</post-language-option>
+      <post-language-option active="false" code="it" name="Italiano">IT</post-language-option>
+      <post-language-option active="true" code="en" name="English">EN</post-language-option>
+    </post-language-switch>
 
-      <!-- Main navigation -->
-      <post-mainnavigation caption="Hauptnavigation">
-        <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
-        </button>
+    <!-- Application title (optional) -->
+    <h1 slot="title">Application title</h1>
 
-        <post-list title-hidden="">
-          <h2>Main Navigation</h2>
+    <!-- Custom content (optional) -->
+    <ul class="list-inline">
+      <li>
+        <a href="#">
+          <span class="visually-hidden-sm">Search</span>
+          <post-icon aria-hidden="true" name="search"></post-icon>
+        </a>
+      </li>
+      <li>
+        <a href="#">
+          <span class="visually-hidden-sm">Login</span>
+          <post-icon aria-hidden="true" name="login"></post-icon>
+        </a>
+      </li>
+    </ul>
 
-          <!-- Link only level 1 -->
-          <post-list-item><a href="/briefe">Briefe</a></post-list-item>
-          <post-list-item><a href="/pakete">Pakete</a></post-list-item>
+    <!-- Main navigation -->
+    <post-mainnavigation caption="Hauptnavigation">
+      <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
+        <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+      </button>
 
-          <!-- Level 1 with megadropdown -->
-          <post-list-item>
-            <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
-            <post-megadropdown id="briefe">
-              <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
-                Back
-              </button>
-              <post-closebutton slot="close-button">Schliessen</post-closebutton>
-              <h2 slot="megadropdown-title">Briefe title</h2>
-              <post-list>
-                <h3>Briefe senden</h3>
-                <post-list-item><a href="/sch">Briefe Schweiz</a></post-list-item>
-                <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
-                <post-list-item><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item><a href="">Express und Kurier</a></post-list-item>
-              </post-list>
-              <post-list>
-                <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
-                <post-list-item><a href="/sch">Pakete Schweiz</a></post-list-item>
-                <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
-                <post-list-item><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item><a href="">Express und Kurier</a></post-list-item>
-              </post-list>
-            </post-megadropdown>
-          </post-list-item>
-          <post-list-item>
-            <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
-            <post-megadropdown id="pakete">
-              <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
-                Back
-              </button>
-              <post-closebutton slot="close-button">Schliessen</post-closebutton>
-              <h2 slot="megadropdown-title">Pakete title</h2>
-              <post-list>
-                <h3>Pakete senden</h3>
-                <post-list-item><a href="/sch">Pakete Schweiz</a></post-list-item>
-                <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
-                <post-list-item><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item><a href="">Express und Kurier</a></post-list-item>
-              </post-list>
-              <post-list>
-                <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
-                <post-list-item><a href="/sch">Pakete Schweiz</a></post-list-item>
-                <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
-                <post-list-item><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item><a href="">Express und Kurier</a></post-list-item>
-              </post-list>
-            </post-megadropdown>
-          </post-list-item>
-        </post-list>
-      </post-mainnavigation>
-    </post-header>
-  </body>
+      <post-list title-hidden="">
+        <h2>Main Navigation</h2>
+
+        <!-- Link only level 1 -->
+        <post-list-item><a
+            href="/briefe"><post-mainnavigation-toplevel-item>Briefe</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item><a
+            href="/pakete"><post-mainnavigation-toplevel-item></post-mainnavigation-toplevel-item>Pakete</post-mainnavigation-toplevel-item></a></post-list-item>
+
+        <!-- Level 1 with megadropdown -->
+        <post-list-item>
+          <post-megadropdown-trigger
+            for="briefe"><post-mainnavigation-toplevel-item>Briefe</post-mainnavigation-toplevel-item></post-megadropdown-trigger>
+          <post-megadropdown id="briefe">
+            <button slot="back-button" class="btn btn-tertiary btn-sm">
+              <post-icon name="arrowright"></post-icon>
+              Back
+            </button>
+            <post-closebutton slot="close-button">Schliessen</post-closebutton>
+            <h2 slot="megadropdown-title">Briefe title</h2>
+            <post-list>
+              <h3>Briefe senden</h3>
+              <post-list-item><a href="/sch">Briefe Schweiz</a></post-list-item>
+              <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+            <post-list>
+              <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
+              <post-list-item><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+          </post-megadropdown>
+        </post-list-item>
+        <post-list-item>
+          <post-megadropdown-trigger
+            for="pakete"><post-mainnavigation-toplevel-item>Pakete</post-mainnavigation-toplevel-item></post-megadropdown-trigger>
+          <post-megadropdown id="pakete">
+            <button slot="back-button" class="btn btn-tertiary btn-sm">
+              <post-icon name="arrowright"></post-icon>
+              Back
+            </button>
+            <post-closebutton slot="close-button">Schliessen</post-closebutton>
+            <h2 slot="megadropdown-title">Pakete title</h2>
+            <post-list>
+              <h3>Pakete senden</h3>
+              <post-list-item><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+            <post-list>
+              <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
+              <post-list-item><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+          </post-megadropdown>
+        </post-list-item>
+      </post-list>
+    </post-mainnavigation>
+  </post-header>
+</body>
+
 </html>

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -293,6 +293,8 @@ export namespace Components {
     }
     interface PostMainnavigation {
     }
+    interface PostMainnavigationToplevelItem {
+    }
     interface PostMegadropdown {
         /**
           * Sets focus to the first focusable element within the component.
@@ -731,6 +733,12 @@ declare global {
         prototype: HTMLPostMainnavigationElement;
         new (): HTMLPostMainnavigationElement;
     };
+    interface HTMLPostMainnavigationToplevelItemElement extends Components.PostMainnavigationToplevelItem, HTMLStencilElement {
+    }
+    var HTMLPostMainnavigationToplevelItemElement: {
+        prototype: HTMLPostMainnavigationToplevelItemElement;
+        new (): HTMLPostMainnavigationToplevelItemElement;
+    };
     interface HTMLPostMegadropdownElementEventMap {
         "postToggleMegadropdown": { isVisible: boolean; focusParent?: boolean };
     }
@@ -893,6 +901,7 @@ declare global {
         "post-list-item": HTMLPostListItemElement;
         "post-logo": HTMLPostLogoElement;
         "post-mainnavigation": HTMLPostMainnavigationElement;
+        "post-mainnavigation-toplevel-item": HTMLPostMainnavigationToplevelItemElement;
         "post-megadropdown": HTMLPostMegadropdownElement;
         "post-megadropdown-trigger": HTMLPostMegadropdownTriggerElement;
         "post-menu": HTMLPostMenuElement;
@@ -1171,6 +1180,8 @@ declare namespace LocalJSX {
     }
     interface PostMainnavigation {
     }
+    interface PostMainnavigationToplevelItem {
+    }
     interface PostMegadropdown {
         /**
           * Emits when the dropdown is shown or hidden. The event payload is an object. `isVisible` is true when the dropdown gets opened and false when it gets closed `focusParent` determines whether after the closing of the mega dropdown, the focus should go back to the trigger parent or naturally go to the next focusable element in the page
@@ -1345,6 +1356,7 @@ declare namespace LocalJSX {
         "post-list-item": PostListItem;
         "post-logo": PostLogo;
         "post-mainnavigation": PostMainnavigation;
+        "post-mainnavigation-toplevel-item": PostMainnavigationToplevelItem;
         "post-megadropdown": PostMegadropdown;
         "post-megadropdown-trigger": PostMegadropdownTrigger;
         "post-menu": PostMenu;
@@ -1392,6 +1404,7 @@ declare module "@stencil/core" {
             "post-list-item": LocalJSX.PostListItem & JSXBase.HTMLAttributes<HTMLPostListItemElement>;
             "post-logo": LocalJSX.PostLogo & JSXBase.HTMLAttributes<HTMLPostLogoElement>;
             "post-mainnavigation": LocalJSX.PostMainnavigation & JSXBase.HTMLAttributes<HTMLPostMainnavigationElement>;
+            "post-mainnavigation-toplevel-item": LocalJSX.PostMainnavigationToplevelItem & JSXBase.HTMLAttributes<HTMLPostMainnavigationToplevelItemElement>;
             "post-megadropdown": LocalJSX.PostMegadropdown & JSXBase.HTMLAttributes<HTMLPostMegadropdownElement>;
             "post-megadropdown-trigger": LocalJSX.PostMegadropdownTrigger & JSXBase.HTMLAttributes<HTMLPostMegadropdownTriggerElement>;
             "post-menu": LocalJSX.PostMenu & JSXBase.HTMLAttributes<HTMLPostMenuElement>;

--- a/packages/components/src/components/post-mainnavigation-toplevel-item/post-mainnavigation-toplevel-item.scss
+++ b/packages/components/src/components/post-mainnavigation-toplevel-item/post-mainnavigation-toplevel-item.scss
@@ -1,0 +1,35 @@
+@use '@swisspost/design-system-styles/variables/animation';
+@use '@swisspost/design-system-styles/mixins/media';
+@use '@swisspost/design-system-styles/mixins/icons';
+@use '@swisspost/design-system-styles/mixins/button';
+@use '@swisspost/design-system-styles/mixins/utilities';
+@use '@swisspost/design-system-styles/components/header/mixins' as header-mx;
+
+:host {
+  display: inline-flex;
+  position: relative;
+}
+
+@include media.max(lg) {
+  .active {
+    display: none;
+  }
+}
+
+@include media.min(lg) {
+  .active,
+  .inactive {
+    display: block;
+    text-align: center;
+  }
+
+  .active {
+    visibility: hidden;
+    font-weight: 700;
+  }
+
+  .inactive {
+    position: absolute;
+    inset-inline: 0;
+  }
+}

--- a/packages/components/src/components/post-mainnavigation-toplevel-item/post-mainnavigation-toplevel-item.tsx
+++ b/packages/components/src/components/post-mainnavigation-toplevel-item/post-mainnavigation-toplevel-item.tsx
@@ -1,0 +1,50 @@
+import { Component, Element, h, Host, State } from '@stencil/core';
+import { version } from '@root/package.json';
+
+@Component({
+  tag: 'post-mainnavigation-toplevel-item',
+  styleUrl: 'post-mainnavigation-toplevel-item.scss',
+  shadow: true,
+})
+export class PostMainnavigationToplevelItem {
+  private readonly slotObserver: MutationObserver;
+
+  @Element() host: HTMLPostMainnavigationToplevelItemElement;
+
+  /**
+   * Slotted html which need to be mirrored in the .active element to avoid layout shifts.
+   */
+  @State() slottedHTML: string;
+
+  constructor() {
+    this.setSlottedHTML = this.setSlottedHTML.bind(this);
+    this.slotObserver = new MutationObserver(this.setSlottedHTML);
+  }
+
+  private setSlottedHTML() {
+    this.slottedHTML = this.host.innerHTML;
+  }
+
+  connectedCallback() {
+    this.setSlottedHTML();
+  }
+
+  componentDidLoad() {
+    this.slotObserver.observe(this.host, { characterData: true, childList: true, subtree: true });
+  }
+
+  disconnectedCallback() {
+    this.slotObserver.disconnect();
+  }
+
+  render() {
+    return (
+      <Host data-version={version}>
+        <span class="active" aria-hidden="true" innerHTML={this.slottedHTML}></span>
+        <span class="inactive">
+          <slot></slot>
+        </span>
+      </Host>
+    );
+  }
+}

--- a/packages/components/src/components/post-mainnavigation-toplevel-item/readme.md
+++ b/packages/components/src/components/post-mainnavigation-toplevel-item/readme.md
@@ -1,0 +1,10 @@
+# post-mainnavigation-toplevel-item
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
@@ -140,33 +140,11 @@ post-mainnavigation {
         font-size: 16px;
         z-index: 4;
 
-        .nav-el-active {
-          font-weight: 700;
-          text-align: center;
-          opacity: 0;
-        }
-
-        .nav-el-inactive {
-          position: absolute;
-          opacity: 1;
-          text-align: center;
-          width: 100%;
-          inset-inline-start: 0;
-        }
-
         &.selected,
         &[aria-expanded='true'] {
           background-color: #050400;
           color: #fff;
           font-weight: 700;
-
-          .nav-el-active {
-            opacity: 1;
-          }
-
-          .nav-el-inactive {
-            opacity: 0;
-          }
         }
 
         &:hover {
@@ -184,10 +162,6 @@ post-mainnavigation {
       post-megadropdown-trigger button {
         padding-inline-end: 12px;
         transition: border-block-end-color animation.$transition-base-timing;
-
-        .nav-el-inactive {
-          width: calc(100% - 28px);
-        }
 
         &::after {
           transition: transform animation.$transition-base-timing;
@@ -228,10 +202,6 @@ post-mainnavigation {
       > button,
       post-megadropdown-trigger button {
         @include header-mx.mobile-header-interactive;
-
-        .nav-el-inactive {
-          display: none;
-        }
       }
     }
 

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
@@ -88,24 +88,9 @@ export class PostMainnavigation {
     }
 
     this.mutationObserver.observe(this.navigationList, { subtree: true, childList: true }); // Recheck scrollability when navigation list changes
-    this.fixLayoutShift();
 
     // Handle focus changes and adjust scroll as needed
     this.navbar.addEventListener('focusin', e => this.adjustTranslation(e));
-  }
-
-  // Hack that duplicates navigation elements to fix the layout shift on active elements
-  private fixLayoutShift() {
-    // Select first level of main navigation elements, both the links and the megadropdown trigger buttons
-    const children = this.host.querySelectorAll(
-      'nav > post-list > div > post-list-item > a, nav > post-list > div > post-list-item > post-megadropdown-trigger > button',
-    );
-
-    // Update HTML so that the content is duplicated
-    children.forEach(
-      child =>
-        (child.innerHTML = `<span class="nav-el-active">${child.innerHTML}</span><span class="nav-el-inactive"aria-hidden="true">${child.innerHTML}</span>`),
-    );
   }
 
   private handleBackButtonClick() {

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -1,182 +1,151 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
-    />
-    <meta name="design-system-settings" data-post-icon-base="/assets/icons" />
-    <title>Stencil Component Starter</title>
 
-    <link id="tokens" rel="stylesheet" href="/assets/css/post-tokens-default.css" />
-    <link id="palette" rel="stylesheet" href="/assets/css/post-palettes.css" />
-    <link rel="stylesheet" href="/assets/css/index.css" />
-    <script type="module" src="/build/post-components.esm.js"></script>
-    <script nomodule src="/build/post-components.js"></script>
-  </head>
-  <body style="min-height: 200vh">
-    <post-header>
-      <!-- Logo -->
-      <post-logo slot="post-logo">Homepage</post-logo>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <meta name="design-system-settings" data-post-icon-base="/assets/icons" />
+  <title>Stencil Component Starter</title>
 
-      <!-- Meta navigation -->
-      <ul class="list-inline" slot="meta-navigation">
-        <li><a href="">Jobs</a></li>
-        <li><a href="">Über uns</a></li>
-      </ul>
+  <link id="tokens" rel="stylesheet" href="/assets/css/post-tokens-default.css" />
+  <link id="palette" rel="stylesheet" href="/assets/css/post-palettes.css" />
+  <link rel="stylesheet" href="/assets/css/index.css" />
+  <script type="module" src="/build/post-components.esm.js"></script>
+  <script nomodule src="/build/post-components.js"></script>
+</head>
 
-      <!-- Menu button for mobile -->
-      <post-togglebutton slot="post-togglebutton">
-        <span class="visually-hidden-sm">Menu</span>
-        <post-icon aria-hidden="true" name="burger" data-showWhen="untoggled"></post-icon>
-        <post-icon aria-hidden="true" name="closex" data-showWhen="toggled"></post-icon>
-      </post-togglebutton>
+<body style="min-height: 200vh">
+  <post-header>
+    <!-- Logo -->
+    <post-logo slot="post-logo">Homepage</post-logo>
 
-      <!-- Language switch -->
-      <post-language-switch
-        caption="Change the language"
-        description="The currently selected language is English."
-        name="language-switch-example"
-        slot="post-language-switch"
-        variant="menu"
-      >
-        <post-language-option code="de" name="Deutsch">DE</post-language-option>
-        <post-language-option code="fr" name="French">FR</post-language-option>
-        <post-language-option code="it" name="Italiano">IT</post-language-option>
-        <post-language-option active code="en" name="English">EN</post-language-option>
-      </post-language-switch>
+    <!-- Meta navigation -->
+    <ul class="list-inline" slot="meta-navigation">
+      <li><a href="">Jobs</a></li>
+      <li><a href="">Über uns</a></li>
+    </ul>
 
-      <!-- Application title (optional) -->
-      <h1 slot="title">Application title</h1>
+    <!-- Menu button for mobile -->
+    <post-togglebutton slot="post-togglebutton">
+      <span class="visually-hidden-sm">Menu</span>
+      <post-icon aria-hidden="true" name="burger" data-showWhen="untoggled"></post-icon>
+      <post-icon aria-hidden="true" name="closex" data-showWhen="toggled"></post-icon>
+    </post-togglebutton>
 
-      <!-- Custom content (optional) -->
-      <ul class="list-inline">
-        <li>
-          <a href="#">
-            <span class="visually-hidden-sm">Search</span>
-            <post-icon aria-hidden="true" name="search"></post-icon>
-          </a>
-        </li>
-        <li>
-          <a href="#">
-            <span class="visually-hidden-sm">Login</span>
-            <post-icon aria-hidden="true" name="login"></post-icon>
-          </a>
-        </li>
-      </ul>
+    <!-- Language switch -->
+    <post-language-switch caption="Change the language" description="The currently selected language is English."
+      name="language-switch-example" slot="post-language-switch" variant="menu">
+      <post-language-option code="de" name="Deutsch">DE</post-language-option>
+      <post-language-option code="fr" name="French">FR</post-language-option>
+      <post-language-option code="it" name="Italiano">IT</post-language-option>
+      <post-language-option active code="en" name="English">EN</post-language-option>
+    </post-language-switch>
 
-      <!-- Main navigation -->
-      <post-mainnavigation caption="Hauptnavigation">
-        <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
-        </button>
+    <!-- Application title (optional) -->
+    <h1 slot="title">Application title</h1>
 
-        <post-list title-hidden="">
-          <h2>Main Navigation</h2>
+    <!-- Custom content (optional) -->
+    <ul class="list-inline">
+      <li>
+        <a href="#">
+          <span class="visually-hidden-sm">Search</span>
+          <post-icon aria-hidden="true" name="search"></post-icon>
+        </a>
+      </li>
+      <li>
+        <a href="#">
+          <span class="visually-hidden-sm">Login</span>
+          <post-icon aria-hidden="true" name="login"></post-icon>
+        </a>
+      </li>
+    </ul>
 
-          <!-- Link only level 1 -->
-          <post-list-item slot="post-list-item"><a href="/briefe">Briefe</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/pakete">Pakete</a></post-list-item>
+    <!-- Main navigation -->
+    <post-mainnavigation caption="Hauptnavigation">
+      <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
+        <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+      </button>
 
-          <!-- Level 1 with megadropdown -->
-          <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
-            <post-megadropdown id="briefe">
-              <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
-                Back
-              </button>
-              <post-closebutton slot="close-button">Schliessen</post-closebutton>
-              <h2 slot="megadropdown-title">Briefe title</h2>
-              <post-list>
-                <h3>Briefe senden</h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Briefe Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-              <post-list>
-                <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Pakete Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-            </post-megadropdown>
-          </post-list-item>
-          <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
-            <post-megadropdown id="pakete">
-              <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
-                Back
-              </button>
-              <post-closebutton slot="close-button">Schliessen</post-closebutton>
-              <h2 slot="megadropdown-title">Pakete title</h2>
-              <post-list>
-                <h3>Pakete senden</h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Pakete Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-              <post-list>
-                <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
-                <post-list-item slot="post-list-item"
-                  ><a href="/sch">Pakete Schweiz</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"
-                  ><a href="/kl">Kleinwaren Ausland</a></post-list-item
-                >
-                <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
-                <post-list-item slot="post-list-item"
-                  ><a href="">Express und Kurier</a></post-list-item
-                >
-              </post-list>
-            </post-megadropdown>
-          </post-list-item>
-        </post-list>
-      </post-mainnavigation>
-    </post-header>
+      <post-list title-hidden="">
+        <h2>Main Navigation</h2>
 
-    <h1>Components package playground</h1>
-    <p class="mb-4">
-      Use this playground for quickly developing Stencil web-components. Run
-      <code style="background-color: lightgrey; padding: 0.125rem 0.25rem; border-radius: 0.25rem"
-        >pnpm components:start</code
-      >
-      to get going.
-    </p>
-    <label for="tokens-select">Select tokens package: </label>
-    <select
-      name="tokens"
-      id="tokens-select"
-      value="default"
-      class="mb-4"
-      onchange="if (['default', 'compact'].includes(this.value)) { document.getElementById('tokens').setAttribute('href', `/assets/css/post-tokens-${encodeURIComponent(this.value)}.css`); }"
-    >
-      <option value="default">Post default</option>
-      <option value="compact">Post compact</option>
-    </select>
-    <hr />
-  </body>
+        <!-- Link only level 1 -->
+        <post-list-item slot="post-list-item"><a
+            href="/briefe"><post-mainnavigation-toplevel-item>Briefe</post-mainnavigation-toplevel-item></a></post-list-item>
+        <post-list-item slot="post-list-item"><a
+            href="/pakete"><post-mainnavigation-toplevel-item>Pakete</post-mainnavigation-toplevel-item></a></post-list-item>
+
+        <!-- Level 1 with megadropdown -->
+        <post-list-item slot="post-list-item">
+          <post-megadropdown-trigger
+            for="briefe"><post-mainnavigation-toplevel-item>Briefe</post-mainnavigation-toplevel-item></post-megadropdown-trigger>
+          <post-megadropdown id="briefe">
+            <button slot="back-button" class="btn btn-tertiary btn-sm">
+              <post-icon name="arrowright"></post-icon>
+              Back
+            </button>
+            <post-closebutton slot="close-button">Schliessen</post-closebutton>
+            <h2 slot="megadropdown-title">Briefe title</h2>
+            <post-list>
+              <h3>Briefe senden</h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Briefe Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+            <post-list>
+              <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+          </post-megadropdown>
+        </post-list-item>
+        <post-list-item slot="post-list-item">
+          <post-megadropdown-trigger
+            for="pakete"><post-mainnavigation-toplevel-item>Pakete</post-mainnavigation-toplevel-item></post-megadropdown-trigger>
+          <post-megadropdown id="pakete">
+            <button slot="back-button" class="btn btn-tertiary btn-sm">
+              <post-icon name="arrowright"></post-icon>
+              Back
+            </button>
+            <post-closebutton slot="close-button">Schliessen</post-closebutton>
+            <h2 slot="megadropdown-title">Pakete title</h2>
+            <post-list>
+              <h3>Pakete senden</h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+            <post-list>
+              <h3><a href="/schritt-für-schritt">Schritt für Schritt</a></h3>
+              <post-list-item slot="post-list-item"><a href="/sch">Pakete Schweiz</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="/kl">Kleinwaren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Waren Ausland</a></post-list-item>
+              <post-list-item slot="post-list-item"><a href="">Express und Kurier</a></post-list-item>
+            </post-list>
+          </post-megadropdown>
+        </post-list-item>
+      </post-list>
+    </post-mainnavigation>
+  </post-header>
+
+  <h1>Components package playground</h1>
+  <p class="mb-4">
+    Use this playground for quickly developing Stencil web-components. Run
+    <code
+      style="background-color: lightgrey; padding: 0.125rem 0.25rem; border-radius: 0.25rem">pnpm components:start</code>
+    to get going.
+  </p>
+  <label for="tokens-select">Select tokens package: </label>
+  <select name="tokens" id="tokens-select" value="default" class="mb-4"
+    onchange="if (['default', 'compact'].includes(this.value)) { document.getElementById('tokens').setAttribute('href', `/assets/css/post-tokens-${encodeURIComponent(this.value)}.css`); }">
+    <option value="default">Post default</option>
+    <option value="compact">Post compact</option>
+  </select>
+  <hr />
+</body>
+
 </html>

--- a/packages/documentation/src/stories/components/back-to-top/back-to-top.stories.ts
+++ b/packages/documentation/src/stories/components/back-to-top/back-to-top.stories.ts
@@ -74,12 +74,24 @@ const meta: MetaComponent = {
         <post-list title-hidden="">
           <h2>Main Navigation</h2>
           <!-- Link only level 1 -->
-          <post-list-item slot="post-list-item"><a href="/briefe">Briefe</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/pakete">Pakete</a></post-list-item>
+          <post-list-item slot="post-list-item"
+            ><a href="/briefe"
+              ><post-mainnavigation-toplevel-item>Briefe</post-mainnavigation-toplevel-item></a
+            ></post-list-item
+          >
+          <post-list-item slot="post-list-item"
+            ><a href="/pakete"
+              ><post-mainnavigation-toplevel-item>Pakete</post-mainnavigation-toplevel-item></a
+            ></post-list-item
+          >
 
           <!-- Level 1 with megadropdown -->
           <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
+            <post-megadropdown-trigger for="briefe"
+              ><post-mainnavigation-toplevel-item
+                >Briefe</post-mainnavigation-toplevel-item
+              ></post-megadropdown-trigger
+            >
             <post-megadropdown id="briefe">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
                 <post-icon name="arrowright"></post-icon>
@@ -116,7 +128,11 @@ const meta: MetaComponent = {
             </post-megadropdown>
           </post-list-item>
           <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
+            <post-megadropdown-trigger for="pakete"
+              ><post-mainnavigation-toplevel-item
+                >Pakete</post-mainnavigation-toplevel-item
+              ></post-megadropdown-trigger
+            >
             <post-megadropdown id="pakete">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
                 <post-icon name="arrowright"></post-icon>

--- a/packages/documentation/src/stories/modules/header/header.stories.ts
+++ b/packages/documentation/src/stories/modules/header/header.stories.ts
@@ -136,12 +136,24 @@ export const Default: Story = {
         <post-list title-hidden="">
           <h2>Main Navigation</h2>
           <!-- Link only level 1 -->
-          <post-list-item slot="post-list-item"><a href="/briefe">Briefe</a></post-list-item>
-          <post-list-item slot="post-list-item"><a href="/pakete">Pakete</a></post-list-item>
+          <post-list-item slot="post-list-item">
+            <a href="/briefe"
+              ><post-mainnavigation-toplevel-item>Briefe</post-mainnavigation-toplevel-item></a
+            >
+          </post-list-item>
+          <post-list-item slot="post-list-item">
+            <a href="/pakete"
+              ><post-mainnavigation-toplevel-item>Pakete</post-mainnavigation-toplevel-item></a
+            >
+          </post-list-item>
 
           <!-- Level 1 with megadropdown -->
           <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
+            <post-megadropdown-trigger for="briefe"
+              ><post-mainnavigation-toplevel-item
+                >Briefe</post-mainnavigation-toplevel-item
+              ></post-megadropdown-trigger
+            >
             <post-megadropdown id="briefe">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
                 <post-icon name="arrowright"></post-icon>
@@ -178,7 +190,11 @@ export const Default: Story = {
             </post-megadropdown>
           </post-list-item>
           <post-list-item slot="post-list-item">
-            <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
+            <post-megadropdown-trigger for="pakete"
+              ><post-mainnavigation-toplevel-item
+                >Pakete</post-mainnavigation-toplevel-item
+              ></post-megadropdown-trigger
+            >
             <post-megadropdown id="pakete">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
                 <post-icon name="arrowright"></post-icon>


### PR DESCRIPTION
## 📄 Description

This compoment implements a consistant way to work around the layout shift, when our mainnavgation items switch from `font-weight: regular` to `font-weight: bold`.

**! We need to decide about the compoment name !**

The following things have not been done so far and should be handled in different issues:

- [ ] Create a documentation page (raw components).
- [ ] Add e2e and snapshot tests.

I will set up these tasks as soon as the decision on the name has been made.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
