### PR TITLE
chore: modify icon workflow to not use serial comma

### DIFF
--- a/.github/workflows/scripts/icons.mjs
+++ b/.github/workflows/scripts/icons.mjs
@@ -118,7 +118,7 @@ function processUiIconFiles(parsedFilePaths) {
  */
 function formatPostIcons(iconFiles) {
   const iconNames = iconFiles.map(({ name }) => `\`${name}\``);
-  return formatList(iconNames, ', ', ', and ');
+  return formatList(iconNames, ', ', ' and ');
 }
 
 /**
@@ -133,7 +133,7 @@ function formatUiIcons(iconFiles) {
   return Array.from(icons.entries())
     .map(([icon, { sizes, variants }]) => {
       const allVariants = formatList(variants, ' & ');
-      const allSizes = formatList(sizes, ', ', ', and ');
+      const allSizes = formatList(sizes, ', ', ' and ');
       return `- \`${icon}\` (${allVariants}): ${allSizes}px`;
     })
     .join('\n');


### PR DESCRIPTION
## 📄 Description

The serial comma was not correct when 2 icons were changed.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
