### PR TITLE
fix(styles): fix background on disabled textarea labels to maintain readability when content overflows

### DIFF
--- a/.changeset/shaggy-women-drive.md
+++ b/.changeset/shaggy-women-drive.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed background on disabled textarea labels to maintain readability when content overflows.

--- a/packages/documentation/src/stories/components/textarea/textarea.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/textarea/textarea.snapshot.stories.ts
@@ -2,7 +2,6 @@ import type { Args, StoryContext, StoryObj } from '@storybook/web-components';
 import meta from './textarea.stories';
 import { html } from 'lit';
 import { COMBINATIONS, getCombinations } from '@/utils/inputComponentsGetCombinations';
-import { schemes } from '@/shared/snapshots/schemes';
 
 const { id, ...metaWithoutId } = meta;
 
@@ -10,6 +9,8 @@ export default {
   ...metaWithoutId,
   title: 'Snapshots',
 };
+
+const SCHEME = ['light', 'dark'];
 
 type Story = StoryObj;
 
@@ -36,19 +37,43 @@ export const Textarea: Story = {
       },
     ];
 
-    return schemes(
-      () => html`
-        <h3>Floating Label</h3>
-        ${getCombinations('floatingLabel', [true], combinations).map((args: Args) => {
-          context.id = crypto.randomUUID();
-          return html` <div>${meta.render?.({ ...context.args, ...args }, context)}</div> `;
-        })}
-        <h3>Standard</h3>
-        ${getCombinations('floatingLabel', [false], combinations).map((args: Args) => {
-          context.id = crypto.randomUUID();
-          return html` <div>${meta.render?.({ ...context.args, ...args }, context)}</div> `;
-        })}
-      `,
-    );
+    // Special combinations for disabled overflow text with floating label
+    const disabledOverflowTextCombinations = [
+      {
+        label: `Floating Label - Disabled with overflow text`,
+        floatingLabel: true,
+        disabled: true,
+        textInside:
+          'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.',
+        rows: 3,
+      }
+    ];
+
+    return html`
+      ${SCHEME.map(
+        scheme => html`
+          <div data-color-scheme="${scheme}" class="palette-default px-48">
+            <h3>Standard Combinations - ${scheme} Theme</h3>
+            <h4>Floating Label</h4>
+            ${getCombinations('floatingLabel', [true], combinations).map((args: Args) => {
+              context.id = crypto.randomUUID();
+              return html` <div class="mb-4">${meta.render?.({ ...context.args, ...args }, context)}</div> `;
+            })}
+            
+            <h4>Standard Label</h4>
+            ${getCombinations('floatingLabel', [false], combinations).map((args: Args) => {
+              context.id = crypto.randomUUID();
+              return html` <div class="mb-4">${meta.render?.({ ...context.args, ...args }, context)}</div> `;
+            })}
+            
+            <h3>Disabled with Overflow Text - ${scheme} Theme</h3>
+            ${disabledOverflowTextCombinations.map((args: Args) => {
+              context.id = crypto.randomUUID();
+              return html` <div class="mb-4">${meta.render?.({ ...context.args, ...args }, context)}</div> `;
+            })}
+          </div>
+        `
+      )}
+    `;
   },
 };

--- a/packages/styles/src/components/form-textarea.scss
+++ b/packages/styles/src/components/form-textarea.scss
@@ -149,7 +149,7 @@ textarea.form-control {
 
     &:disabled ~ label {
       color: tokens.get('textarea-disabled-fg');
-      background-color: tokens.get('textarea-disabled-bg');
+      background-color: var(--post-current-palette-bg);
     }
 
     &:not(:disabled):hover ~ label {


### PR DESCRIPTION
## 📄 Description
Fixed disabled textarea labels to inherit parent background color using `--post-current-palette-bg` variable.

## 🚀 Demo

Before:
![image](https://github.com/user-attachments/assets/ed2306ac-4005-43eb-af7a-1f82717aca97)

After:
![image](https://github.com/user-attachments/assets/8fbf5fbc-8d07-4404-93c7-4a22c8fb6d84)

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
