### PR TITLE
fix(component): fix animation error in post-collapsible when inside inactive tabs

### DIFF
--- a/.changeset/tricky-buckets-sniff.md
+++ b/.changeset/tricky-buckets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed an issue where `post-accordion` placed inside inactive tabs would throw animation errors.

--- a/packages/components/src/components/post-collapsible/post-collapsible.tsx
+++ b/packages/components/src/components/post-collapsible/post-collapsible.tsx
@@ -77,7 +77,10 @@ export class PostCollapsible {
 
     await animation.finished;
 
-    animation.commitStyles();
+    const isVisible = this.host.offsetParent || this.host.offsetWidth || this.host.offsetHeight;
+    if (isVisible) {
+      animation.commitStyles();
+    }
 
     return open;
   }


### PR DESCRIPTION
## 📄 Description

This PR adds visibility check before committing animation styles in PostCollapsible.toggle() to prevent InvalidStateError when the target element is hidden. This resolves errors occurring when animating elements inside hidden tab panels.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
