### PR TITLE
fix(styles): fixed the `back-button` disalignment in the mobile menu

### DIFF
--- a/packages/components/src/components/post-header/post-header.scss
+++ b/packages/components/src/components/post-header/post-header.scss
@@ -265,6 +265,14 @@
     gap: 32px;
   }
 
+  @include media.max(sm) {
+    :has([slot="target-group"]) {
+      ::slotted(post-mainnavigation) {
+        gap: 24px;
+      }
+    }
+  }
+
   .navigation-footer {
     background-color: #f0efed;
     gap: 24px;
@@ -276,9 +284,5 @@
   ::slotted(post-mainnavigation),
   .navigation-footer {
     padding-inline: 16px;
-  }
-
-  ::slotted(post-mainnavigation) {
-    gap: 24px;
   }
 }

--- a/packages/components/src/components/post-header/post-header.scss
+++ b/packages/components/src/components/post-header/post-header.scss
@@ -230,8 +230,7 @@
   }
 
   ::slotted(post-mainnavigation),
-  .navigation-footer,
-  .navigation-target-group {
+  .navigation-footer {
     display: none;
     flex-direction: column;
 
@@ -277,5 +276,9 @@
   ::slotted(post-mainnavigation),
   .navigation-footer {
     padding-inline: 16px;
+  }
+
+  ::slotted(post-mainnavigation) {
+    gap: 24px;
   }
 }

--- a/packages/components/src/components/post-header/post-header.tsx
+++ b/packages/components/src/components/post-header/post-header.tsx
@@ -354,6 +354,9 @@ export class PostHeader {
             </div>
           </div>
           <div class="global-sub">
+            {this.device === 'desktop' && <slot name="target-group"></slot>}
+          </div>
+          <div class="global-sub">
             {this.device === 'desktop' && <slot name="meta-navigation"></slot>}
             <slot name="global-controls"></slot>
             {this.device === 'desktop' && <slot name="post-language-switch"></slot>}

--- a/packages/components/src/components/post-header/post-header.tsx
+++ b/packages/components/src/components/post-header/post-header.tsx
@@ -23,6 +23,7 @@ import { eventGuard } from '@/utils/event-guard';
  * @slot title - Holds the application title.
  * @slot default - Custom controls or content, right aligned in the local header.
  * @slot post-mainnavigation - Has a default slot because it's only meant to be used in the `<post-header>`.
+ * @slot target-group - Holds the list of buttons to choose the target group.
  */
 
 @Component({

--- a/packages/components/src/components/post-header/post-header.tsx
+++ b/packages/components/src/components/post-header/post-header.tsx
@@ -23,7 +23,6 @@ import { eventGuard } from '@/utils/event-guard';
  * @slot title - Holds the application title.
  * @slot default - Custom controls or content, right aligned in the local header.
  * @slot post-mainnavigation - Has a default slot because it's only meant to be used in the `<post-header>`.
- * @slot target-group - Holds the list of buttons to choose the target group.
  */
 
 @Component({
@@ -333,11 +332,6 @@ export class PostHeader {
         style={{ '--post-header-navigation-current-inset': `${mobileMenuScrollTop}px` }}
       >
         <div class="mobile-menu" ref={el => (this.mobileMenu = el)}>
-          <div class="navigation-target-group">
-            {(this.device === 'mobile' || this.device === 'tablet') && (
-              <slot name="target-group"></slot>
-            )}
-          </div>
           <slot name="post-mainnavigation"></slot>
           {(this.device === 'mobile' || this.device === 'tablet') && (
             <div class="navigation-footer">
@@ -358,9 +352,6 @@ export class PostHeader {
             <div class="logo">
               <slot name="post-logo"></slot>
             </div>
-          </div>
-          <div class="global-sub">
-            {this.device === 'desktop' && <slot name="target-group"></slot>}
           </div>
           <div class="global-sub">
             {this.device === 'desktop' && <slot name="meta-navigation"></slot>}

--- a/packages/components/src/components/post-header/readme.md
+++ b/packages/components/src/components/post-header/readme.md
@@ -34,6 +34,7 @@ Type: `Promise<void>`
 | `"post-logo"`            | Should be used together with the `<post-logo>` component.                     |
 | `"post-mainnavigation"`  | Has a default slot because it's only meant to be used in the `<post-header>`. |
 | `"post-togglebutton"`    | Holds the mobile menu toggler.                                                |
+| `"target-group"`         | Holds the list of buttons to choose the target group.                         |
 | `"title"`                | Holds the application title.                                                  |
 
 

--- a/packages/components/src/components/post-header/readme.md
+++ b/packages/components/src/components/post-header/readme.md
@@ -34,7 +34,6 @@ Type: `Promise<void>`
 | `"post-logo"`            | Should be used together with the `<post-logo>` component.                     |
 | `"post-mainnavigation"`  | Has a default slot because it's only meant to be used in the `<post-header>`. |
 | `"post-togglebutton"`    | Holds the mobile menu toggler.                                                |
-| `"target-group"`         | Holds the list of buttons to choose the target group.                         |
 | `"title"`                | Holds the application title.                                                  |
 
 

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
@@ -11,6 +11,14 @@
 @use '@swisspost/design-system-styles/variables/color';
 
 post-mainnavigation {
+  // Target group container - NEW ADDITION
+  .navigation-target-group {
+      @include media.min(lg) {
+        display: none !important; // Extra safety for desktop
+    }
+  }
+  // END NEW ADDITION
+
   // reset links and buttons
   post-list-item {
     > a {

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
@@ -42,12 +42,6 @@ post-mainnavigation {
     }
   }
 
-  // Absolute positioned so that it goes over the target group if present
-  > .back-button {
-    position: absolute;
-    top: 16px;
-  }
-
   .back-button {
     @include media.max(lg) {
       font-size: 16px;

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
@@ -11,13 +11,6 @@
 @use '@swisspost/design-system-styles/variables/color';
 
 post-mainnavigation {
-  // Target group container - NEW ADDITION
-  .navigation-target-group {
-      @include media.min(lg) {
-        display: none !important; // Extra safety for desktop
-    }
-  }
-
   // reset links and buttons
   post-list-item {
     > a {

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
@@ -17,7 +17,6 @@ post-mainnavigation {
         display: none !important; // Extra safety for desktop
     }
   }
-  // END NEW ADDITION
 
   // reset links and buttons
   post-list-item {

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
@@ -162,6 +162,7 @@ export class PostMainnavigation {
 
     for (const navigationItem of this.navigationItems) {
       const { right, width } = navigationItem.getBoundingClientRect();
+
       // Scroll to the first navigation item that is less than 75% visible
       const isThreeQuartersVisible = right - 0.25 * width < scrollRightLeftEdge;
       if (!isThreeQuartersVisible) {
@@ -170,6 +171,7 @@ export class PostMainnavigation {
       }
     }
   }
+
   private scrollLeft() {
     const scrollLeftRightEdge = document
       .querySelector('.scroll-left')
@@ -177,6 +179,7 @@ export class PostMainnavigation {
 
     for (const navigationItem of this.navigationItems.reverse()) {
       const { left, width } = navigationItem.getBoundingClientRect();
+
       // Scroll to the first navigation item that is less than 75% visible
       const isThreeQuartersVisible = left + 0.25 * width > scrollLeftRightEdge;
       if (!isThreeQuartersVisible) {
@@ -201,7 +204,6 @@ export class PostMainnavigation {
   }
 
   render() {
-    console.log('PostMainnavigation device:', this.device);
     const shouldShowTargetGroup = this.device === 'mobile' || this.device === 'tablet';
     
     return (

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
@@ -199,6 +199,10 @@ export class PostMainnavigation {
           <slot name="back-button"></slot>
         </div>
 
+        <div class="navigation-target-group">
+          <slot name="target-group"></slot>
+        </div>
+
         <div
           aria-hidden="true"
           class={{ 'scroll-control scroll-left': true, 'd-none': !this.canScrollLeft }}

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
@@ -2,6 +2,10 @@ import { Component, Host, h, State, Listen } from '@stencil/core';
 import { version } from '@root/package.json';
 import { breakpoint } from '@/utils';
 
+/**
+ * @slot target-group - Holds the list of buttons to choose the target group.
+ */
+
 const SCROLL_REPEAT_INTERVAL = 100; // Interval for repeated scrolling when holding down scroll button
 const NAVBAR_DISABLE_DURATION = 400; // Duration to temporarily disable navbar interactions during scrolling
 
@@ -203,20 +207,13 @@ export class PostMainnavigation {
     }, NAVBAR_DISABLE_DURATION);
   }
 
-  render() {
-    const shouldShowTargetGroup = this.device === 'mobile' || this.device === 'tablet';
-    
+  render() {    
     return (
       <Host slot="post-mainnavigation" version={version}>
         <div onClick={() => this.handleBackButtonClick()} class="back-button">
           <slot name="back-button"></slot>
         </div>
-
-        {/* Always render target-group slot but control visibility with CSS */}
-        <div class={`navigation-target-group ${shouldShowTargetGroup ? 'show' : 'hide'}`}>
-          <slot name="target-group"></slot>
-        </div>
-
+        <slot name="target-group"></slot>
         <div
           aria-hidden="true"
           class={{ 'scroll-control scroll-left': true, 'd-none': !this.canScrollLeft }}

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.tsx
@@ -37,20 +37,6 @@ export class PostMainnavigation {
     window.addEventListener('postBreakpoint:name', this.breakpointChange);
   }
 
-  disconnectedCallback() {
-    window.removeEventListener('postBreakpoint:name', this.breakpointChange);
-    
-    if (this.mutationObserver) {
-      this.mutationObserver.disconnect();
-    }
-    if (this.resizeObserver) {
-      this.resizeObserver.disconnect();
-    }
-    if (this.navbar) {
-      this.navbar.removeEventListener('scrollend', this.checkScrollability);
-    }
-  }
-
   private readonly breakpointChange = (e: CustomEvent) => {
     this.device = e.detail;
   };
@@ -69,6 +55,16 @@ export class PostMainnavigation {
 
     // Ensure the scroll buttons are correctly displayed or hidden whenever the navbar is scrolled
     this.navbar.addEventListener('scrollend', this.checkScrollability);
+  }
+
+  /**
+   * Disconnects observers and remove event listeners when the main navigation is removed from the DOM.
+   */
+  disconnectedCallback() {
+    window.removeEventListener('postBreakpoint:name', this.breakpointChange);
+    this.mutationObserver.disconnect();
+    this.resizeObserver.disconnect();
+    this.navbar.removeEventListener('scrollend', this.checkScrollability);
   }
 
   /**
@@ -162,13 +158,10 @@ export class PostMainnavigation {
   private scrollRight() {
     const scrollRightLeftEdge = document
       .querySelector('.scroll-right')
-      ?.getBoundingClientRect().left;
-
-    if (!scrollRightLeftEdge) return;
+      .getBoundingClientRect().left;
 
     for (const navigationItem of this.navigationItems) {
       const { right, width } = navigationItem.getBoundingClientRect();
-
       // Scroll to the first navigation item that is less than 75% visible
       const isThreeQuartersVisible = right - 0.25 * width < scrollRightLeftEdge;
       if (!isThreeQuartersVisible) {
@@ -177,17 +170,13 @@ export class PostMainnavigation {
       }
     }
   }
-
   private scrollLeft() {
     const scrollLeftRightEdge = document
       .querySelector('.scroll-left')
-      ?.getBoundingClientRect().right;
-
-    if (!scrollLeftRightEdge) return;
+      .getBoundingClientRect().right;
 
     for (const navigationItem of this.navigationItems.reverse()) {
       const { left, width } = navigationItem.getBoundingClientRect();
-
       // Scroll to the first navigation item that is less than 75% visible
       const isThreeQuartersVisible = left + 0.25 * width > scrollLeftRightEdge;
       if (!isThreeQuartersVisible) {

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -205,17 +205,5 @@
       <option value="compact">Post compact</option>
     </select>
     <hr />
-
-    <div style="padding: 2rem; background: #f8f9fa; margin: 2rem 0; border: 1px solid #dee2e6;">
-      <h2>How it works:</h2>
-      <ul>
-        <li><strong>Desktop:</strong> Target group appears in the global header area of post-header</li>
-        <li><strong>Mobile/Tablet:</strong> Target group appears in the mobile menu of post-mainnavigation</li>
-        <li><strong>Duplicate content:</strong> Same target-group markup is provided to both slots</li>
-        <li><strong>CSS controls visibility:</strong> Media queries show/hide the appropriate version</li>
-      </ul>
-      
-      <p><em>Resize the browser window to see the target group switch between desktop and mobile layouts.</em></p>
-    </div>
   </body>
 </html>

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -85,6 +85,18 @@
           <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
 
+        <ul slot="target-group" class="target-group">
+          <li>
+            <a href="#" class="active">Private customers</a>
+          </li>
+          <li>
+            <a href="#">Business customers</a>
+          </li>
+          <li>
+            <a href="#">Authorities</a>
+          </li>
+        </ul>
+
         <post-list title-hidden="">
           <h2>Main Navigation</h2>
 

--- a/packages/components/src/index.html
+++ b/packages/components/src/index.html
@@ -51,6 +51,7 @@
       <!-- Application title (optional) -->
       <h1 slot="title">Application title</h1>
 
+      <!-- TARGET GROUP FOR DESKTOP (shows in post-header global area) -->
       <ul slot="target-group" class="target-group">
         <li>
           <a href="#" class="active">Private customers</a>
@@ -85,6 +86,7 @@
           <post-icon aria-hidden="true" name="arrowleft"></post-icon> Back
         </button>
 
+        <!-- TARGET GROUP FOR MOBILE (shows in post-mainnavigation mobile menu) -->
         <ul slot="target-group" class="target-group">
           <li>
             <a href="#" class="active">Private customers</a>
@@ -203,5 +205,17 @@
       <option value="compact">Post compact</option>
     </select>
     <hr />
+
+    <div style="padding: 2rem; background: #f8f9fa; margin: 2rem 0; border: 1px solid #dee2e6;">
+      <h2>How it works:</h2>
+      <ul>
+        <li><strong>Desktop:</strong> Target group appears in the global header area of post-header</li>
+        <li><strong>Mobile/Tablet:</strong> Target group appears in the mobile menu of post-mainnavigation</li>
+        <li><strong>Duplicate content:</strong> Same target-group markup is provided to both slots</li>
+        <li><strong>CSS controls visibility:</strong> Media queries show/hide the appropriate version</li>
+      </ul>
+      
+      <p><em>Resize the browser window to see the target group switch between desktop and mobile layouts.</em></p>
+    </div>
   </body>
 </html>

--- a/packages/styles/src/components/target-group.scss
+++ b/packages/styles/src/components/target-group.scss
@@ -57,7 +57,7 @@ tokens.$default-map: components.$post-button;
   }
 
   @include media.max(lg) {
-    padding: 20px 0;
+    padding: 20px 0 28px;
   }
 
   @include media.max(sm) {

--- a/packages/styles/src/components/target-group.scss
+++ b/packages/styles/src/components/target-group.scss
@@ -14,6 +14,10 @@ tokens.$default-map: components.$post-button;
   justify-content: center;
   padding-inline-start: 32px;
 
+  @include media.max(sm) {
+    gap: 0;
+  }
+
   li {
     list-style: none;
   }
@@ -58,7 +62,7 @@ tokens.$default-map: components.$post-button;
   @include media.max(sm) {
     flex-direction: column;
     gap: 8px;
-    padding: 68px 16px 8px;
+    padding: 68px 16px 0;
 
     a {
       width: 100%;

--- a/packages/styles/src/components/target-group.scss
+++ b/packages/styles/src/components/target-group.scss
@@ -16,6 +16,7 @@ tokens.$default-map: components.$post-button;
 
   @include media.max(sm) {
     gap: 0;
+    margin-block: 0 !important;
   }
 
   li {
@@ -62,7 +63,7 @@ tokens.$default-map: components.$post-button;
   @include media.max(sm) {
     flex-direction: column;
     gap: 8px;
-    padding: 68px 16px 0;
+    padding: 0 16px;
 
     a {
       width: 100%;

--- a/packages/styles/src/components/target-group.scss
+++ b/packages/styles/src/components/target-group.scss
@@ -14,7 +14,7 @@ tokens.$default-map: components.$post-button;
   justify-content: center;
   padding-inline-start: 32px;
 
-  @include media.max(sm) {
+  @include media.max(lg) {
     gap: 0;
     margin-block: 0 !important;
   }
@@ -57,7 +57,7 @@ tokens.$default-map: components.$post-button;
   }
 
   @include media.max(lg) {
-    padding: 102px 0 36px;
+    padding: 20px 0;
   }
 
   @include media.max(sm) {

--- a/packages/styles/src/components/target-group.scss
+++ b/packages/styles/src/components/target-group.scss
@@ -16,7 +16,6 @@ tokens.$default-map: components.$post-button;
 
   @include media.max(lg) {
     gap: 0;
-    margin-block: 0 !important;
   }
 
   li {


### PR DESCRIPTION
## 📄 Description

This PR fixes the disalignment of the back button in the mobile menu by restructuring how the target group and navigation elements are positioned. The main changes include:

- Removed absolute positioning of the `back-button` that was causing overlap issues with the target group
- Added `target-group slot`  to post-mainnavigation to be able to style it from there

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
