### PR TITLE
fix(docs): add `.palette` class where needed

### DIFF
--- a/packages/documentation/src/stories/components/card-product/card-product.stories.ts
+++ b/packages/documentation/src/stories/components/card-product/card-product.stories.ts
@@ -149,7 +149,8 @@ export const Multipart: Story = {
                 <h3>Affordable</h3>
                 <h4 class="mb-16">Sample Product</h4>
                 <p class="lead">
-                  With SAMPLE PRODUCT, your letters arrive at their destination cost-effectively and reliably.
+                  With SAMPLE PRODUCT, your letters arrive at their destination cost-effectively and
+                  reliably.
                 </p>
               </div>
               <div>
@@ -161,7 +162,7 @@ export const Multipart: Story = {
             </div>
           </div>
 
-          <div class="card-body palette-alternate" data-sync-height-with="product-body-1">
+          <div class="card-body palette palette-alternate" data-sync-height-with="product-body-1">
             <h5 class="h6">Sample Product</h5>
             <p>140 x 90 mm bis B5 (250 x 176 mm)</p>
             <dl class="mt-16">
@@ -208,7 +209,7 @@ export const Multipart: Story = {
             </dl>
           </div>
 
-          <div class="card-body palette-alternate" data-sync-height-with="product-body-3">
+          <div class="card-body palette palette-alternate" data-sync-height-with="product-body-3">
             <h5 class="h6">Sample Product</h5>
             <p>140 x 90 mm bis B5 (250 x 176 mm)</p>
             <dl class="mt-16">
@@ -223,7 +224,7 @@ export const Multipart: Story = {
             </dl>
           </div>
 
-          <div class="card-body palette-alternate">
+          <div class="card-body palette palette-alternate">
             <button class="btn btn-secondary w-full mb-12">
               <span>Order Sample Product</span>
             </button>
@@ -243,7 +244,9 @@ export const Multipart: Story = {
                 <h3>Faster</h3>
                 <h4 class="mb-16">Sample Product</h4>
                 <p class="lead">
-                  This is a sample description with more detailed information about the product features and benefits. It demonstrates the layout and structure of the product card component.
+                  This is a sample description with more detailed information about the product
+                  features and benefits. It demonstrates the layout and structure of the product
+                  card component.
                 </p>
               </div>
               <div>
@@ -255,7 +258,7 @@ export const Multipart: Story = {
             </div>
           </div>
 
-          <div class="card-body palette-alternate" data-sync-height-with="product-body-1">
+          <div class="card-body palette palette-alternate" data-sync-height-with="product-body-1">
             <h5 class="h6">Sample Product</h5>
             <p>140 x 90 mm bis B5 (250 x 176 mm)</p>
             <dl class="mt-16">
@@ -293,7 +296,7 @@ export const Multipart: Story = {
             </dl>
           </div>
 
-          <div class="card-body palette-alternate" data-sync-height-with="product-body-3">
+          <div class="card-body palette palette-alternate" data-sync-height-with="product-body-3">
             <h5 class="h6">Sample Product</h5>
             <p>140 x 90 mm bis B5 (250 x 176 mm)</p>
             <dl class="mt-16">
@@ -308,7 +311,7 @@ export const Multipart: Story = {
             </dl>
           </div>
 
-          <div class="card-body palette-alternate">
+          <div class="card-body palette palette-alternate">
             <button class="btn btn-secondary w-full mb-12">
               <span>Order Sample Product</span>
             </button>

--- a/packages/documentation/src/stories/components/card/card.stories.ts
+++ b/packages/documentation/src/stories/components/card/card.stories.ts
@@ -346,7 +346,7 @@ export const Palette: Story = {
   },
   render: () =>
     html`
-      <div class="palette-default">
+      <div class="palette palette-default">
         <div class="container py-32">
           <div class="row gy-16">
             <div class="col-sm-6 col-12">${renderSimpleInteractiveCard}</div>
@@ -354,7 +354,7 @@ export const Palette: Story = {
           </div>
         </div>
       </div>
-      <div class="palette-alternate">
+      <div class="palette palette-alternate">
         <div class="container py-32">
           <div class="row gy-16">
             <div class="col-sm-6 col-12">${renderSimpleInteractiveCard}</div>

--- a/packages/documentation/src/stories/components/dialog/dialog.stories.ts
+++ b/packages/documentation/src/stories/components/dialog/dialog.stories.ts
@@ -146,7 +146,7 @@ const Template = {
 
     return html`
       <dialog
-        class="${args.palette}"
+        class="palette ${args.palette}"
         data-size="${args.size}"
         data-position="${args.position}"
         data-animation="${args.animation}"

--- a/packages/documentation/src/stories/components/subnavigation/subnavigation.stories.ts
+++ b/packages/documentation/src/stories/components/subnavigation/subnavigation.stories.ts
@@ -63,7 +63,7 @@ function clickBlocker(story: StoryFn, context: StoryContext) {
 
 function renderTest(args: Args) {
   return html`
-    <div class="subnavigation ${args.palette}">
+    <div class="subnavigation palette ${args.palette}">
       <div class="container container-fluid-xs container-fluid-sm">
         <ul class="subnavigation-list">
           ${Array.from(

--- a/packages/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
+++ b/packages/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
@@ -212,7 +212,7 @@ export class Search extends React.Component {
     const popover = document.querySelector('#icon-panel') as HTMLPostPopovercontainerElement;
 
     return (
-      <post-popovercontainer id="icon-panel" class="palette-default icon-panel">
+      <post-popovercontainer id="icon-panel" class="palette palette-default icon-panel">
         <div className="icon-panel-content">
           <div>
             <div className="resizer-container">

--- a/packages/documentation/src/stories/foundations/layout/sections/sections.stories.ts
+++ b/packages/documentation/src/stories/foundations/layout/sections/sections.stories.ts
@@ -113,13 +113,14 @@ type Story = StoryObj;
 
 export const Default: Story = {
   render: () => html`
-    <section class="section palette-brand">
+    <section class="section palette palette-brand">
       <div class="container py-64">
         <h2>Title</h2>
         <p>
-          This section demonstrates a foundational layout component with proper spacing and container styling.
-          Sections help in organizing content into distinct visual blocks, improving readability and structure.
-          The container ensures consistent horizontal padding and maximum width across different screen sizes.
+          This section demonstrates a foundational layout component with proper spacing and
+          container styling. Sections help in organizing content into distinct visual blocks,
+          improving readability and structure. The container ensures consistent horizontal padding
+          and maximum width across different screen sizes.
         </p>
       </div>
     </section>
@@ -156,7 +157,7 @@ export const Alignment: Story = {
     }
 
     return html`
-      <section class="section palette-brand">
+      <section class="section palette palette-brand">
         <div class="container">${content}</div>
       </section>
     `;

--- a/packages/documentation/src/stories/raw-components/internet-header/header.stories.ts
+++ b/packages/documentation/src/stories/raw-components/internet-header/header.stories.ts
@@ -195,7 +195,7 @@ export const CssVariables = {
         }
       </style>
       ${meta.render && meta.render(args, context)}
-      <p id="my-div" class="position-sticky palette-accent p-16">
+      <p id="my-div" class="position-sticky palette palette-accent p-16">
         I am sticky! I am always positioned right below the header when you scroll up and down.
       </p>
     `;

--- a/packages/documentation/src/stories/templates/error-page/error-page.stories.ts
+++ b/packages/documentation/src/stories/templates/error-page/error-page.stories.ts
@@ -12,7 +12,7 @@ const meta: Meta = {
 
 function render() {
   return html`
-    <div class="palette-alternate error-container">
+    <div class="palette palette-alternate error-container">
       <div class="container">
         <div class="row">
           <div class="col-sm-8 py-56">

--- a/packages/nextjs-integration/src/app/page.tsx
+++ b/packages/nextjs-integration/src/app/page.tsx
@@ -135,7 +135,7 @@ export default function Home() {
         </button>
       </div>
       <PostPopover
-        className="palette-alternate"
+        className="palette palette-alternate"
         id="popover-one"
         placement="top"
         closeButtonCaption="Close Popover"
@@ -178,7 +178,7 @@ export default function Home() {
           Button
         </button>
       </PostTooltipTrigger>
-      <PostTooltip id="tooltip-one" className="palette-accent" placement="top">
+      <PostTooltip id="tooltip-one" className="palette palette-accent" placement="top">
         Hi there 👋
       </PostTooltip>
     </>

--- a/packages/styles/index.html
+++ b/packages/styles/index.html
@@ -11,7 +11,7 @@
     <script src="playground.js" defer></script>
   </head>
   <body>
-    <aside class="palette-brand p-16">
+    <aside class="palette palette-brand p-16">
       <h1>Styles package playground</h1>
       <fieldset id="token-selects" class="mt-16">
         <legend class="my-8">Select tokens</legend>


### PR DESCRIPTION
## 📄 Description

Fixed some pages in the docs where there was a missing `.palette` class which prevented the specific palette class to work.