### PR TITLE
chore: move main (next) to v10

### DIFF
--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -31,8 +31,8 @@
     "@angular/platform-browser": "19.2.0",
     "@angular/platform-browser-dynamic": "19.2.0",
     "@angular/router": "19.2.0",
-    "@swisspost/design-system-components": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-styles": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-components": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-styles": "workspace:10.0.0-next.36",
     "rxjs": "7.8.1",
     "tslib": "2.8.1",
     "zone.js": "0.15.0"

--- a/packages/components-angular/projects/components/package.json
+++ b/packages/components-angular/projects/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swisspost/design-system-components-angular",
-  "version": "9.0.0-next.36",
+  "version": "10.0.0-next.36",
   "description": "Swiss Post Design System - Angular Wrapper Components",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     "linkDirectory": true
   },
   "dependencies": {
-    "@swisspost/design-system-components": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-components": "workspace:10.0.0-next.36",
     "tslib": "2.8.1"
   },
   "peerDependencies": {

--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swisspost/design-system-components-react",
-  "version": "9.0.0-next.36",
+  "version": "10.0.0-next.36",
   "description": "Design System React Components for easy integration with the React ecosystem",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "lint:fix": "eslint --fix"
   },
   "dependencies": {
-    "@swisspost/design-system-components": "workspace:9.0.0-next.36"
+    "@swisspost/design-system-components": "workspace:10.0.0-next.36"
   },
   "devDependencies": {
     "@eslint/js": "9.18.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swisspost/design-system-components",
-  "version": "9.0.0-next.36",
+  "version": "10.0.0-next.36",
   "description": "A collection of web components built with Stencil JS for the Swiss Post Design System.",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",
@@ -45,8 +45,8 @@
   "dependencies": {
     "@floating-ui/dom": "1.7.0",
     "@oddbird/popover-polyfill": "0.5.2",
-    "@swisspost/design-system-icons": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-styles": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-icons": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-styles": "workspace:10.0.0-next.36",
     "ally.js": "1.4.1",
     "long-press-event": "2.5.0",
     "nanoid": "5.1.5"

--- a/packages/documentation/package.json
+++ b/packages/documentation/package.json
@@ -29,11 +29,11 @@
     "doctor": "storybook doctor"
   },
   "dependencies": {
-    "@swisspost/design-system-components": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-components-react": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-icons": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-styles": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-tokens": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-components": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-components-react": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-icons": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-styles": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-tokens": "workspace:10.0.0-next.36",
     "@swisspost/internet-header": "workspace:2.0.0-next.36",
     "bootstrap": "5.3.3"
   },
@@ -56,7 +56,7 @@
     "@storybook/types": "8.4.7",
     "@storybook/web-components": "8.4.7",
     "@storybook/web-components-vite": "8.4.7",
-    "@swisspost/design-system-components-angular": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-components-angular": "workspace:10.0.0-next.36",
     "@types/css-modules": "1.0.5",
     "@types/mdx": "2.0.13",
     "@types/react": "18.3.3",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swisspost/design-system-icons",
-  "version": "9.0.0-next.36",
+  "version": "10.0.0-next.36",
   "description": "A collection of Swiss Post icons intended for use with the Design System.",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",

--- a/packages/internet-header/package.json
+++ b/packages/internet-header/package.json
@@ -42,7 +42,7 @@
     "generate": "stencil generate"
   },
   "dependencies": {
-    "@swisspost/design-system-styles": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-styles": "workspace:10.0.0-next.36",
     "body-scroll-lock": "4.0.0-beta.0",
     "iframe-resizer": "4.4.5",
     "jquery": "3.7.1",

--- a/packages/nextjs-integration/package.json
+++ b/packages/nextjs-integration/package.json
@@ -23,8 +23,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@swisspost/design-system-components-react": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-styles": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-components-react": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-styles": "workspace:10.0.0-next.36",
     "@swisspost/internet-header": "workspace:2.0.0-next.36",
     "next": "15.2.4",
     "react": "18.3.1",

--- a/packages/styles-primeng-workspace/package.json
+++ b/packages/styles-primeng-workspace/package.json
@@ -31,7 +31,7 @@
     "@angular/platform-browser-dynamic": "19.2.0",
     "@angular/router": "19.2.0",
     "@primeng/themes": "19.0.9",
-    "@swisspost/design-system-styles": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-styles": "workspace:10.0.0-next.36",
     "primeng": "19.0.9",
     "rxjs": "7.8.1",
     "tslib": "2.8.1",

--- a/packages/styles-primeng-workspace/projects/styles-primeng/package.json
+++ b/packages/styles-primeng-workspace/projects/styles-primeng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swisspost/design-system-styles-primeng",
-  "version": "9.0.0-next.36",
+  "version": "10.0.0-next.36",
   "description": "Swiss Post styles for PrimeNg datatable.",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
     "primeng": "^19.0.0"
   },
   "dependencies": {
-    "@swisspost/design-system-styles": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-styles": "workspace:10.0.0-next.36",
     "tslib": "2.8.1"
   },
   "sideEffects": false,

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swisspost/design-system-styles",
-  "version": "9.0.0-next.36",
+  "version": "10.0.0-next.36",
   "description": "Design System Styles for the Swiss Post web platform.",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",
