### PR TITLE
chore(docs): move focus to icon details popover to ensure accessible keyboard navigation

### DIFF
--- a/.changeset/heavy-spiders-join.md
+++ b/.changeset/heavy-spiders-join.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Trap keyboard focus within the icon details popover on the find icon page to ensure accessible and consistent keyboard navigation.

--- a/packages/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
+++ b/packages/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
@@ -140,6 +140,53 @@ export class Search extends React.Component {
     document.body.style.overflow = '';
   }
 
+  private trapFocusInElement(container: HTMLElement) {
+    const focusableSelectors = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ];
+    const focusables = Array.from(
+      container.querySelectorAll(focusableSelectors.join(',')),
+    ) as HTMLElement[];
+
+    if (focusables.length === 0) return () => {};
+
+    // Focus the first focusable element
+    focusables[0].focus();
+
+    function trapFocus(e: KeyboardEvent) {
+      if (e.key !== 'Tab' || focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+
+      if (e.shiftKey) {
+        // Shift+Tab
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        // Tab
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    container.addEventListener('keydown', trapFocus);
+
+    // Return a cleanup function
+    return () => {
+      container.removeEventListener('keydown', trapFocus);
+    };
+  }
+
   openIconDetails(icon: Icon) {
     const popover = document.querySelector('#icon-panel') as HTMLPostPopovercontainerElement;
     popover?.removeEventListener('postToggle', this.popoverEventListener);
@@ -148,6 +195,17 @@ export class Search extends React.Component {
     this.setState(this.activeIcon);
     popover.showPopover();
     popover?.addEventListener('postToggle', this.popoverEventListener);
+    setTimeout(() => {
+      // Trap focus inside the popover
+      const cleanupFocusTrap = this.trapFocusInElement(popover);
+
+      // Clean up the focus trap when the popover closes
+      const cleanup = () => {
+        cleanupFocusTrap?.();
+        popover.removeEventListener('postToggle', cleanup);
+      };
+      popover.addEventListener('postToggle', cleanup);
+    }, 0);
   }
 
   iconDetailPanel() {
@@ -169,7 +227,9 @@ export class Search extends React.Component {
               <dd>{this.activeIcon?.name}</dd>
               <dt>Download</dt>
               <dd>
-                <a href={`/post-icons/${this.activeIcon?.name}.svg`} download>{this.activeIcon?.name}.svg</a>
+                <a href={`/post-icons/${this.activeIcon?.name}.svg`} download>
+                  {this.activeIcon?.name}.svg
+                </a>
               </dd>
               <dt>Keywords</dt>
               <dd>{this.activeIcon?.keywords}</dd>


### PR DESCRIPTION
…keyboard navigation

## 📄 Description
When opening the icon details, the focus now moves to the first focusable element within the popover. Currently this is the download anchor element. When pressing tab again it moves to the next focusable element which is the close button. After that it moves back to the first essentially trapping the focus inside the popover until it is closed and the focus is returned back to the element which opened the details.

## 🚀 Demo

Uploading FindIconFocusBehaviour.mp4…

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
