### PR TITLE
test: run full build for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cypress-
 
       - name: Install & build dependencies
-        run: pnpm bootstrap
+        run: pnpm install && pnpm -r build
 
       - name: Prepare Cypress – Spawn Xvfb server
         run: Xvfb :99 &


### PR DESCRIPTION
The `pnpm bootstrap` command is optimised to only run only necessary pacakges for development, we should do a full build for e2e tests here to catch any issues in building integration packages as well. Otherwise, issues in these packages are going unnoticed.
