### PR TITLE
chore(documentation): minor updates for `back to top`, `card-control` and `popover`.

### DIFF
--- a/.changeset/clever-bears-pay.md
+++ b/.changeset/clever-bears-pay.md
@@ -2,5 +2,5 @@
 '@swisspost/design-system-documentation': patch
 ---
 
-Added `close-button-caption` attribute in `post-popover`.
+Added `close-button-caption` attribute in `post-popover` component.
 Removed an obsolete parameter from the `post-back-to-top` component metadata object.

--- a/.changeset/clever-bears-pay.md
+++ b/.changeset/clever-bears-pay.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Implemented minor changes in `back-to-top`, `card-control` and `popover` documentation pages.

--- a/.changeset/clever-bears-pay.md
+++ b/.changeset/clever-bears-pay.md
@@ -2,4 +2,5 @@
 '@swisspost/design-system-documentation': patch
 ---
 
-Implemented minor changes in `back-to-top`, `card-control` and `popover` documentation pages.
+Added `close-button-caption` attribute in `post-popover`.
+Removed an obsolete parameter from the `post-back-to-top` component metadata object.

--- a/packages/documentation/src/stories/components/back-to-top/back-to-top.stories.ts
+++ b/packages/documentation/src/stories/components/back-to-top/back-to-top.stories.ts
@@ -9,7 +9,6 @@ const meta: MetaComponent = {
   component: 'post-back-to-top',
   tags: ['package:WebComponents'],
   parameters: {
-    layout: 'fullscreen',
     design: {
       type: 'figma',
       url: 'https://www.figma.com/design/JIT5AdGYqv6bDRpfBPV8XR/Foundations-%26-Components-Next-Level?node-id=18-11',

--- a/packages/documentation/src/stories/components/card-control/standard-html/card-control.stories.ts
+++ b/packages/documentation/src/stories/components/card-control/standard-html/card-control.stories.ts
@@ -146,6 +146,7 @@ export const Default = {
     const cardClasses = mapClasses({
       'checked': args.checked,
       'disabled': args.disabled,
+      'is-valid': args.validation === 'is-valid',
       'is-invalid': args.validation === 'is-invalid',
       'checkbox-button-card': args.type === 'checkbox',
       'radio-button-card': args.type === 'radio',

--- a/packages/documentation/src/stories/components/card-control/standard-html/card-control.stories.ts
+++ b/packages/documentation/src/stories/components/card-control/standard-html/card-control.stories.ts
@@ -146,7 +146,6 @@ export const Default = {
     const cardClasses = mapClasses({
       'checked': args.checked,
       'disabled': args.disabled,
-      'is-valid': args.validation === 'is-valid',
       'is-invalid': args.validation === 'is-invalid',
       'checkbox-button-card': args.type === 'checkbox',
       'radio-button-card': args.type === 'radio',

--- a/packages/documentation/src/stories/components/popover/popover.stories.ts
+++ b/packages/documentation/src/stories/components/popover/popover.stories.ts
@@ -53,7 +53,7 @@ const meta: MetaComponent = {
         'Value can either be in `vw`, `px` or `%`. If no max-width is defined, the popover will extend to the width of its content.',
       table: {
         category: 'General',
-        defaultValue: { summary: '280px' }
+        defaultValue: { summary: '280px' },
       },
     },
     palette: {
@@ -104,6 +104,7 @@ function render(args: Args) {
       class="${args.palette}"
       id="${args.id}"
       placement="${args.placement}"
+      close-button-caption="${args.closeButtonCaption}"
       ?arrow="${args.arrow}"
       style="${args.maxWidth ? '--post-popover-max-width: ' + args.maxWidth : ''}"
     >


### PR DESCRIPTION
## 📄 Description

- Back-top-top: Removed unnecessary`fullscreen` property.
- Popover: Added missing `close-button-caption` attribute 

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- ✔️ New and existing unit tests pass locally with my changes
