### PR TITLE
fix(component): fix `<post-header>` component overlapping content on tablet and mobile devices

### DIFF
--- a/.changeset/flat-turtles-show.md
+++ b/.changeset/flat-turtles-show.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed `<post-header>` component overlapping content on tablet and mobile devices.

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -481,7 +481,7 @@ export namespace Components {
         /**
           * Defines the icon `name` inside of the component. <span className="banner banner-sm banner-info">If not set the icon will not show up.</span> To learn which icons are available, please visit our <a href="/?path=/docs/0dcfe3c0-bfc0-4107-b43b-7e9d825b805f--docs">icon library</a>.
          */
-        "icon": string;
+        "icon"?: string;
         /**
           * Defines the size of the component.
          */

--- a/packages/components/src/components/post-header/post-header.scss
+++ b/packages/components/src/components/post-header/post-header.scss
@@ -33,12 +33,6 @@
     --post-logo-height: var(--post-global-header-height);
     --post-global-controls-top: 0;
   }
-
-  @include media.max(lg) {
-    position: fixed;
-    inset: 0;
-    bottom: auto;
-  }
 }
 
 :host(:not(:has([slot='title']))) {
@@ -70,7 +64,6 @@
   @include media.max(lg) {
     z-index: 4;
     inset-block-start: 0;
-    position: relative;
   }
 
   @include media.min(lg) {
@@ -157,7 +150,7 @@
 
   @include media.max(lg) {
     z-index: 3;
-    position: relative;
+    inset-block-start: var(--post-global-header-height);
     padding-block: 8px;
 
     flex-wrap: wrap;


### PR DESCRIPTION
## 📄 Description

This PR fixes the header overlapping content issue on tablet and mobile devices reported in issue #5820 by reverting the changes introduced in PR #5621.

### Changes Made:
- **Reverted** the changes from PR #5621 

**Note:** A separate ticket has been created to address the original iOS Chrome gap issue with an alternative approach:
https://github.com/orgs/swisspost/projects/3/views/12?pane=issue&itemId=120735062&issue=swisspost%7Cdesign-system%7C5825

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
