### PR TITLE
fix(documentation): improve contrast on <pre> code

### DIFF
--- a/.changeset/gentle-pots-kick.md
+++ b/.changeset/gentle-pots-kick.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Changed some of the code colors in `<pre>` tags in the documentation to improve contrast and make it accessible.

--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -116,10 +116,6 @@ $monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier
     .token.doctype {
       color: #888;
     }
-
-    .token.property {
-      color: #cb0000;
-    }
   }
 
   code {

--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -111,6 +111,15 @@ $monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier
 
   pre {
     font-size: 100%;
+
+    .token.comment,
+    .token.doctype {
+      color: #888;
+    }
+
+    .token.property {
+      color: #cb0000;
+    }
   }
 
   code {

--- a/packages/documentation/src/stories/components/avatar/avatar.docs.mdx
+++ b/packages/documentation/src/stories/components/avatar/avatar.docs.mdx
@@ -1,5 +1,6 @@
-import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { Canvas, Controls, Meta, Source } from '@storybook/blocks';
 import * as AvatarPictureStories from './avatar.stories';
+import AvatarSample from './avatar.sample.scss?raw';
 
 <Meta of={AvatarPictureStories} />
 
@@ -42,12 +43,7 @@ The component provides some css-variables, which allow you to switch the backgro
   Please ensure at all times, that the background and foreground colors have sufficient contrast!
 </div>
 
-```scss
-post-avatar {
-  --post-avatar-bg: {your-custom-bg-color};
-  --post-avatar-fg: {your-custom-fg-color};
-}
-```
+<Source code={AvatarSample} language="scss" />
 
 ## Properties
 

--- a/packages/documentation/src/stories/components/avatar/avatar.sample.scss
+++ b/packages/documentation/src/stories/components/avatar/avatar.sample.scss
@@ -1,0 +1,4 @@
+post-avatar {
+  --post-avatar-bg: {your-custom-bg-color};
+  --post-avatar-fg: {your-custom-fg-color};
+}


### PR DESCRIPTION
## 📄 Description

Updated colors of some of the text elements in the `pre` parts of the docs.
Changed the avatar SCSS code preview to use `Source` in order to have a dark background like the rest of the docs.