### PR TITLE
chore(components): remove `PostTag` from Next.js integration package

### DIFF
--- a/packages/nextjs-integration/src/app/page.tsx
+++ b/packages/nextjs-integration/src/app/page.tsx
@@ -17,7 +17,6 @@ import {
   PostTabs,
   PostTabHeader,
   PostTabPanel,
-  PostTag,
   PostTooltipTrigger,
   PostTooltip,
 } from '@swisspost/design-system-components-react/server';
@@ -169,7 +168,6 @@ export default function Home() {
       </PostTabs>
 
       <h2>Tag</h2>
-      <PostTag>Tag</PostTag>
 
       <h2>Tooltip</h2>
       <PostTooltipTrigger for="tooltip-one">


### PR DESCRIPTION
## 📄 Description

After the removal of the `<post-tag>` component in #5764, we need to clean up the Next.js integration package where `PostTag` is still being imported but no longer available.

The error occurs when running the Next.js dev server:

`Attempted import error: 'PostTag' is not exported from '@swisspost/design-system-components-react/server' (imported as 'PostTag').`

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
