### PR TITLE
chore(internet-header): make package private

### DIFF
--- a/packages/internet-header/package.json
+++ b/packages/internet-header/package.json
@@ -4,6 +4,7 @@
   "description": "The header for client facing applications.",
   "author": "Swiss Post <design-system@post.ch>",
   "license": "Apache-2.0",
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/swisspost/design-system.git"
@@ -20,7 +21,7 @@
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/swisspost-internet-header/swisspost-internet-header.esm.js",
   "publishConfig": {
-    "access": "public"
+    "access": "restricted"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## 📄 Description

This will make the internet-header package private, (so it will not be released) on the release/v8 branch.
The package will be removed fully from the branch anyway with the PR #5674.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
