### PR TITLE
chore: fix v8 deploy target

### DIFF
--- a/packages/documentation/netlify.config.json
+++ b/packages/documentation/netlify.config.json
@@ -1,4 +1,4 @@
 {
-  "siteId": "f6d103b2-7c7c-42ef-a6d6-5942af069c68",
-  "siteUrl": "swisspost-design-system.netlify.app"
+  "siteId": "2c8bd568-fbac-447b-a75c-2014acb42e40",
+  "siteUrl": "design-system-version-8.netlify.app"
 }


### PR DESCRIPTION
## 📄 Description

Re-routes v8 deploys to the dedicated v8 netlify site.
