### PR TITLE
fix(docs): fix broken links to v5 documentation throughout the codebase/v8

### DIFF
--- a/.changeset/two-pigs-tap.md
+++ b/.changeset/two-pigs-tap.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Resolved broken links to v5 documentation.

--- a/packages/documentation/public/_redirects
+++ b/packages/documentation/public/_redirects
@@ -1,6 +1,6 @@
 # Redirects from what the browser requests to what we serve
 # This file is used by Netlify to handle redirects
 
-/v5   https://6401b58ebf0f4e298ee2dbe7--swisspost-web-frontend.netlify.app
+/v5   https://swiss-post-design-system-v5.netlify.app
 /v6   https://design-system-version-6.netlify.app
 /v7   https://design-system-version-7.netlify.app

--- a/packages/documentation/public/assets/versions.json
+++ b/packages/documentation/public/assets/versions.json
@@ -65,7 +65,7 @@
     "title": "Version 5",
     "version": "5.4.1",
     "description": "Pattern documentation, code snippets and implementation guidelines for the Design System Styles.",
-    "url": "https://6401b58ebf0f4e298ee2dbe7--swisspost-web-frontend.netlify.app/",
+    "url": "https://swiss-post-design-system-v5.netlify.app",
     "dependencies": {
       "@angular/core": "14.2.12",
       "@ng-bootstrap/ng-bootstrap": "12.1.2",


### PR DESCRIPTION
## 📄 Description

This PR updates all v5 documentation links:
- Changed from: `https://6401b58ebf0f4e298ee2dbe7--swisspost-web-frontend.netlify.app` 
- Changed to: `https://swiss-post-design-system-v5.netlify.app`

Reference to the ticket: https://github.com/orgs/swisspost/projects/3/views/11?pane=issue&itemId=107557929&issue=swisspost%7Cdesign-system%7C5334

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
