### PR TITLE
chore: add a registry field to the .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
+registry=https://registry.npmjs.org/
 # Added for storybook peer dependencies to react
 strict-peer-dependencies=false
 # Install new dependencies with exact version to let renovate handle the update


### PR DESCRIPTION
## 📄 Description

Some Post projects require the internal Post registry to be set at the npm user config level.
Specifying the registry at project level prevent dependencies being installed for unwanted registries. 

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
