### PR TITLE
fix: rename outdated palette CSS variables

### DIFF
--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
@@ -33,8 +33,8 @@
     box-shadow: elevation.$elevation-300;
     width: max-content;
     max-width: 100%;
-    color: var(--post-current-palette-fg);
-    background-color: var(--post-current-palette-bg);
+    color: var(--post-current-fg);
+    background-color: var(--post-current-bg);
     border-radius: commons.$border-radius;
 
     &.animate-pop-in {

--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -368,7 +368,7 @@ $monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier
 
   &::after {
     content: '';
-    background: var(--post-current-palette-bg);
+    background: var(--post-current-bg);
     width: 33%;
     height: 1.7rem;
     display: block;

--- a/packages/styles/src/components/form-textarea.scss
+++ b/packages/styles/src/components/form-textarea.scss
@@ -156,7 +156,7 @@ textarea.form-control {
 
     &:disabled ~ label {
       color: tokens.get('textarea-disabled-fg');
-      background-color: var(--post-current-palette-bg);
+      background-color: var(--post-current-bg);
     }
 
     &:not(:disabled):hover ~ label {


### PR DESCRIPTION
## 📄 Description

With the recent changes to the palettes we renamed the `--post-current-palette-fg` and `--post-current-palette-bg` CSS properties to `--post-current-fg` and `--post-current-bg`. However some components where still using the old names and therefore appear broken. This PR fixes them.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
