### PR TITLE
feat(components): allow fewer than four link columns in the post-footer

### DIFF
--- a/.changeset/fast-eels-obey.md
+++ b/.changeset/fast-eels-obey.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': minor
+---
+
+Updated the `post-footer` component to support fewer than four columns of links, allowing flexibility in the number of `grid-*` slots used.

--- a/packages/components/src/components/post-accordion-item/post-accordion-item.scss
+++ b/packages/components/src/components/post-accordion-item/post-accordion-item.scss
@@ -58,7 +58,11 @@ tokens.$default-map: components.$post-accordion;
     content: '';
     inset: 0;
     inset-block-end: auto;
-    border-block-start: var(--post-accordion-button-border-top);
+
+    // if needed the border can be added or removed by setting the custom property respectively to "unset" or "0"
+    border-block-start-width: var(--post-accordion-button-border-top-width, #{tokens.get('accordion-group-border-top-width')});
+    border-block-start-style: tokens.get('accordion-border-top-style');
+    border-block-start-color: tokens.get('accordion-enabled-border');
   }
 
   @include utility-mx.focus-style() {

--- a/packages/components/src/components/post-accordion/post-accordion.scss
+++ b/packages/components/src/components/post-accordion/post-accordion.scss
@@ -15,8 +15,6 @@ tokens.$default-map: components.$post-accordion;
   margin-block-start: calc(tokens.get('accordion-group-border-top-width') * -1);
 }
 
-::slotted(post-accordion-item:not(:only-of-type):first-of-type) {
-  --post-accordion-button-border-top: #{tokens.get('accordion-group-border-top-width')} #{tokens.get(
-      'accordion-border-top-style'
-    )} #{tokens.get('accordion-enabled-border')};
+::slotted(post-accordion-item:where(:only-of-type, :not(:first-of-type))) {
+  --post-accordion-button-border-top-width: 0;
 }

--- a/packages/components/src/components/post-footer/post-footer.scss
+++ b/packages/components/src/components/post-footer/post-footer.scss
@@ -151,3 +151,20 @@ footer {
   column-gap: 0.5rem;
   font-size: var(--post-footer-copyright-font-size);
 }
+
+post-accordion-item {
+  &.d-none {
+    display: none;
+  }
+
+  // make sure the first visible accordion item has a border top
+  &.d-none + & {
+    --post-accordion-button-border-top-width: unset;
+  }
+
+  // remove the border top if the accordion item is not the first visible or if it is the only visible
+  &:not(.d-none) ~ &,
+  &:not(&:not(.d-none) ~ *):not(:has(~ #{&}:not(.d-none))) {
+    --post-accordion-button-border-top-width: 0;
+  }
+}

--- a/packages/components/src/components/post-footer/post-footer.tsx
+++ b/packages/components/src/components/post-footer/post-footer.tsx
@@ -2,6 +2,8 @@ import { Component, Element, h, Host, Prop, State, Watch } from '@stencil/core';
 import { version } from '@root/package.json';
 import { checkRequiredAndType, breakpoint } from '@/utils';
 
+const GRID_SLOTS = ['grid-1', 'grid-2', 'grid-3', 'grid-4'];
+
 /**
  * @slot grid-{1|2|3|4}-title - Slot for the accordion headers (mobile).
  * @slot grid-{1|2|3|4} - Slot for the accordion bodies (mobile) and the grid cells (tablet, desktop).
@@ -25,18 +27,25 @@ export class PostFooter {
   @Prop() readonly label!: string;
 
   @State() isMobile: boolean = breakpoint.get('name') === 'mobile';
+  @State() gridSlotDisplayed: Record<string, boolean> = {};
 
   @Watch('label')
   validateLabel() {
     checkRequiredAndType(this, 'label', 'string');
   }
 
+  connectedCallback() {
+    window.addEventListener('postBreakpoint:name', this.breakpointChange);
+  }
+
   componentWillLoad() {
     this.validateLabel();
   }
 
-  connectedCallback() {
-    window.addEventListener('postBreakpoint:name', this.breakpointChange);
+  componentDidLoad() {
+    GRID_SLOTS.forEach(slotName => {
+      this.updateGridSlotDisplay(this.host.shadowRoot.querySelector(`slot[name="${slotName}"]`));
+    });
   }
 
   disconnectedCallback() {
@@ -47,56 +56,34 @@ export class PostFooter {
     this.isMobile = e.detail === 'mobile';
   };
 
+  private updateGridSlotDisplay(slot: Element | EventTarget) {
+    if (slot instanceof HTMLSlotElement) {
+      const hasContent = slot.assignedElements().length > 0;
+      this.gridSlotDisplayed = {...this.gridSlotDisplayed, [slot.name]: hasContent};
+    }
+  }
+
   private renderAccordion() {
     return (
-      <div class="footer-grid">
-        <post-accordion headingLevel={3} multiple>
-          <post-accordion-item collapsed>
+      <post-accordion headingLevel={3} multiple={true}>
+        {GRID_SLOTS.map(slotName => (
+          <post-accordion-item class={{ 'd-none': !this.gridSlotDisplayed[slotName] }} collapsed={true}>
             <span slot="header">
-              <slot name="grid-1-title"></slot>
+              <slot name={slotName + '-title'}></slot>
             </span>
-            <slot name="grid-1"></slot>
+            <slot onSlotchange={(e) => this.updateGridSlotDisplay(e.target)} name={slotName}></slot>
           </post-accordion-item>
-          <post-accordion-item collapsed>
-            <span slot="header">
-              <slot name="grid-2-title"></slot>
-            </span>
-            <slot name="grid-2"></slot>
-          </post-accordion-item>
-          <post-accordion-item collapsed>
-            <span slot="header">
-              <slot name="grid-3-title"></slot>
-            </span>
-            <slot name="grid-3"></slot>
-          </post-accordion-item>
-          <post-accordion-item collapsed>
-            <span slot="header">
-              <slot name="grid-4-title"></slot>
-            </span>
-            <slot name="grid-4"></slot>
-          </post-accordion-item>
-        </post-accordion>
-      </div>
+        ))}
+      </post-accordion>
     );
   }
 
-  private renderGrid() {
-    return (
-      <div class="footer-grid">
-        <div>
-          <slot name="grid-1"></slot>
-        </div>
-        <div>
-          <slot name="grid-2"></slot>
-        </div>
-        <div>
-          <slot name="grid-3"></slot>
-        </div>
-        <div>
-          <slot name="grid-4"></slot>
-        </div>
+  private renderColumns() {
+    return GRID_SLOTS.map(slotName => (
+      <div class={{ 'd-none': !this.gridSlotDisplayed[slotName] }}>
+        <slot onSlotchange={(e) => this.updateGridSlotDisplay(e.target)} name={slotName}></slot>
       </div>
-    );
+    ));
   }
 
   render() {
@@ -106,7 +93,9 @@ export class PostFooter {
           <h2 class="visually-hidden">{this.label}</h2>
 
           <div class="footer-container">
-            {this.isMobile ? this.renderAccordion() : this.renderGrid()}
+            <div class="footer-grid">
+              {this.isMobile ? this.renderAccordion() : this.renderColumns()}
+            </div>
 
             <div class="footer-column">
               <div class="footer-socialmedia">


### PR DESCRIPTION
## 📄 Description

Until now it was only possible to have exactly 4 columns in the footer. With this change you can set 4 columns or less.
---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
