### PR TITLE
chore(docs): add deprecation notice for ng-bootstrap components

### DIFF
--- a/.changeset/chilled-mangos-clap.md
+++ b/.changeset/chilled-mangos-clap.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added deprecation notice on the `ng-bootstrap` components.

--- a/packages/documentation/src/shared/nb-bootstrap/ngb-component-alert.mdx
+++ b/packages/documentation/src/shared/nb-bootstrap/ngb-component-alert.mdx
@@ -1,3 +1,6 @@
+<div className="alert alert-warning mb-big">
+  <p>This component is deprecated. The styles for ng-bootstrap component will be removed in a future major version of the Design System. Alternative cross-framework compatible components along with a migration guide will be provided.</p>
+</div>
 <div className="alert alert-info mb-bigger-big">
   <p className="alert-heading">The {props.component} is an ng-bootstrap component.</p>
   <p>This documentation gives only the specifics for a usage within Post project.<br/>

--- a/packages/documentation/src/stories/components/carousel/carousel.docs.mdx
+++ b/packages/documentation/src/stories/components/carousel/carousel.docs.mdx
@@ -22,10 +22,6 @@ import SampleLight from './carousel-light.sample.html?raw';
 
 <p className="lead">A slideshow component for cycling through elements—images or slides of text—like a carousel.</p>
 
-<div className="alert alert-warning">
-The carousel is deprecated and will be removed in a future version.
-</div>
-
 <NgbComponentAlert component="carousel" />
 
 <ul>

--- a/packages/documentation/src/stories/components/modal/modal.docs.mdx
+++ b/packages/documentation/src/stories/components/modal/modal.docs.mdx
@@ -24,10 +24,6 @@ import modalBlocking from './modal-blocking.sample?raw';
 
 <NgbComponentAlert component="modal" />
 
-<div className="alert alert-warning mb-4">
-  This component is deprecated in favor of the <a href="/?path=/docs/562eac2b-6dc1-4007-ba8e-4e981cef0cbc--docs">dialog component</a>.
-</div>
-
 <ul>
   <li>
     <a href="#component-import" target="_self">Component Import</a>


### PR DESCRIPTION
## 📄 Description

Added a deprecation notice on the documentation for the ng-bootstrap components.