### PR TITLE
chore(monorepo): updated turbo to run on bootstrap as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "styles": "pnpm styles:start",
     "styles:play": "pnpm --filter design-system-styles play",
     "styles:start": "pnpm --filter design-system-styles start",
-    "styles:build": "pnpm turbo run build --filter=@swisspost/design-system-styles",
+    "styles:build": "pnpm --filter design-system-styles build",
     "styles:unit": "pnpm --filter design-system-styles unit",
     "styles:lint": "pnpm --filter design-system-styles lint",
     "styles:lint:fix": "pnpm --filter design-system-styles lint:fix",

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -21,8 +21,9 @@
   "scripts": {
     "play": "vite --open",
     "start": "gulp watch",
-    "build": "pnpm clean && gulp build",
-    "clean": "rimraf out-tsc dist src/tokens/temp",
+    "build": "pnpm turbo run build:force",
+    "build:force": "pnpm clean && gulp build",
+    "clean": "rimraf dist src/tokens/temp",
     "unit": "gulp sass:tests",
     "lint": "stylelint src/**/*.scss !src/tokens/temp/**",
     "lint:fix": "stylelint src/**/*.scss !src/tokens/temp/** --fix",

--- a/packages/styles/turbo.json
+++ b/packages/styles/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build:force": {
+      "outputs": ["dist/**", "src/tokens/temp/**"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,3 @@
 {
-  "tasks": {
-    "build": {
-      "dependsOn": ["^build"]
-    },
-    "styles#build": {
-      "outputs": ["out-tsc/**", "dist/**", "src/tokens/temp/**"]
-    }
-  }
+  "tasks": {}
 }


### PR DESCRIPTION
## 📄 Description

This enables turbo to run on other commands like `pnpm bootstrap` as well because it's working at the local package level and not the global. Before, only running `pnpm styles:build` specifically triggered a turbo enhanced build.
