### PR TITLE
chore: manually set the release tag of the changeset:publish script to "version-8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "nextjs:start": "pnpm --filter design-system-nextjs-integration dev",
     "nextjs:build": "pnpm --filter design-system-nextjs-integration build",
     "nextjs:lint": "pnpm --filter design-system-nextjs-integration lint",
-    "changeset:publish": "pnpm changeset publish",
+    "changeset:publish": "pnpm changeset publish --tag version-8",
     "changeset:version": "pnpm changeset version && pnpm install --lockfile-only",
     "tokens:build": "pnpm --filter design-system-tokens build",
     "primeng": "pnpm primeng:start",


### PR DESCRIPTION
## 📄 Description

Since we did not automate that already, we need to manually set the publish tag on older release branches to their version, so the package won't be released under the tag "main". Therefor this PR sets the tag to "version-8" for the current release branch.


---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
