### PR TITLE
chore(components): prevent errors when post-tooltip has no internal element (cherrypick /v9)

### DIFF
--- a/.changeset/unlucky-ravens-sort.md
+++ b/.changeset/unlucky-ravens-sort.md
@@ -1,5 +1,5 @@
 ---
-"@swisspost/design-system-components": patch
+'@swisspost/design-system-components': patch
 ---
 
 Added check to prevent errors when `<post-tooltip-trigger>` has no internal element.

--- a/.changeset/unlucky-ravens-sort.md
+++ b/.changeset/unlucky-ravens-sort.md
@@ -1,0 +1,5 @@
+---
+"@swisspost/design-system-components": patch
+---
+
+Added check to prevent errors when `<post-tooltip-trigger>` has no internal element

--- a/.changeset/unlucky-ravens-sort.md
+++ b/.changeset/unlucky-ravens-sort.md
@@ -2,4 +2,4 @@
 "@swisspost/design-system-components": patch
 ---
 
-Added check to prevent errors when `<post-tooltip-trigger>` has no internal element
+Added check to prevent errors when `<post-tooltip-trigger>` has no internal element.

--- a/.changeset/unlucky-ravens-sort.md
+++ b/.changeset/unlucky-ravens-sort.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-components': patch
 ---
 
-Added check to prevent errors when `<post-tooltip-trigger>` has no internal element.
+Updated `post-tooltip-trigger` component to prevent errors when it does not contain an internal HTML element.

--- a/packages/components/cypress/e2e/tooltip.cy.ts
+++ b/packages/components/cypress/e2e/tooltip.cy.ts
@@ -8,6 +8,10 @@ describe('tooltips', { baseUrl: null, includeShadowDom: true }, () => {
       cy.get('post-tooltip-trigger[for="tooltip-one"]').as('trigger');
     });
 
+    it('should contain an HTML element inside the trigger, not just plain text', () => {
+      cy.get('@trigger').children().should('have.length.at.least', 1);
+    });
+
     it('should display a tooltip', () => {
       cy.get('@tooltip').should('not.be.visible');
       cy.get('@target2').focus();
@@ -44,20 +48,20 @@ describe('tooltips', { baseUrl: null, includeShadowDom: true }, () => {
         doc.body.appendChild(trigger);
       });
 
-      cy.get('#added-later')
-        .should('exist')
-        .and('have.attr', 'aria-describedby', 'tooltip-one');
+      cy.get('#added-later').should('exist').and('have.attr', 'aria-describedby', 'tooltip-one');
     });
 
     describe('trigger behavior', () => {
       it('should initialize trigger with correct attributes', () => {
-        cy.get('@trigger').first().within(() => {
-          cy.get('button')
-            .should('have.attr', 'aria-describedby')
-            .then((ariaDescribedBy) => {
-              expect(ariaDescribedBy).to.include('tooltip-one');
-            });
-        });
+        cy.get('@trigger')
+          .first()
+          .within(() => {
+            cy.get('button')
+              .should('have.attr', 'aria-describedby')
+              .then(ariaDescribedBy => {
+                expect(ariaDescribedBy).to.include('tooltip-one');
+              });
+          });
       });
 
       it('should show tooltip on trigger hover', () => {
@@ -114,9 +118,7 @@ describe('tooltips', { baseUrl: null, includeShadowDom: true }, () => {
     });
 
     it('should add tabindex', () => {
-      cy.get('@target')
-        .should('have.attr', 'tabindex')
-        .and('eq', '0');
+      cy.get('@target').should('have.attr', 'tabindex').and('eq', '0');
     });
   });
 

--- a/packages/components/src/components/post-tooltip-trigger/post-tooltip-trigger.tsx
+++ b/packages/components/src/components/post-tooltip-trigger/post-tooltip-trigger.tsx
@@ -51,17 +51,15 @@ export class PostTooltipTrigger {
   @Watch('for')
   validateControlFor() {
     checkType(
-      this.for,  // The actual property value
-      'string',  // The expected type
-      'The "for" property must be a string'  // A meaningful error message
+      this.for, // The actual property value
+      'string', // The expected type
+      'The "for" property must be a string', // A meaningful error message
     );
   }
 
-  private get tooltip(): HTMLPostTooltipElement | null {    
+  private get tooltip(): HTMLPostTooltipElement | null {
     const ref = document.getElementById(this.for);
-    return ref?.localName === 'post-tooltip'
-      ? (ref as HTMLPostTooltipElement)
-      : null;
+    return ref?.localName === 'post-tooltip' ? (ref as HTMLPostTooltipElement) : null;
   }
 
   componentDidLoad() {
@@ -83,7 +81,7 @@ export class PostTooltipTrigger {
 
   private handleSlotChange() {
     this.cleanupTrigger();
-    
+
     this.setupTrigger();
   }
 
@@ -95,7 +93,7 @@ export class PostTooltipTrigger {
           .split(' ')
           .filter(id => id !== this.for)
           .join(' ');
-        
+
         if (newDescribedBy) {
           this.trigger.setAttribute('aria-describedby', newDescribedBy);
         } else {
@@ -120,7 +118,9 @@ export class PostTooltipTrigger {
         this.trigger.setAttribute('aria-describedby', `${describedBy} ${this.for}`.trim());
       }
     } else {
-      console.warn('No content found in the post-tooltip-trigger slot. Please insert a focusable element or content that can receive focus.');
+      console.warn(
+        'No content found in the post-tooltip-trigger slot. Please insert a focusable element or content that can receive focus.',
+      );
     }
   }
 
@@ -129,7 +129,7 @@ export class PostTooltipTrigger {
       this.host.addEventListener(event, this.boundTriggerHandler);
     });
   }
-  
+
   private removeListeners() {
     TRIGGER_EVENTS.forEach(event => {
       this.host.removeEventListener(event, this.boundTriggerHandler);
@@ -188,7 +188,7 @@ export class PostTooltipTrigger {
 
     if (
       (this.tooltip && newTarget && this.tooltip.contains(newTarget)) ||
-      (newTarget === this.trigger)
+      newTarget === this.trigger
     ) {
       return;
     }
@@ -197,13 +197,15 @@ export class PostTooltipTrigger {
   }
 
   private interestHandler() {
-    if (this.delay > 0) {
-      this.delayTimeout = window.setTimeout(() => {
+    if (this.trigger) {
+      if (this.delay > 0) {
+        this.delayTimeout = window.setTimeout(() => {
+          this.tooltip?.show(this.trigger);
+          this.delayTimeout = null;
+        }, this.delay);
+      } else {
         this.tooltip?.show(this.trigger);
-        this.delayTimeout = null;
-      }, this.delay);
-    } else {
-      this.tooltip?.show(this.trigger);
+      }
     }
   }
 


### PR DESCRIPTION
## 📄 Description

This PR updates the `post-tooltip-trigger` to not throw an error if it does not contain an internal HTML element.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
