### PR TITLE
fix(docs): align close button correctly when toast is fixed positioned

### DIFF
--- a/.changeset/lazy-eels-nail.md
+++ b/.changeset/lazy-eels-nail.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed an issue where the close button in the Toast component was not properly aligned when the toast was rendered with `position: fixed`.

--- a/packages/documentation/src/stories/components/toast/toast.stories.ts
+++ b/packages/documentation/src/stories/components/toast/toast.stories.ts
@@ -362,19 +362,20 @@ function render(args: Args, context: StoryContext) {
   const [_, updateArgs] = useArgs();
 
   updateAlignments(args, updateArgs);
-
-  const timeoutStore = timeoutStores[context.name as keyof ITimeoutStores];
-
+  
+  const timeoutStore = timeoutStores[context.name as keyof ITimeoutStores] || timeoutStores['Default'];
+  
+  const isFixed = args.position === 'fixed';
+  
   const classes = [
     'toast',
     args.variant,
     args.noIcon && 'no-icon',
-    args.dismissible && 'toast-dismissible',
+    (args.dismissible || isFixed) && 'toast-dismissible',
   ]
     .filter(c => c && c !== 'null')
     .join(' ');
 
-  const isFixed = args.position === 'fixed';
   const alignV = args.alignVRestricted ?? args.alignV;
   const alignH = args.alignHRestricted ?? args.alignH;
   let role;
@@ -411,11 +412,14 @@ function render(args: Args, context: StoryContext) {
   if (args.stacked) {
     wrappedContent = html` ${component} ${component} `;
   } else if (isFixed) {
+    wrappedContent = html`
+      <div style="${args.show ? '' : 'display: none;'}">
+        ${component}
+      </div>
+    `;
+    
     if (args.show) {
       createAutoHideTimeout(timeoutStore, args, updateArgs);
-      wrappedContent = component;
-    } else {
-      wrappedContent = null;
     }
   } else {
     return component;


### PR DESCRIPTION
## 📄 Description
Fixed an issue where the close button in the Toast component was not properly aligned when the toast was rendered with `position: fixed`.

## 🚀 Demo
**Before:**
![image](https://github.com/user-attachments/assets/eef7be2c-351d-4123-b20d-be8431a134d8)

**After:**
![image](https://github.com/user-attachments/assets/a38d8ad0-ca3d-4be6-a09d-a6f9e0eb16ae)
---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
