### PR TITLE
chore: add "on hold" label to the token ticket template

### DIFF
--- a/.github/ISSUE_TEMPLATE/component_tokens.md
+++ b/.github/ISSUE_TEMPLATE/component_tokens.md
@@ -2,7 +2,7 @@
 name: Component/Tokens
 about: Adding Design Tokens for a new component.
 title: '[tokens] componentnamehere'
-labels: '🔮 tokens'
+labels: '🔮 tokens', 'on hold'
 assignees: ''
 type: 'Task'
 ---


### PR DESCRIPTION
## 📄 Description

This PR adds a label to the tokens ticket so that they do not appear as ready for triage until the component design is defined.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
