### PR TITLE
chore: prevent release workflow from creating release branches for the next version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,7 +121,7 @@ jobs:
               .reduce((packages, pkg) => ({ ...packages, [pkg.name]: updatedVersions[pkg.name] ?? pkg.version }), { ...(styles.peerDependencies ?? {}) })
 
             return {
-              isMajor: release.type === 'major',
+              isMajor: release.type === 'major' && newMajor !== oldMajor,
               old: {
                 version: release.oldVersion,
                 major: oldMajor,


### PR DESCRIPTION
## 📄 Description

Currently, whenever a major change is merged into the `main` branch, a new release branch is created.
However, `main` is only used for pre-releases, so it should not create release branches.
Changeset is correctly handing this, marking the change as major but not increasing the major version number.
We just need to check this number to know if we are releasing or pre-releasing.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
