### PR TITLE
fix(component): fix animation error in `post-collapsible` rendered in hidden tabs (cherrypick/v9)

### DIFF
--- a/.changeset/tricky-buckets-sniff.md
+++ b/.changeset/tricky-buckets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Resolved an issue where `post-accordion` components placed within inactive tab panels caused animation-related exceptions.

--- a/packages/components/src/animations/collapse.ts
+++ b/packages/components/src/animations/collapse.ts
@@ -1,6 +1,6 @@
 const collapseDuration = 350;
 const collapseEasing = 'ease';
-const collapsedKeyframe: Keyframe = { height: '0', overflow: 'hidden' };
+export const collapsedKeyframe: Keyframe = { height: '0', overflow: 'hidden' };
 
 const animationOptions: KeyframeAnimationOptions = {
   duration: collapseDuration,

--- a/packages/components/src/components/post-collapsible/post-collapsible.tsx
+++ b/packages/components/src/components/post-collapsible/post-collapsible.tsx
@@ -10,7 +10,7 @@ import {
   Watch,
 } from '@stencil/core';
 import { version } from '@root/package.json';
-import { collapse, expand } from '@/animations/collapse';
+import { collapse, collapsedKeyframe, expand } from '@/animations/collapse';
 import { checkEmptyOrType, isMotionReduced } from '@/utils';
 
 /**
@@ -40,8 +40,18 @@ export class PostCollapsible {
       'boolean',
       'The `collapsed` property of the `post-collapsible` must be a boolean.',
     );
-
-    void this.toggle(!this.collapsed);
+    
+    if (!this.isLoaded) {
+    
+      const expandedKeyframe: Keyframe = { height: 'auto', overflow: 'visible' }; 
+      Object.assign(
+        this.host.style, 
+        this.collapsed ? collapsedKeyframe : expandedKeyframe
+      );
+      this.isOpen = !this.collapsed;
+    } else {
+      void this.toggle(!this.collapsed);
+    }
   }
 
   /**


### PR DESCRIPTION
## 📄 Description

This PR adds visibility check before committing animation styles in PostCollapsible.toggle() to prevent InvalidStateError when the target element is hidden. This resolves errors occurring when animating elements inside hidden tab panels.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes

---------

## 📄 Description

Please include a summary of the changes made in this PR.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
