### PR TITLE
chore(components): added e2e test for the `post-footer` component

### DIFF
--- a/.changeset/olive-pans-talk.md
+++ b/.changeset/olive-pans-talk.md
@@ -1,5 +1,0 @@
----
-'@swisspost/design-system-components': minor
----
-
-Added e2e test for the `post-footer` and fixed the render function to use the correct `post-accordion` component.


### PR DESCRIPTION
## 📄 Description

Added more comprehensive e2e test for the `post-footer`. I also found a typo where it misspelled `post-accor**dd**ion` in the render function of the footer. Surprisingly it still partially worked because the browser just created a custom tag instead of using the `post-accordion` component.
## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
