### PR TITLE
chore(docs): add missing Figma link to Composable Footer documentation

### DIFF
--- a/.changeset/two-planets-fix.md
+++ b/.changeset/two-planets-fix.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added the missing Figma design link to the Composable Footer documentation page in Storybook.

--- a/packages/documentation/src/stories/modules/footer/footer.docs.mdx
+++ b/packages/documentation/src/stories/modules/footer/footer.docs.mdx
@@ -4,12 +4,12 @@ import * as FooterStories from './footer.stories';
 <Meta of={FooterStories}/>
 
 <div className="docs-title">
-  # Composible Footer
+  # Composable Footer
 
   <link-design of={JSON.stringify(FooterStories)}></link-design>
 </div>
 
-<p className="lead">The composible footer component for your Swiss Post page.</p>
+<p className="lead">The composable footer component for your Swiss Post page.</p>
 
 Internally the `<post-footer>` component has a fix structure, but it offers a number of slots, which can be used to add your very own content, so it ultimatly fulfills everyones requirements.
 

--- a/packages/documentation/src/stories/modules/footer/footer.docs.mdx
+++ b/packages/documentation/src/stories/modules/footer/footer.docs.mdx
@@ -3,7 +3,11 @@ import * as FooterStories from './footer.stories';
 
 <Meta of={FooterStories}/>
 
-# Composible Footer
+<div className="docs-title">
+  # Composible Footer
+
+  <link-design of={JSON.stringify(FooterStories)}></link-design>
+</div>
 
 <p className="lead">The composible footer component for your Swiss Post page.</p>
 


### PR DESCRIPTION
## 📄 Description

This PR adds the missing Figma design link to the Composable Footer documentation page in Storybook.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
