### PR TITLE
chore(components-angular): fix the visual example of the `post-tooltip` in angular playground

### DIFF
--- a/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.html
+++ b/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.html
@@ -103,4 +103,5 @@
   <post-tooltip-trigger for="tooltip-one">
     <button class="btn btn-secondary btn-large">Button</button>
   </post-tooltip-trigger>
+  <post-tooltip id="tooltip-one"> My tooltip </post-tooltip>
 </div>


### PR DESCRIPTION
## 📄 Description

Quick fix in the `components-angular` playground example where the `post-tooltip-trigger` was linked to a non-existing `post-tooltip`.