### PR TITLE
fix(styles): fixed post-tooltip text overflow by implementing proper word wrapping and updating width constraints (cherrypick/v9)

### DIFF
--- a/.changeset/angry-trams-stick.md
+++ b/.changeset/angry-trams-stick.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed `post-tooltip` text overflow by implementing proper word wrapping and updating width constraints. Tooltips now break correctly within a maximum width of 280px, preventing text from bleeding outside container boundaries.

--- a/packages/components/src/components/post-tooltip/post-tooltip.scss
+++ b/packages/components/src/components/post-tooltip/post-tooltip.scss
@@ -27,7 +27,9 @@ post-popovercontainer {
 
   & > div {
     padding: spacing.$size-micro spacing.$size-mini;
-    max-width: 200px;
+    max-width: 280px;
     min-height: 32px;
+    word-wrap: break-word;
+    white-space: normal;
   }
 }


### PR DESCRIPTION
Cherrypick of the  https://github.com/swisspost/design-system/pull/5544 to release/v9

## Description

- Updated `max-width` from 200px to 280px for better content accommodation
- Implemented proper word breaking for content that exceeds container width

---

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes

## 📄 Description

Please include a summary of the changes made in this PR.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
