### PR TITLE
chore(docs): clarify PrimeNG package scope

### DIFF
--- a/.changeset/forty-rings-refuse.md
+++ b/.changeset/forty-rings-refuse.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added an info banner to the styles for PrimeNG package documentation to clearly communicate that `@swisspost/design-system-styles-primeng` only provides styling for PrimeNG datatables.

--- a/packages/documentation/src/stories/packages/styles-primeng/styles-primeng.docs.mdx
+++ b/packages/documentation/src/stories/packages/styles-primeng/styles-primeng.docs.mdx
@@ -10,7 +10,10 @@ import { PostBanner } from '@swisspost/design-system-components-react';
 
 [![npm version](https://badge.fury.io/js/@swisspost%2Fdesign-system-styles-primeng.svg)](https://badge.fury.io/js/@swisspost%2Fdesign-system-styles-primeng)
 
-The Design System Styles for PrimeNG datatables.
+<div className="lead">
+  The Design System Styles for PrimeNG datatables.
+</div>
+<br />
 
 <PostBanner type="info">
   <p>

--- a/packages/documentation/src/stories/packages/styles-primeng/styles-primeng.docs.mdx
+++ b/packages/documentation/src/stories/packages/styles-primeng/styles-primeng.docs.mdx
@@ -2,6 +2,7 @@ import { Meta, Source } from '@storybook/blocks';
 import * as PackageStories from './styles-primeng.stories';
 import PrimeNGStyleImportsSample from './primeng-style-imports.sample.scss?raw';
 import PrimeNGProviderSample from './primeng-provider.sample.txt?raw';
+import { PostBanner } from '@swisspost/design-system-components-react';
 
 <Meta of={PackageStories} />
 
@@ -9,7 +10,15 @@ import PrimeNGProviderSample from './primeng-provider.sample.txt?raw';
 
 [![npm version](https://badge.fury.io/js/@swisspost%2Fdesign-system-styles-primeng.svg)](https://badge.fury.io/js/@swisspost%2Fdesign-system-styles-primeng)
 
-The Design System Styles for PrimeNG to style your PrimeNG datatables.
+The Design System Styles for PrimeNG datatables.
+
+<PostBanner type="info">
+  <p>
+    - This package provides Design System styles specifically <strong>for PrimeNG datatables only</strong>.
+    - Other PrimeNG components (buttons, forms, menus, etc.) are not styled by this package and will use their default PrimeNG appearance.
+  </p>
+</PostBanner>
+
 
 ## Prerequisites
 


### PR DESCRIPTION
## 📄 Description

**Changes**

- Added `PostBanner` component with clear messaging about package limitations
- Emphasized that only DataTable components are styled by this package
- Clarified that other PrimeNG components will use default PrimeNG appearance


## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
