### PR TITLE
feat(components): implement full-width tabs layout 

### DIFF
--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -448,6 +448,10 @@ export namespace Components {
          */
         "activePanel"?: HTMLPostTabPanelElement['name'];
         /**
+          * When this property is set to true, the tabs container should extend across the * full width of the screen, spanning from edge to edge.
+         */
+        "fullWidth"?: boolean;
+        /**
           * Shows the panel with the given name and selects its associated tab. Any other panel that was previously shown becomes hidden and its associated tab is unselected.
          */
         "show": (panelName: string) => Promise<void>;
@@ -1291,6 +1295,10 @@ declare namespace LocalJSX {
           * The name of the panel that is initially shown. If not specified, it defaults to the panel associated with the first tab.  **Changing this value after initialization has no effect.**
          */
         "activePanel"?: HTMLPostTabPanelElement['name'];
+        /**
+          * When this property is set to true, the tabs container should extend across the * full width of the screen, spanning from edge to edge.
+         */
+        "fullWidth"?: boolean;
         /**
           * An event emitted after the active tab changes, when the fade in transition of its associated panel is finished. The payload is the name of the newly shown panel.
          */

--- a/packages/components/src/components/post-tabs/post-tabs.scss
+++ b/packages/components/src/components/post-tabs/post-tabs.scss
@@ -3,3 +3,22 @@
 :host {
   display: block;
 }
+
+$container-max-width: var(--post-core-dimension-1280);
+
+:host([fullwidth]) .tabs-wrapper {
+  // Extra space outside the container
+  $extra-space: calc((100vw - #{$container-max-width}) / 2);
+  $space-to-compensate: max(0px, $extra-space);
+  $total-offset-per-side: calc(
+    max(var(--post-core-dimension-40), 0.5 * var(--post-grid-gutter-x)) + $space-to-compensate
+  );
+  // Negative margin to make the tabs-wrapper fullwidth
+  margin-inline: calc(-1 * $total-offset-per-side);
+  padding-inline: 0;
+
+  //Internal padding to re-align the tabs header to the container
+  .tabs {
+    padding-inline: $total-offset-per-side;
+  }
+}

--- a/packages/components/src/components/post-tabs/post-tabs.tsx
+++ b/packages/components/src/components/post-tabs/post-tabs.tsx
@@ -38,9 +38,16 @@ export class PostTabs {
   @Prop() readonly activePanel?: HTMLPostTabPanelElement['name'];
 
   /**
+   * When this property is set to true, the tabs container should extend across the
+   * * full width of the screen, spanning from edge to edge.
+   */
+  @Prop({ reflect: true }) fullWidth?: boolean;
+
+  /**
    * An event emitted after the active tab changes, when the fade in transition of its associated panel is finished.
    * The payload is the name of the newly shown panel.
    */
+
   @Event() postChange: EventEmitter<string>;
 
   componentDidLoad() {
@@ -194,7 +201,7 @@ export class PostTabs {
 
   render() {
     return (
-      <Host data-version={version}>
+      <Host data-version={version} fullwidth={this.fullWidth}>
         <div class="tabs-wrapper" part="tabs">
           <div class="tabs" role="tablist">
             <slot name="tabs" onSlotchange={() => this.enableTabs()} />

--- a/packages/components/src/components/post-tabs/readme.md
+++ b/packages/components/src/components/post-tabs/readme.md
@@ -7,9 +7,10 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                                                                                                                           | Type     | Default     |
-| ------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------- |
-| `activePanel` | `active-panel` | The name of the panel that is initially shown. If not specified, it defaults to the panel associated with the first tab.  **Changing this value after initialization has no effect.** | `string` | `undefined` |
+| Property      | Attribute      | Description                                                                                                                                                                           | Type      | Default     |
+| ------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------- |
+| `activePanel` | `active-panel` | The name of the panel that is initially shown. If not specified, it defaults to the panel associated with the first tab.  **Changing this value after initialization has no effect.** | `string`  | `undefined` |
+| `fullWidth`   | `full-width`   | When this property is set to true, the tabs container should extend across the * full width of the screen, spanning from edge to edge.                                                | `boolean` | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
## 📄 Description

This PR adds a `fullwidth` prop to the `post-tabs` component. When  `fullwidth` is set to `true`, the tabs header wrapper becomes full-width. It is extended to fit the 100% width of the screen, while the tabs content Remains aligned to the container.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- ✔️ New and existing unit tests pass locally with my changes
