### PR TITLE
fix(documentation): improve contrast to vertical align preview

### DIFF
--- a/.changeset/chatty-rivers-drum.md
+++ b/.changeset/chatty-rivers-drum.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Changed a text's color in the Vertical align documentation to improve contrast and make it accessible.

--- a/packages/documentation/src/stories/utilities/vertical-align/vertical-align.styles.scss
+++ b/packages/documentation/src/stories/utilities/vertical-align/vertical-align.styles.scss
@@ -8,7 +8,7 @@
     margin: 0;
     height: 100px;
     td:nth-of-type(5) {
-      color: red;
+      color: #c80000;
     }
   }
 
@@ -16,7 +16,7 @@
     padding-inline: 0.5rem;
     &:nth-of-type(7) {
       padding-inline-start: 2rem;
-      color: red;
+      color: #c80000;
     }
   }
 


### PR DESCRIPTION
## 📄 Description

Changed a text's color in the Vertical align documentation to improve contrast and make it accessible.