### PR TITLE
fix(documentation): remove nav tag around figma links

### DIFF
--- a/.changeset/metal-humans-serve.md
+++ b/.changeset/metal-humans-serve.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Removed all occurences of the `<nav>` tag around the figma links to avoid having two navigations within the same page.

--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -89,7 +89,7 @@ $monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier
 
   // Style buttons related to the current page next to the tile
   .docs-title,
-  .docs-title nav {
+  .docs-title > .buttons-container {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -97,7 +97,8 @@ $monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier
   }
 
   // aligns figma button to the title
-  .docs-title nav {
+  .docs-title > link-design,
+  .docs-title > .buttons-container {
     margin-block-end: tokens.get('h1-margin-block-end', elements.$post-heading);
   }
 

--- a/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
+++ b/packages/documentation/src/stories/components/accordion/accordion.docs.mdx
@@ -8,9 +8,7 @@ import SampleCustomTrigger from './accordion-custom-trigger.sample?raw';
 <div className="docs-title">
   # Accordion
 
-  <nav>
-    <link-design of={JSON.stringify(accordionStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(accordionStories)}></link-design>
 </div>
 
 

--- a/packages/documentation/src/stories/components/app-store-badge/app-store-badge.mdx
+++ b/packages/documentation/src/stories/components/app-store-badge/app-store-badge.mdx
@@ -6,9 +6,7 @@ import * as AppStoreBadgeStories from './app-store-badge.stories';
 <div className="docs-title">
   # App Store Badge
 
-  <nav>
-    <link-design of={JSON.stringify(AppStoreBadgeStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(AppStoreBadgeStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/avatar/avatar.docs.mdx
+++ b/packages/documentation/src/stories/components/avatar/avatar.docs.mdx
@@ -7,9 +7,7 @@ import AvatarSample from './avatar.sample.scss?raw';
 <div className="docs-title">
   # Avatar
 
-  <nav>
-    <link-design of={JSON.stringify(AvatarPictureStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(AvatarPictureStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/back-to-top/back-to-top.docs.mdx
+++ b/packages/documentation/src/stories/components/back-to-top/back-to-top.docs.mdx
@@ -7,9 +7,7 @@ import BackToTop from './back-to-top.sample.html?raw';
 <div className="docs-title">
  # Back To Top
 
-  <nav>
-    <link-design of={JSON.stringify(BackToTopStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(BackToTopStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/badge/badge.docs.mdx
+++ b/packages/documentation/src/stories/components/badge/badge.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Badge
 
-  <nav>
-    <link-design of={JSON.stringify(badgeStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(badgeStories)}></link-design>
 </div>
 
 <div className="lead">Highlight a numerical characteristic or mark an item with a status.</div>

--- a/packages/documentation/src/stories/components/banner/banner.docs.mdx
+++ b/packages/documentation/src/stories/components/banner/banner.docs.mdx
@@ -10,9 +10,7 @@ import BannerDismissSample from './web-component/banner-dismiss.sample?raw';
 <div className="docs-title">
   # Banner
 
-  <nav>
-    <link-design of={JSON.stringify(BannerStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(BannerStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/blockquote/blockquote.docs.mdx
+++ b/packages/documentation/src/stories/components/blockquote/blockquote.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Blockquote
 
-  <nav>
-    <link-design of={JSON.stringify(BlockquoteStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(BlockquoteStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/breadcrumb/breadcrumbs.mdx
+++ b/packages/documentation/src/stories/components/breadcrumb/breadcrumbs.mdx
@@ -3,7 +3,11 @@ import * as BreadcrumbsStories from './breadcrumbs.stories';
 
 <Meta of={BreadcrumbsStories} />
 
-# Post Breadcrumbs
+<div className="docs-title">
+  # Post Breadcrumbs
+
+  <link-design of={JSON.stringify(BreadcrumbsStories)}></link-design>
+</div>
 
 <div className="lead">
     The breadcrumbs is a secondary navigation pattern that helps users understand the hierarchy among levels and navigate back through them.

--- a/packages/documentation/src/stories/components/button-close/button-close.docs.mdx
+++ b/packages/documentation/src/stories/components/button-close/button-close.docs.mdx
@@ -6,9 +6,7 @@ import * as CloseButtonStories from './button-close.stories';
 <div className="docs-title">
   # Button Close
 
-  <nav>
-    <link-design of={JSON.stringify(CloseButtonStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(CloseButtonStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/button-group/button-group.docs.mdx
+++ b/packages/documentation/src/stories/components/button-group/button-group.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Button Group
 
-  <nav>
-    <link-design of={JSON.stringify(ButtonGroupStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ButtonGroupStories)}></link-design>
 </div>
 
 <div className="lead">Group a series of buttons together on a single line.</div>

--- a/packages/documentation/src/stories/components/button/button.docs.mdx
+++ b/packages/documentation/src/stories/components/button/button.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Button
 
-  <nav>
-    <link-design of={JSON.stringify(ButtonStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ButtonStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/card-control/card-control.docs.mdx
+++ b/packages/documentation/src/stories/components/card-control/card-control.docs.mdx
@@ -13,9 +13,7 @@ import SampleCardControlMethods from './web-component/card-control-methods.sampl
 <div className="docs-title">
   # Card-Control
 
-  <nav>
-    <link-design of={JSON.stringify(CardControlStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(CardControlStories)}></link-design>
 </div>
 
 <p className="lead">For a more specialized visualization of checkbox and radio elements.</p>

--- a/packages/documentation/src/stories/components/card-product/card-product.docs.mdx
+++ b/packages/documentation/src/stories/components/card-product/card-product.docs.mdx
@@ -10,9 +10,7 @@ import ProductCardAngularSyncHeights from './card-product.sample.ts?raw';
 <div className="docs-title">
   # Card for Products
 
-  <nav>
-    <link-design of={JSON.stringify(ProductCardStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ProductCardStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/card/card.docs.mdx
+++ b/packages/documentation/src/stories/components/card/card.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Card
 
-  <nav>
-    <link-design of={JSON.stringify(CardStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(CardStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/checkbox/checkbox.docs.mdx
+++ b/packages/documentation/src/stories/components/checkbox/checkbox.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Checkbox
 
-  <nav>
-    <link-design of={JSON.stringify(checkboxStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(checkboxStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/datepicker/datepicker.docs.mdx
+++ b/packages/documentation/src/stories/components/datepicker/datepicker.docs.mdx
@@ -18,7 +18,7 @@ import datepickerValidation from './datepicker-validation.sample.html?raw';
 <div className="docs-title">
   # Datepicker
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <link-design of={JSON.stringify(datepickerStories)}></link-design>
     <NgbComponentDemoLink component="datepicker" />
   </div>

--- a/packages/documentation/src/stories/components/datepicker/datepicker.docs.mdx
+++ b/packages/documentation/src/stories/components/datepicker/datepicker.docs.mdx
@@ -18,10 +18,10 @@ import datepickerValidation from './datepicker-validation.sample.html?raw';
 <div className="docs-title">
   # Datepicker
 
-  <nav>
+  <div className='buttons-container'>
     <link-design of={JSON.stringify(datepickerStories)}></link-design>
     <NgbComponentDemoLink component="datepicker" />
-  </nav>
+  </div>
 </div>
 
 <div className="lead mb-16">

--- a/packages/documentation/src/stories/components/dropdown/dropdown.docs.mdx
+++ b/packages/documentation/src/stories/components/dropdown/dropdown.docs.mdx
@@ -14,10 +14,10 @@ import SampleIcons from './dropdown-icons.sample.html?raw';
 <div className="docs-title">
   # Dropdown
 
-  <nav>
+  <div className='buttons-container'>
     <link-design of={JSON.stringify(DropdownStories)}></link-design>
     <NgbComponentDemoLink component="dropdown" />
-  </nav>
+  </div>
 </div>
 
 <div className="lead mb-16">

--- a/packages/documentation/src/stories/components/dropdown/dropdown.docs.mdx
+++ b/packages/documentation/src/stories/components/dropdown/dropdown.docs.mdx
@@ -14,7 +14,7 @@ import SampleIcons from './dropdown-icons.sample.html?raw';
 <div className="docs-title">
   # Dropdown
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <link-design of={JSON.stringify(DropdownStories)}></link-design>
     <NgbComponentDemoLink component="dropdown" />
   </div>

--- a/packages/documentation/src/stories/components/form-footer/form-footer.docs.mdx
+++ b/packages/documentation/src/stories/components/form-footer/form-footer.docs.mdx
@@ -6,9 +6,7 @@ import * as FormFooterStories from './form-footer.stories';
 <div className="docs-title">
   # Footer
 
-  <nav>
-    <link-design of={JSON.stringify(FormFooterStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(FormFooterStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/forms/hint/hint.docs.mdx
+++ b/packages/documentation/src/stories/components/forms/hint/hint.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Form hint
 
-  <nav>
-    <link-design of={JSON.stringify(HintStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(HintStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/forms/validation/validation.docs.mdx
+++ b/packages/documentation/src/stories/components/forms/validation/validation.docs.mdx
@@ -6,9 +6,7 @@ import * as ValidationStories from './validation.stories';
 <div className="docs-title">
 # Validation
 
-  <nav>
-    <link-design of={JSON.stringify(ValidationStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ValidationStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/input/input.docs.mdx
+++ b/packages/documentation/src/stories/components/input/input.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Input
 
-  <nav>
-    <link-design of={JSON.stringify(InputStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(InputStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/language-switch/language-switch.docs.mdx
+++ b/packages/documentation/src/stories/components/language-switch/language-switch.docs.mdx
@@ -6,9 +6,7 @@ import * as languageSwitchStories from './language-switch.stories';
 <div className="docs-title">
   # Language Switch
 
-  <nav>
-    <link-design of={JSON.stringify(languageSwitchStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(languageSwitchStories)}></link-design>
 </div>
 
 <p className="lead">The language option switch is a web component which enables users to select their preferred

--- a/packages/documentation/src/stories/components/list-group/list-group.docs.mdx
+++ b/packages/documentation/src/stories/components/list-group/list-group.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # List Group
 
-  <nav>
-    <link-design of={JSON.stringify(ListGroup)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ListGroup)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/modal/modal.docs.mdx
+++ b/packages/documentation/src/stories/components/modal/modal.docs.mdx
@@ -13,10 +13,10 @@ import modalBlocking from './modal-blocking.sample?raw';
 <div className="docs-title">
   # Modal
 
-  <nav>
+  <div className='buttons-container'>
     <link-design of={JSON.stringify(modalStories)}></link-design>
     <NgbComponentDemoLink component="modal" />
-  </nav>
+  </div>
 </div>
 
 <p className="lead">Display information that requires the user’s immediate attention.</p>

--- a/packages/documentation/src/stories/components/modal/modal.docs.mdx
+++ b/packages/documentation/src/stories/components/modal/modal.docs.mdx
@@ -13,7 +13,7 @@ import modalBlocking from './modal-blocking.sample?raw';
 <div className="docs-title">
   # Modal
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <link-design of={JSON.stringify(modalStories)}></link-design>
     <NgbComponentDemoLink component="modal" />
   </div>

--- a/packages/documentation/src/stories/components/notification-overlay/notification-overlay.docs.mdx
+++ b/packages/documentation/src/stories/components/notification-overlay/notification-overlay.docs.mdx
@@ -11,10 +11,10 @@ import basicExampleAngular from './notification-overlay.sample.ts?raw';
 <div className="docs-title">
   # Notification overlay
 
-  <nav>
+  <div className='buttons-container'>
     <link-design of={JSON.stringify(notificationOverlayStories)}></link-design>
     <PostComponentDemoLink component="notification-overlay" />
-  </nav>
+  </div>
 </div>
 
 <div className="lead mb-16">

--- a/packages/documentation/src/stories/components/notification-overlay/notification-overlay.docs.mdx
+++ b/packages/documentation/src/stories/components/notification-overlay/notification-overlay.docs.mdx
@@ -11,7 +11,7 @@ import basicExampleAngular from './notification-overlay.sample.ts?raw';
 <div className="docs-title">
   # Notification overlay
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <link-design of={JSON.stringify(notificationOverlayStories)}></link-design>
     <PostComponentDemoLink component="notification-overlay" />
   </div>

--- a/packages/documentation/src/stories/components/pagination/pagination.docs.mdx
+++ b/packages/documentation/src/stories/components/pagination/pagination.docs.mdx
@@ -12,10 +12,10 @@ import paginationDefault from './pagination-default.sample.html?raw';
 <div className="docs-title">
   # Pagination
 
-  <nav>
+  <div className='buttons-container'>
     <link-design of={JSON.stringify(paginationStories)}></link-design>
     <NgbComponentDemoLink component="pagination" />
-  </nav>
+  </div>
 </div>
 
 <p className="lead">A component to display a navigation with page numbers.</p>

--- a/packages/documentation/src/stories/components/pagination/pagination.docs.mdx
+++ b/packages/documentation/src/stories/components/pagination/pagination.docs.mdx
@@ -12,7 +12,7 @@ import paginationDefault from './pagination-default.sample.html?raw';
 <div className="docs-title">
   # Pagination
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <link-design of={JSON.stringify(paginationStories)}></link-design>
     <NgbComponentDemoLink component="pagination" />
   </div>

--- a/packages/documentation/src/stories/components/popover/popover.docs.mdx
+++ b/packages/documentation/src/stories/components/popover/popover.docs.mdx
@@ -6,9 +6,7 @@ import * as PopoverStories from './popover.stories';
 <div className="docs-title">
   # Popover
 
-  <nav>
-    <link-design of={JSON.stringify(PopoverStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(PopoverStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/progressbar/progressbar.docs.mdx
+++ b/packages/documentation/src/stories/components/progressbar/progressbar.docs.mdx
@@ -10,10 +10,10 @@ import progressbarDefault from './progressbar-default.sample.html?raw';
 <div className="docs-title">
   # Progressbar
 
-  <nav>
+  <div className='buttons-container'>
     <link-design of={JSON.stringify(progressbarStories)}></link-design>
     <NgbComponentDemoLink component="progressbar" />
-  </nav>
+  </div>
 </div>
 
 <div className="lead mb-16">

--- a/packages/documentation/src/stories/components/progressbar/progressbar.docs.mdx
+++ b/packages/documentation/src/stories/components/progressbar/progressbar.docs.mdx
@@ -10,7 +10,7 @@ import progressbarDefault from './progressbar-default.sample.html?raw';
 <div className="docs-title">
   # Progressbar
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <link-design of={JSON.stringify(progressbarStories)}></link-design>
     <NgbComponentDemoLink component="progressbar" />
   </div>

--- a/packages/documentation/src/stories/components/radio/radio.docs.mdx
+++ b/packages/documentation/src/stories/components/radio/radio.docs.mdx
@@ -8,9 +8,7 @@ import * as RadioStories from './radio.stories';
 <div className="docs-title">
   # Radio
 
-  <nav>
-    <link-design of={JSON.stringify(RadioStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(RadioStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/rating/post-rating.docs.mdx
+++ b/packages/documentation/src/stories/components/rating/post-rating.docs.mdx
@@ -7,9 +7,7 @@ import SampleEvents from './post-rating.events.sample?raw';
 <div className="docs-title">
   # Rating
 
-  <nav>
-    <link-design of={JSON.stringify(RatingStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(RatingStories)}></link-design>
 </div>
 
 <p className="lead">Our Rating Web Component allows you to easily integrate

--- a/packages/documentation/src/stories/components/search/search.mdx
+++ b/packages/documentation/src/stories/components/search/search.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Search Input
 
-  <nav>
-    <link-design of={JSON.stringify(SearchInputStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(SearchInputStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/segmented-button/segmented-button.docs.mdx
+++ b/packages/documentation/src/stories/components/segmented-button/segmented-button.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Segmented Button
 
-  <nav>
-    <link-design of={JSON.stringify(SegmentedButtonStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(SegmentedButtonStories)}></link-design>
 </div>
 
 The segmented button is a single-select component.

--- a/packages/documentation/src/stories/components/select/select.docs.mdx
+++ b/packages/documentation/src/stories/components/select/select.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Select
 
-  <nav>
-    <link-design of={JSON.stringify(SelectStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(SelectStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/slider/slider.docs.mdx
+++ b/packages/documentation/src/stories/components/slider/slider.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Slider
 
-  <nav>
-    <link-design of={JSON.stringify(SliderStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(SliderStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/spinner/spinner.docs.mdx
+++ b/packages/documentation/src/stories/components/spinner/spinner.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Spinner
 
-  <nav>
-    <link-design of={JSON.stringify(SpinnerStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(SpinnerStories)}></link-design>
 </div>
 
 <p className="lead">Indicate a loading state and prevent interactivity behind it</p>

--- a/packages/documentation/src/stories/components/stepper/stepper.docs.mdx
+++ b/packages/documentation/src/stories/components/stepper/stepper.docs.mdx
@@ -7,9 +7,7 @@ import * as StepperStories from './stepper.stories';
 <div className="docs-title">
   # Stepper
 
-  <nav>
-    <link-design of={JSON.stringify(StepperStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(StepperStories)}></link-design>
 </div>
 
 <div className="lead mb-16">

--- a/packages/documentation/src/stories/components/switch/switch.docs.mdx
+++ b/packages/documentation/src/stories/components/switch/switch.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Switch
 
-  <nav>
-    <link-design of={JSON.stringify(switchStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(switchStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/table/table.docs.mdx
+++ b/packages/documentation/src/stories/components/table/table.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Table
 
-  <nav>
-    <link-design of={JSON.stringify(TableStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(TableStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/tabs/tabs.docs.mdx
+++ b/packages/documentation/src/stories/components/tabs/tabs.docs.mdx
@@ -8,9 +8,7 @@ import SampleCustomTrigger from './tabs-custom-trigger.sample?raw';
 <div className="docs-title">
   # Tabs
 
-  <nav>
-    <link-design of={JSON.stringify(TabStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(TabStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/tag/tag.docs.mdx
+++ b/packages/documentation/src/stories/components/tag/tag.docs.mdx
@@ -8,9 +8,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Tag
 
-  <nav>
-    <link-design of={JSON.stringify(TagStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(TagStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/teaser/teaser.docs.mdx
+++ b/packages/documentation/src/stories/components/teaser/teaser.docs.mdx
@@ -6,9 +6,7 @@ import * as TeaserStories from './teaser.stories';
 <div className="docs-title">
   # Card Teaser
 
-  <nav>
-    <link-design of={JSON.stringify(TeaserStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(TeaserStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/textarea/textarea.docs.mdx
+++ b/packages/documentation/src/stories/components/textarea/textarea.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Textarea
 
-  <nav>
-    <link-design of={JSON.stringify(TextareaStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(TextareaStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/timepicker/timepicker.docs.mdx
+++ b/packages/documentation/src/stories/components/timepicker/timepicker.docs.mdx
@@ -14,9 +14,9 @@ import SampleValidation from './timepicker-validation.sample.html?raw';
 <div className="docs-title">
   # Timepicker
 
-  <nav>
+  <div className='buttons-container'>
     <NgbComponentDemoLink component="timepicker" />
-  </nav>
+  </div>
 </div>
 
 <p className="lead">A component that allows the user to choose a time.</p>

--- a/packages/documentation/src/stories/components/timepicker/timepicker.docs.mdx
+++ b/packages/documentation/src/stories/components/timepicker/timepicker.docs.mdx
@@ -14,7 +14,7 @@ import SampleValidation from './timepicker-validation.sample.html?raw';
 <div className="docs-title">
   # Timepicker
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <NgbComponentDemoLink component="timepicker" />
   </div>
 </div>

--- a/packages/documentation/src/stories/components/toast/toast.docs.mdx
+++ b/packages/documentation/src/stories/components/toast/toast.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Toast
 
-  <nav>
-    <link-design of={JSON.stringify(ToastStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ToastStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/components/tooltip/tooltip.docs.mdx
+++ b/packages/documentation/src/stories/components/tooltip/tooltip.docs.mdx
@@ -6,9 +6,7 @@ import * as TooltipStories from './tooltip.stories';
 <div className="docs-title">
   # Tooltip
 
-  <nav>
-    <link-design of={JSON.stringify(TooltipStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(TooltipStories)}></link-design>
 </div>
 
 <div className="lead">For short, informative messages or explanations.</div>

--- a/packages/documentation/src/stories/components/typeahead/typeahead.docs.mdx
+++ b/packages/documentation/src/stories/components/typeahead/typeahead.docs.mdx
@@ -11,10 +11,10 @@ import typeaheadSampleBasicAngular from './typeahead-basic.sample.ts?raw';
 <div className="docs-title">
   # Typeahead
 
-  <nav>
+  <div className='buttons-container'>
     <link-design of={JSON.stringify(typeaheadStories)}></link-design>
     <NgbComponentDemoLink component="typeahead" />
-  </nav>
+  </div>
 </div>
 
 <div className="lead mb-16">

--- a/packages/documentation/src/stories/components/typeahead/typeahead.docs.mdx
+++ b/packages/documentation/src/stories/components/typeahead/typeahead.docs.mdx
@@ -11,7 +11,7 @@ import typeaheadSampleBasicAngular from './typeahead-basic.sample.ts?raw';
 <div className="docs-title">
   # Typeahead
 
-  <div className='buttons-container'>
+  <div className="buttons-container">
     <link-design of={JSON.stringify(typeaheadStories)}></link-design>
     <NgbComponentDemoLink component="typeahead" />
   </div>

--- a/packages/documentation/src/stories/foundations/icons/icon.docs.mdx
+++ b/packages/documentation/src/stories/foundations/icons/icon.docs.mdx
@@ -9,9 +9,7 @@ import './icon.styles.scss';
 <div className="docs-title">
   # Icons
 
-  <nav>
-    <link-design of={JSON.stringify(IconStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(IconStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/foundations/layout/sections/sections.docs.mdx
+++ b/packages/documentation/src/stories/foundations/layout/sections/sections.docs.mdx
@@ -6,9 +6,7 @@ import * as SectionStories from './sections.stories';
 <div className="docs-title">
   # Sections
 
-  <nav>
-    <link-design of={JSON.stringify(SectionStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(SectionStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/foundations/logo/logo.docs.mdx
+++ b/packages/documentation/src/stories/foundations/logo/logo.docs.mdx
@@ -6,9 +6,7 @@ import * as logoStories from './logo.stories';
 <div className="docs-title">
  # Post Logo
 
-  <nav>
-    <link-design of={JSON.stringify(logoStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(logoStories)}></link-design>
 </div>
 
 <p className="lead">Display the Post logo as a clickable link or as a simple image.</p>

--- a/packages/documentation/src/stories/foundations/typography/heading/heading.docs.mdx
+++ b/packages/documentation/src/stories/foundations/typography/heading/heading.docs.mdx
@@ -7,9 +7,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Heading
 
-  <nav>
-    <link-design of={JSON.stringify(HeadingStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(HeadingStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/foundations/typography/highlighted-text/highlighted-text.docs.mdx
+++ b/packages/documentation/src/stories/foundations/typography/highlighted-text/highlighted-text.docs.mdx
@@ -6,9 +6,8 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 
 <div className="docs-title">
   # Highlighted Text
-  <nav>
-    <link-design of={JSON.stringify(HighlightedTextStories)}></link-design>
-  </nav>
+
+  <link-design of={JSON.stringify(HighlightedTextStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/foundations/typography/lead/lead.docs.mdx
+++ b/packages/documentation/src/stories/foundations/typography/lead/lead.docs.mdx
@@ -6,9 +6,8 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 
 <div className="docs-title">
   # Lead
-  <nav>
-    <link-design of={JSON.stringify(LeadStories)}></link-design>
-  </nav>
+
+  <link-design of={JSON.stringify(LeadStories)}></link-design>
 </div>
 
 <div>

--- a/packages/documentation/src/stories/foundations/typography/legend/legend.docs.mdx
+++ b/packages/documentation/src/stories/foundations/typography/legend/legend.docs.mdx
@@ -5,9 +5,8 @@ import * as LegendStories from './legend.stories';
 
 <div className="docs-title">
   # Legend
-  <nav>
-    <link-design of={JSON.stringify(LegendStories)}></link-design>
-  </nav>
+
+  <link-design of={JSON.stringify(LegendStories)}></link-design>
 </div>
 
 A legend is in general the title of a group of related (interactive) elements in a form. Not to be confused with caption.

--- a/packages/documentation/src/stories/foundations/typography/link/link.docs.mdx
+++ b/packages/documentation/src/stories/foundations/typography/link/link.docs.mdx
@@ -6,10 +6,9 @@ import * as LinkStories from './link.stories';
 <div className="docs-title">
   # Link
 
-  <nav>
-    <link-design of={JSON.stringify(LinkStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(LinkStories)}></link-design>
 </div>
+
 <div className="lead">
   Use links to navigate users to another location, such as a different site, resource, or section within the same page.
 </div>

--- a/packages/documentation/src/stories/foundations/typography/paragraph/paragraph.docs.mdx
+++ b/packages/documentation/src/stories/foundations/typography/paragraph/paragraph.docs.mdx
@@ -6,9 +6,7 @@ import * as ParagraphStories from './paragraph.stories';
 <div className="docs-title">
   # Paragraph
 
-  <nav>
-    <link-design of={JSON.stringify(ParagraphStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ParagraphStories)}></link-design>
 </div>
 
 Default paragraph without size variants.

--- a/packages/documentation/src/stories/modules/header/header.docs.mdx
+++ b/packages/documentation/src/stories/modules/header/header.docs.mdx
@@ -8,9 +8,7 @@ import StylesPackageImport from '@/shared/styles-package-import.mdx';
 <div className="docs-title">
   # Header
 
-  <nav>
-    <link-design of={JSON.stringify(HeaderStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(HeaderStories)}></link-design>
 </div>
 
 <div className="lead">The header of the Post.</div>

--- a/packages/documentation/src/stories/raw-components/breadcrumbs/breadcrumbs.docs.mdx
+++ b/packages/documentation/src/stories/raw-components/breadcrumbs/breadcrumbs.docs.mdx
@@ -6,9 +6,7 @@ import * as BreadcrumbsStories from './breadcrumbs.stories';
 <div className="docs-title">
   # Breadcrumbs
 
-  <nav>
-    <link-design of={JSON.stringify(BreadcrumbsStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(BreadcrumbsStories)}></link-design>
 </div>
 
 <div className="lead">Indicate the current page’s location within the navigational hierarchy.</div>

--- a/packages/documentation/src/stories/raw-components/footer/footer.docs.mdx
+++ b/packages/documentation/src/stories/raw-components/footer/footer.docs.mdx
@@ -6,9 +6,7 @@ import * as FooterStories from './footer.stories';
 <div className="docs-title">
   # Footer
 
-  <nav>
-    <link-design of={JSON.stringify(FooterStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(FooterStories)}></link-design>
 </div>
 
 <div className="lead">

--- a/packages/documentation/src/stories/raw-components/internet-header/header.docs.mdx
+++ b/packages/documentation/src/stories/raw-components/internet-header/header.docs.mdx
@@ -7,9 +7,7 @@ import './header.scss';
 <div className="docs-title">
   # Internet Header
 
-  <nav>
-    <link-design of={JSON.stringify(HeaderStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(HeaderStories)}></link-design>
 </div>
 
 <p className="lead">For external, client facing applications.</p>

--- a/packages/documentation/src/stories/raw-components/language-option/language-option.docs.mdx
+++ b/packages/documentation/src/stories/raw-components/language-option/language-option.docs.mdx
@@ -6,9 +6,7 @@ import * as languageOptionStories from './language-option.stories';
 <div className="docs-title">
   # Language Option
 
-  <nav>
-    <link-design of={JSON.stringify(languageOptionStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(languageOptionStories)}></link-design>
 </div>
 
 <p className="lead">Enable users to select their preferred language.</p>

--- a/packages/documentation/src/stories/raw-components/list/list.docs.mdx
+++ b/packages/documentation/src/stories/raw-components/list/list.docs.mdx
@@ -6,9 +6,7 @@ import * as ListStories from './list.stories';
 <div className="docs-title">
   # List
 
-  <nav>
-    <link-design of={JSON.stringify(ListStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(ListStories)}></link-design>
 </div>
 
 The `<post-list>` is a container for `<post-list-item>` components.

--- a/packages/documentation/src/stories/raw-components/megadropdown/megadropdown.docs.mdx
+++ b/packages/documentation/src/stories/raw-components/megadropdown/megadropdown.docs.mdx
@@ -6,9 +6,7 @@ import * as megadropdownStories from './megadropdown.stories';
 <div className="docs-title">
   # Mega dropdown
 
-  <nav>
-    <link-design of={JSON.stringify(megadropdownStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(megadropdownStories)}></link-design>
 </div>
 
 <p className="lead">

--- a/packages/documentation/src/stories/raw-components/menu-button/menu-button.docs.mdx
+++ b/packages/documentation/src/stories/raw-components/menu-button/menu-button.docs.mdx
@@ -6,9 +6,7 @@ import * as MenuButtonStories from './menu-button.stories';
 <div className="docs-title">
   # Menu Button
 
-  <nav>
-    <link-design of={JSON.stringify(MenuButtonStories)}></link-design>
-  </nav>
+  <link-design of={JSON.stringify(MenuButtonStories)}></link-design>
 </div>
 
 <div className="lead">


### PR DESCRIPTION
## 📄 Description

Removed all occurences of the `<nav>` tag around the figma links to avoid having two navigations within the same page.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
