### PR TITLE
chore(styles): remove unused placeholder + cleanup

### DIFF
--- a/.changeset/loose-jeans-hug.md
+++ b/.changeset/loose-jeans-hug.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': minor
+---
+
+Removed the unused placeholder `%btn-transparent-background`.

--- a/packages/documentation/src/stories/misc/migration-guide/migrationv8-9.component.ts
+++ b/packages/documentation/src/stories/misc/migration-guide/migrationv8-9.component.ts
@@ -575,6 +575,12 @@ export class MigrationV89Component extends LitElement {
                 </li>
                 <li class="mb-16">
                   <p>
+                    The <code>%btn-transparent-background</code> CSS placeholder has been removed.
+                    <span class="tag tag-sm tag-danger">breaking</span>
+                  </p>
+                </li>
+                <li class="mb-16">
+                  <p>
                     The <code>.pi-*</code> classes have been removed
                     <span class="tag tag-sm tag-danger">breaking</span>
                   </p>

--- a/packages/styles/src/placeholders/_button.scss
+++ b/packages/styles/src/placeholders/_button.scss
@@ -1,23 +1,10 @@
 @use './../mixins/utilities';
-@use './../mixins/color' as color-mx;
-@use './../variables/color';
 @use './../variables/components/button';
 @use './../mixins/button' as button-mx;
 @use '../functions/tokens';
 @use '../tokens/components';
 
 tokens.$default-map: components.$post-button;
-
-%btn-transparent-background {
-  @include utilities.not-disabled-focus-hover() {
-    color: color.$black;
-  }
-
-  // Invert icon on dark backgrounds
-  @include color-mx.on-dark-background() {
-    color: color.$black;
-  }
-}
 
 %btn {
   // Resets

--- a/packages/styles/src/placeholders/_close.scss
+++ b/packages/styles/src/placeholders/_close.scss
@@ -1,34 +1,30 @@
-@use './../mixins/button' as button-mx;
-@use './../mixins/color' as color-mx;
-@use './../mixins/forms' as forms-mx;
-@use './../mixins/icons' as icons-mx;
-@use './../mixins/utilities' as utilities-mx;
+@use './../mixins/button';
+@use './../mixins/icons';
+@use './../mixins/utilities';
 
-@use './../variables/animation';
-@use './../variables/color';
 @use './../variables/commons';
 @use './../variables/components/close';
 
 %btn-close {
-  @include button-mx.reset-button;
+  @include button.reset-button;
   border-radius: close.$close-border-radius;
   color: close.$close-color;
   transition: close.$close-transition;
   cursor: pointer;
 
-  @include utilities-mx.focus-style {
+  @include utilities.focus-style {
     border-radius: commons.$border-radius;
   }
 
   &::before {
-    @include icons-mx.icon(2043);
+    @include icons.icon(2043);
     content: '';
     display: block;
     height: close.$close-size;
     width: close.$close-size;
   }
 
-  @include utilities-mx.not-disabled-focus-hover() {
+  @include utilities.not-disabled-focus-hover() {
     color: close.$close-hover-color;
   }
 
@@ -36,11 +32,11 @@
     color: close.$close-disabled-color;
   }
 
-  @include utilities-mx.high-contrast-mode() {
+  @include utilities.high-contrast-mode() {
     color: CanvasText;
     forced-color-adjust: none;
 
-    @include utilities-mx.not-disabled-focus-hover() {
+    @include utilities.not-disabled-focus-hover() {
       color: Highlight;
     }
   }


### PR DESCRIPTION
## 📄 Description

I noticed the `%btn-transparent-background` was never used so I removed it and cleaned up the other placeholder files to remove unnecessary imports.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