@@ -50,8 +50,8 @@
     "gulp-sourcemaps": "3.0.0"
   },
   "devDependencies": {
-    "@swisspost/design-system-icons": "workspace:9.0.0-next.36",
-    "@swisspost/design-system-tokens": "workspace:9.0.0-next.36",
+    "@swisspost/design-system-icons": "workspace:10.0.0-next.36",
+    "@swisspost/design-system-tokens": "workspace:10.0.0-next.36",
     "@types/node": "22.10.5",
     "autoprefixer": "10.4.20",
     "copyfiles": "2.4.1",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swisspost/design-system-tokens",
-  "version": "9.0.0-next.36",
+  "version": "10.0.0-next.36",
   "description": "Design Tokens for the Swiss Post Design System.",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    optionalDependencies:
+      '@web-types/lit':
+        specifier: 2.0.0-3
+        version: 2.0.0-3
     devDependencies:
       '@changesets/cli':
         specifier: 2.29.2
@@ -17,10 +21,6 @@ importers:
       turbo:
         specifier: 2.5.0
         version: 2.5.0
-    optionalDependencies:
-      '@web-types/lit':
-        specifier: 2.0.0-3
-        version: 2.0.0-3
 
   packages/changelog-github:
     dependencies:
@@ -65,10 +65,10 @@ importers:
         specifier: 0.5.2
         version: 0.5.2
       '@swisspost/design-system-icons':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../icons
       '@swisspost/design-system-styles':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../styles/dist
       ally.js:
         specifier: 1.4.1
@@ -189,10 +189,10 @@ importers:
         specifier: 19.2.0
         version: 19.2.0(@angular/common@19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.0(@angular/animations@19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
       '@swisspost/design-system-components':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../components
       '@swisspost/design-system-styles':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../styles/dist
       rxjs:
         specifier: 7.8.1
@@ -271,7 +271,7 @@ importers:
         specifier: ^19.0.0
         version: 19.2.0(@angular/common@19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.2.0(@angular/animations@19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
       '@swisspost/design-system-components':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../../../components
       tslib:
         specifier: 2.8.1
@@ -281,7 +281,7 @@ importers:
   packages/components-react:
     dependencies:
       '@swisspost/design-system-components':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../components
     devDependencies:
       '@eslint/js':
@@ -327,19 +327,19 @@ importers:
   packages/documentation:
     dependencies:
       '@swisspost/design-system-components':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../components
       '@swisspost/design-system-components-react':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../components-react
       '@swisspost/design-system-icons':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../icons
       '@swisspost/design-system-styles':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../styles/dist
       '@swisspost/design-system-tokens':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../tokens/dist
       '@swisspost/internet-header':
         specifier: workspace:2.0.0-next.36
@@ -403,7 +403,7 @@ importers:
         specifier: 8.4.7
         version: 8.4.7(lit@3.2.1)(storybook@8.4.7(prettier@2.8.8))(vite@6.3.4(@types/node@22.10.5)(jiti@2.4.2)(less@4.2.2)(sass-embedded@1.78.0)(sass@1.85.1)(terser@5.39.0)(yaml@2.7.0))
       '@swisspost/design-system-components-angular':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../components-angular/dist/components
       '@types/css-modules':
         specifier: 1.0.5
@@ -629,7 +629,7 @@ importers:
   packages/internet-header:
     dependencies:
       '@swisspost/design-system-styles':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../styles/dist
       body-scroll-lock:
         specifier: 4.0.0-beta.0
@@ -768,10 +768,10 @@ importers:
   packages/nextjs-integration:
     dependencies:
       '@swisspost/design-system-components-react':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../components-react
       '@swisspost/design-system-styles':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../styles/dist
       '@swisspost/internet-header':
         specifier: workspace:2.0.0-next.36
@@ -854,10 +854,10 @@ importers:
         version: 3.0.0
     devDependencies:
       '@swisspost/design-system-icons':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../icons
       '@swisspost/design-system-tokens':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../tokens/dist
       '@types/node':
         specifier: 22.10.5
@@ -951,11 +951,11 @@ importers:
         specifier: 19.0.9
         version: 19.0.9
       '@swisspost/design-system-styles':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../styles/dist
       primeng:
         specifier: 19.0.9
-        version: 19.0.9(553da6a5bf19415560b0c79df2838c31)
+        version: 19.0.9(fxrnogyevcwbkooc5wfwgygr6i)
       rxjs:
         specifier: 7.8.1
         version: 7.8.1
@@ -1039,11 +1039,11 @@ importers:
   packages/styles-primeng-workspace/projects/styles-primeng:
     dependencies:
       '@swisspost/design-system-styles':
-        specifier: workspace:9.0.0-next.36
+        specifier: workspace:10.0.0-next.36
         version: link:../../../styles/dist
       primeng:
         specifier: ^19.0.0
-        version: 19.0.9(553da6a5bf19415560b0c79df2838c31)
+        version: 19.0.9(fxrnogyevcwbkooc5wfwgygr6i)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -21974,7 +21974,7 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.2.0
 
-  primeng@19.0.9(553da6a5bf19415560b0c79df2838c31):
+  primeng@19.0.9(fxrnogyevcwbkooc5wfwgygr6i):
     dependencies:
       '@angular/animations': 19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))
       '@angular/cdk': 19.2.2(@angular/common@19.2.0(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.2.0(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)


### PR DESCRIPTION
## 📄 Description

This moves main to the next major version, since we're introducing an in-between version compatible with Angular 19. Fingers crossed. This change has been made manually. Tasks to look at are added to https://github.com/swisspost/design-system/issues/4565.
