### PR TITLE
fix: define caption side for tables

### DIFF
--- a/.changeset/two-hounds-march.md
+++ b/.changeset/two-hounds-march.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Add caption-side style to the table component. This will place the caption correctly for projects not using the resets.css

--- a/packages/styles/src/components/tables.scss
+++ b/packages/styles/src/components/tables.scss
@@ -27,6 +27,7 @@ tokens.$default-map: utilities.$post-spacing;
   margin-bottom: 1rem;
   vertical-align: top;
   border-color: var(--table-border-color);
+  caption-side: bottom;
 
   > :not(:first-child) {
     border-width: 0;


### PR DESCRIPTION
This change makes the table component a bit more independent for projects that are not using our reset file. The caption-side is already defined there for the element table selector, but not all projects are using our reset.
