### PR TITLE
fix(components): error on post-tooltip when show is called on delay

### DIFF
--- a/.changeset/chatty-knives-grab.md
+++ b/.changeset/chatty-knives-grab.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed an error on the `post-tooltip` component that occured when the `show` method was triggered on a delay.

--- a/packages/components/src/components/post-tooltip/post-tooltip.tsx
+++ b/packages/components/src/components/post-tooltip/post-tooltip.tsx
@@ -206,8 +206,9 @@ export class PostTooltip {
   @Method()
   async show(target: HTMLElement, triggeredByFocus = false) {
     const showTooltip = () => {
+      // The method might have been called after a delay and the host might not be defined anymore
       // If focus or pointer event is not on the button anymore, don't show the tooltip
-      if (globalCurrentTarget !== target) return;
+      if (!this.host || globalCurrentTarget !== target) return;
 
       // Determine if the tooltip was opened by a focus event
       this.wasOpenedByFocus = triggeredByFocus;


### PR DESCRIPTION
## 📄 Description

When delay is used on the `<post-tooltip>` component, an error sometimes occur when cursor leaves the trigger to go to the tooltip itself. It calls the `show` method but the host is undefined.