### PR TITLE
fix(components): typo for `post-accordion` in `post-footer`

### DIFF
--- a/.changeset/odd-parrots-press.md
+++ b/.changeset/odd-parrots-press.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed a typo in the render function of the `post-footer` to use the correct `post-accordion` component.

--- a/packages/components/cypress/e2e/footer.cy.ts
+++ b/packages/components/cypress/e2e/footer.cy.ts
@@ -15,17 +15,17 @@ describe('Footer', () => {
       cy.get('@label').should('have.text', 'Footer label');
     });
 
-    it('should render the post-accorddion on mobile', () => {
+    it('should render the post-accordion on mobile', () => {
       cy.viewport('iphone-3');
-      cy.get('@footer').find('post-accorddion').as('accorddion');
+      cy.get('@footer').find('post-accordion').as('accordion');
 
-      cy.get('@accorddion').should('exist');
+      cy.get('@accordion').should('exist');
     });
 
-    it('should have accorddion-items with slotted elements on mobile', () => {
+    it('should have accordion-items with slotted elements on mobile', () => {
       cy.viewport('iphone-3');
-      cy.get('@footer').find('post-accorddion').as('accorddion');
-      cy.get('@accorddion').find('post-accordion-item').as('accordionItems');
+      cy.get('@footer').find('post-accordion').as('accordion');
+      cy.get('@accordion').find('post-accordion-item').as('accordionItems');
 
       cy.get('@accordionItems').should('have.length', 4);
       cy.get('@accordionItems')

--- a/packages/components/src/components/post-accordion/readme.md
+++ b/packages/components/src/components/post-accordion/readme.md
@@ -62,6 +62,19 @@ Type: `Promise<void>`
 | `"default"` | Slot for placing post-accordion-item components. |
 
 
+## Dependencies
+
+### Used by
+
+ - [post-footer](../post-footer)
+
+### Graph
+```mermaid
+graph TD;
+  post-footer --> post-accordion
+  style post-accordion fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/components/src/components/post-footer/post-footer.tsx
+++ b/packages/components/src/components/post-footer/post-footer.tsx
@@ -50,7 +50,7 @@ export class PostFooter {
   private renderAccordion() {
     return (
       <div class="footer-grid">
-        <post-accorddion heading-level="3" multiple>
+        <post-accordion headingLevel={3} multiple>
           <post-accordion-item collapsed>
             <span slot="header">
               <slot name="grid-1-title"></slot>
@@ -75,7 +75,7 @@ export class PostFooter {
             </span>
             <slot name="grid-4"></slot>
           </post-accordion-item>
-        </post-accorddion>
+        </post-accordion>
       </div>
     );
   }

--- a/packages/components/src/components/post-footer/readme.md
+++ b/packages/components/src/components/post-footer/readme.md
@@ -29,11 +29,13 @@
 
 ### Depends on
 
+- [post-accordion](../post-accordion)
 - [post-accordion-item](../post-accordion-item)
 
 ### Graph
 ```mermaid
 graph TD;
+  post-footer --> post-accordion
   post-footer --> post-accordion-item
   post-accordion-item --> post-collapsible-trigger
   post-accordion-item --> post-icon


### PR DESCRIPTION
## 📄 Description

Took the typo fix from @schaertim's PR #5709 to separate it from the tests.