### PR TITLE
fix(docs): hide scroll-to anchor on icons search page

### DIFF
--- a/.changeset/yummy-dots-look.md
+++ b/.changeset/yummy-dots-look.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-documentation': patch
 ---
 
-Made the scroll-to anchor on the icons search page unfocussable and hided it for screenreaders, since we only need it our custom search.block javascript logic.
+Made the scroll-to anchor on the icons search page unfocusable and hid it for screenreaders, since we only need it for our custom search-icons.block javascript logic.

--- a/.changeset/yummy-dots-look.md
+++ b/.changeset/yummy-dots-look.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Made the scroll-to anchor on the icons search page unfocussable and hided it for screenreaders, since we only need it our custom search.block javascript logic.

--- a/packages/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
+++ b/packages/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
@@ -400,7 +400,7 @@ export class Search extends React.Component {
       <div className="container">
         <div className="search-form">{this.searchForm()}</div>
         <div className="search-results">
-          <a href="#results-top"></a>
+          <a href="#results-top" aria-hidden="true" tabindex="-1"></a>
           {this.paging()}
           {this.resultsList()}
           {this.paging()}


### PR DESCRIPTION
## 📄 Description

Hides the scroll-to anchor on the icons search page for keyboards and also from screenreaders.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
