### PR TITLE
fix(components): remove back button rotation on `post-header`

### DIFF
--- a/.changeset/brave-garlics-lead.md
+++ b/.changeset/brave-garlics-lead.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-documentation': minor
+'@swisspost/design-system-components': minor
+---
+
+Removed the rotation of the back button in the `post-header`, which means users need to change the back button's icon `arrowright` to `arrowleft` to make sure it's pointing in the right direction.

--- a/packages/components/cypress/fixtures/post-mainnavigation-overflow.test.html
+++ b/packages/components/cypress/fixtures/post-mainnavigation-overflow.test.html
@@ -64,7 +64,7 @@
       <!-- Main navigation -->
       <post-mainnavigation caption="Hauptnavigation">
         <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+          <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
 
         <post-list title-hidden="">
@@ -74,7 +74,7 @@
             <post-megadropdown-trigger for="item-1">Item 1</post-megadropdown-trigger>
             <post-megadropdown id="item-1">
               <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>
@@ -132,7 +132,7 @@
             <post-megadropdown-trigger for="item-20">Item 20</post-megadropdown-trigger>
             <post-megadropdown id="item-20">
               <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>

--- a/packages/components/cypress/fixtures/post-mainnavigation.test.html
+++ b/packages/components/cypress/fixtures/post-mainnavigation.test.html
@@ -64,7 +64,7 @@
       <!-- Main navigation -->
       <post-mainnavigation caption="Hauptnavigation">
         <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+          <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
 
         <post-list title-hidden="">
@@ -79,7 +79,7 @@
             <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
             <post-megadropdown id="briefe">
               <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>
@@ -104,7 +104,7 @@
             <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
             <post-megadropdown id="pakete">
               <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
@@ -43,10 +43,6 @@ post-mainnavigation {
   }
 
   .back-button {
-    post-icon {
-      transform: rotate(180deg);
-    }
-
     @include media.max(lg) {
       font-size: 16px;
     }

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -69,7 +69,7 @@
       <!-- Main navigation -->
       <post-mainnavigation caption="Hauptnavigation">
         <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+          <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
 
         <post-list title-hidden="">
@@ -84,7 +84,7 @@
             <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
             <post-megadropdown id="briefe">
               <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>
@@ -121,7 +121,7 @@
             <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
             <post-megadropdown id="pakete">
               <button slot="back-button" class="btn btn-tertiary btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>

--- a/packages/documentation/src/stories/components/back-to-top/back-to-top.stories.ts
+++ b/packages/documentation/src/stories/components/back-to-top/back-to-top.stories.ts
@@ -69,7 +69,7 @@ const meta: MetaComponent = {
       <!-- Main navigation -->
       <post-mainnavigation caption="Hauptnavigation">
         <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+          <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
         <post-list title-hidden="">
           <h2>Main Navigation</h2>
@@ -82,7 +82,7 @@ const meta: MetaComponent = {
             <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
             <post-megadropdown id="briefe">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>
@@ -119,7 +119,7 @@ const meta: MetaComponent = {
             <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
             <post-megadropdown id="pakete">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>

--- a/packages/documentation/src/stories/modules/header/header.stories.ts
+++ b/packages/documentation/src/stories/modules/header/header.stories.ts
@@ -131,7 +131,7 @@ export const Default: Story = {
       <!-- Main navigation -->
       <post-mainnavigation caption="Hauptnavigation">
         <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="arrowright"></post-icon> Back
+          <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
         <post-list title-hidden="">
           <h2>Main Navigation</h2>
@@ -144,7 +144,7 @@ export const Default: Story = {
             <post-megadropdown-trigger for="briefe">Briefe</post-megadropdown-trigger>
             <post-megadropdown id="briefe">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>
@@ -181,7 +181,7 @@ export const Default: Story = {
             <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
             <post-megadropdown id="pakete">
               <button slot="back-button" class="btn btn-tertiary px-0 btn-sm">
-                <post-icon name="arrowright"></post-icon>
+                <post-icon name="arrowleft"></post-icon>
                 Back
               </button>
               <post-closebutton slot="close-button">Schliessen</post-closebutton>

--- a/packages/documentation/src/stories/raw-components/megadropdown/megadropdown.stories.ts
+++ b/packages/documentation/src/stories/raw-components/megadropdown/megadropdown.stories.ts
@@ -77,17 +77,15 @@ export function megadropdownDecorator(story: StoryFn, context: StoryContext) {
       <!-- Main navigation -->
       <post-mainnavigation caption="Hauptnavigation">
         <button type="button" slot="back-button" class="btn btn-sm btn-tertiary">
-          <post-icon aria-hidden="true" name="3024"></post-icon> Back
+          <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
         <post-list title-hidden="">
           <h2>Main Navigation</h2>
-          <post-list-item>
-            ${story(context.args, context)} 
-          </post-list-item>
+          <post-list-item> ${story(context.args, context)} </post-list-item>
         </post-list>
       </post-mainnavigation>
     </post-header>
-     <div class="container">
+    <div class="container">
       <p class="fake-content"></p>
       <p class="fake-content"></p>
     </div>
@@ -99,7 +97,7 @@ function render() {
     <post-megadropdown-trigger for="pakete">Pakete</post-megadropdown-trigger>
     <post-megadropdown id="pakete">
       <button slot="back-button" class="btn btn-tertiary px-0">
-        <post-icon name="arrowright"></post-icon>
+        <post-icon name="arrowleft"></post-icon>
         Zurück
       </button>
       <post-closebutton slot="close-button">Schliessen</post-closebutton>


### PR DESCRIPTION
## 📄 Description

When the header was first developed, we didn't have as many icons available and the `arrowleft` icon was missing. Therefore we had used the `arrowright` icon with a 180 deg rotation on whatever the user was putting in the back button slot.

Now that we have the correct icon, this PR removes the 180deg rotation so that users can use the correct icon which is `arrowleft`.
