### PR TITLE
chore(styles): revert update colors list for `tag` component (#5476)

### DIFF
--- a/.changeset/mean-oranges-smile.md
+++ b/.changeset/mean-oranges-smile.md
@@ -1,5 +1,0 @@
----
-'@swisspost/design-system-styles': patch
----
-
-Updated the color variables for the `tag` components.

--- a/packages/styles/src/variables/components/_tag.scss
+++ b/packages/styles/src/variables/components/_tag.scss
@@ -21,9 +21,9 @@ $tag-sm-icon-size: $tag-font-size;
 $tag-default-background: color.$gray-10;
 $tag-backgrounds: (
   'white': color.$white,
-  'info': color.$info,
-  'success': color.$success,
-  'error': color.$error,
-  'warning': color.$warning,
   'yellow': color.$yellow,
+  'success': color.$success,
+  'warning': color.$warning,
+  'danger': color.$error,
+  'info': color.$info,
 );


### PR DESCRIPTION
This reverts commit 79f93287684d83be51d8605f388f0167a89543ac.

## 📄 Description

After checking with the designers, we still do not know which colors the tag component will be offered in. 
Therefore, we should wait for a definite design before implementing breaking changes in this component.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
