### PR TITLE
fix(component): fixed megadropdown menus staying expanded after switching from desktop to mobile view

### DIFF
--- a/.changeset/loud-ads-enjoy.md
+++ b/.changeset/loud-ads-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed a bug where megadropdown menus retained their expanded state when switching from desktop to mobile view, causing them to appear open when the mobile menu was subsequently opened.

--- a/packages/components/src/components/post-header/post-header.tsx
+++ b/packages/components/src/components/post-header/post-header.tsx
@@ -97,6 +97,13 @@ export class PostHeader {
     if (this.device === 'desktop' && this.mobileMenuExtended) {
       this.closeMobileMenu();
     }
+    
+    if (this.device !== 'desktop') {
+      Array.from(this.host.querySelectorAll('post-megadropdown')).forEach(dropdown => {
+        dropdown.hide(false, true);
+      });
+      this.megadropdownOpen = false;
+    }
   };
 
   connectedCallback() {
@@ -167,6 +174,10 @@ export class PostHeader {
   @Method()
   async toggleMobileMenu(force?: boolean) {
     if (this.device === 'desktop') return;
+     if (this.megadropdownOpen) {
+      this.megadropdownOpen = false;
+      return;
+     }
 
     this.mobileMenuAnimation = this.mobileMenuExtended
       ? slideUp(this.mobileMenu)


### PR DESCRIPTION
## 📄 Description

Added cleanup logic in the `breakpointChange` method to reset all megadropdown states when switching away from desktop view. This ensures megadropdowns are properly collapsed when transitioning to mobile/tablet breakpoints.

**Changes**

- Modified `breakpointChange` method to hide all megadropdowns and reset megadropdownOpen state when switching from desktop to mobile/tablet
- Ensures consistent megadropdown behavior across device transitions

## 🚀 Demo

**Before**

https://github.com/user-attachments/assets/a7c8655d-ed1d-4171-a951-35867d1666bf

**After**

https://github.com/user-attachments/assets/e980340d-018f-4f7d-a1d5-f4b7fde36428

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
