### PR TITLE
chore: Update pnpm feature source in devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20",
   "features": {
-    "ghcr.io/devcontainers-contrib/features/pnpm:2": {
+    "ghcr.io/devcontainers-extra/features/pnpm:2": {
       "version": "9"
     }
   },


### PR DESCRIPTION
Switched pnpm feature from 'devcontainers-contrib' to 'devcontainers-extra' in .devcontainer/devcontainer.json to use the updated source.