### PR TITLE
chore(components): update tooltip and popover styles for palettes 2.0

### DIFF
--- a/.changeset/beige-fans-see.md
+++ b/.changeset/beige-fans-see.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-documentation': patch
+'@swisspost/design-system-components': patch
+---
+
+Updated `post-tooltip` and `post-popover` components: added `.palette` class in the documentation examples and overrided default `popovercontainer` styles in both components.

--- a/packages/components/src/components/post-popover/post-popover.scss
+++ b/packages/components/src/components/post-popover/post-popover.scss
@@ -15,6 +15,8 @@
 }
 
 .popover-container {
+  color: var(--post-current-fg);
+  background-color: var(--post-current-bg);
   display: flex;
   align-items: self-start;
   padding: 0.5em;

--- a/packages/components/src/components/post-tooltip/post-tooltip.scss
+++ b/packages/components/src/components/post-tooltip/post-tooltip.scss
@@ -28,6 +28,8 @@ post-popovercontainer {
   }
 
   & > div {
+    color: var(--post-current-fg);
+    background-color: var(--post-current-bg);
     padding: tokens.get('utility-gap-4') tokens.get('utility-gap-8');
     max-width: 280px;
     min-height: 32px;

--- a/packages/documentation/src/stories/components/popover/popover.stories.ts
+++ b/packages/documentation/src/stories/components/popover/popover.stories.ts
@@ -101,7 +101,7 @@ function render(args: Args) {
       </button>
     </div>
     <post-popover
-      class="${args.palette}"
+      class="palette ${args.palette}"
       id="${args.id}"
       placement="${args.placement}"
       close-button-caption="${args.closeButtonCaption}"

--- a/packages/documentation/src/stories/components/tooltip/tooltip.stories.ts
+++ b/packages/documentation/src/stories/components/tooltip/tooltip.stories.ts
@@ -92,7 +92,7 @@ function render(args: Args) {
     <post-tooltip
       id="${args.id}"
       arrow="${ifDefined(args.arrow)}"
-      class="${args.palette}"
+      class="palette ${args.palette}"
       placement="${ifDefined(args.placement)}"
       animation="${ifDefined(args.animation)}"
     >


### PR DESCRIPTION
## 📄 Description

This PR updates the `tooltip` and `popover` as follows:

1. Adds the `.palette` class in both components' examples in the documentation.
2. Updates both components styles to override the default popovercontainer component styles.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- ✔️ New and existing unit tests pass locally with my changes
