### PR TITLE
chore(components): update tooltip display to `contents`

### DIFF
--- a/.changeset/selfish-donuts-invite.md
+++ b/.changeset/selfish-donuts-invite.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Updated `<post-tooltip>` display property to `contents` to avoid affecting document layout.

--- a/packages/components/src/components/post-tooltip/post-tooltip.scss
+++ b/packages/components/src/components/post-tooltip/post-tooltip.scss
@@ -11,7 +11,7 @@
 }
 
 :host([open]) {
-  display: block;
+  display: contents;
 }
 
 post-popovercontainer {


### PR DESCRIPTION
## 📄 Description

This PR updates the tooltip `display` property to `contents` to avoid affecting the layout.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- ⚠️ My changes generate no new warnings or errors
- ✔️ New and existing unit tests pass locally with my changes
