### PR TITLE
chore(docs): remove bootstrap and ng-bootstrap dependencies from versions.json

### DIFF
--- a/.changeset/early-hats-do.md
+++ b/.changeset/early-hats-do.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Removed the bootstrap and ng-bootstrap dependencies from the `versions.json` file.

--- a/.changeset/early-hats-do.md
+++ b/.changeset/early-hats-do.md
@@ -1,5 +1,0 @@
----
-'@swisspost/design-system-documentation': patch
----
-
-Removed the bootstrap and ng-bootstrap dependencies from the `versions.json` file.

--- a/packages/documentation/public/assets/versions.json
+++ b/packages/documentation/public/assets/versions.json
@@ -6,8 +6,6 @@
     "url": "https://next.design-system.post.ch",
     "dependencies": {
       "@angular/core": "^19.0.0",
-      "@ng-bootstrap/ng-bootstrap": "^18.0.0",
-      "bootstrap": "~5.3.0",
       "@swisspost/design-system-changelog-github": "1.0.2",
       "@swisspost/design-system-components": "10.0.0-next.39",
       "@swisspost/design-system-components-angular-workspace": "1.1.10-next.39",


### PR DESCRIPTION
## 📄 Description

Removed the bootstrap and ng-bootstrap dependencies from the versions.json file to update the VersionSwitcher.