### PR TITLE
fix(styles): add back `text-reset` class

### DIFF
--- a/.changeset/nice-dogs-kick.md
+++ b/.changeset/nice-dogs-kick.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Added back the `.text-reset` class as it was deleted accidentally.

--- a/packages/styles/src/utilities/_variables.scss
+++ b/packages/styles/src/utilities/_variables.scss
@@ -560,6 +560,13 @@ $utilities: (
     class: fs,
     values: utilities_formatted.$font-size,
   ),
+  'color': (
+    property: color,
+    class: text,
+    values: (
+      reset: inherit,
+    ),
+  ),
 );
 
 /* IMPORTANT: When adding new utilities here, please ensure to remove the corresponding bootstrap utilities in `src/themes/bootstrap/_utilities.scss`. */


### PR DESCRIPTION
Added back the `.text-reset` class as it was deleted accidentally.