### PR TITLE
fix(component): fix expected toggle behavior for mobile-menu in `post-header`

### DIFF
--- a/packages/components/cypress/e2e/header.cy.ts
+++ b/packages/components/cypress/e2e/header.cy.ts
@@ -36,5 +36,41 @@ describe('Header', () => {
 
       cy.get('[data-post-scroll-locked]').should('not.exist');
     });
+
+    it('should close both megadropdown and mobile menu with one click', () => {
+      // Open mobile menu
+      cy.get('post-togglebutton').click();
+      cy.get('div.local-header-mobile-extended').should('exist');
+      // Open megadropdown
+      cy.get('post-megadropdown-trigger').first().click();
+      cy.get('post-megadropdown .megadropdown-container').should('be.visible');
+      // Click menu button to close both
+      cy.get('post-togglebutton').click();
+      cy.get('div.local-header-mobile-extended').should('not.exist');
+      cy.get('post-megadropdown .megadropdown-container').should('not.be.visible');
+    });
+
+    it('should animate megadropdown open after forced close', () => {
+      // Open mobile menu and megadropdown
+      cy.get('post-togglebutton').click();
+      cy.get('div.local-header-mobile-extended').should('exist');
+      cy.get('post-megadropdown-trigger').first().should('be.visible').click();
+      cy.get('post-megadropdown .megadropdown-container').should('be.visible');
+
+      // Force close by toggling menu
+      cy.get('post-togglebutton').click();
+      cy.get('div.local-header-mobile-extended').should('not.exist');
+      cy.get('post-megadropdown .megadropdown-container').should('not.be.visible');
+
+      // Reopen mobile menu before clicking the trigger again
+      cy.get('post-togglebutton').click();
+      cy.get('div.local-header-mobile-extended').should('exist');
+      cy.get('post-megadropdown-trigger').first().should('be.visible').click();
+
+      // Check if animation class is present
+      cy.get('post-megadropdown .megadropdown-container')
+        .should('be.visible')
+        .should('have.class', 'slide-in')
+    });
   });
 });

--- a/packages/components/src/components/post-header/post-header.tsx
+++ b/packages/components/src/components/post-header/post-header.tsx
@@ -171,9 +171,11 @@ export class PostHeader {
   async toggleMobileMenu(force?: boolean) {
     if (this.device === 'desktop') return;
     if (this.megadropdownOpen) {
-      this.megadropdownOpen = false;
-      return;
-    }
+    Array.from(this.host.querySelectorAll('post-megadropdown')).forEach(dropdown => {
+      dropdown.hide(false, true);
+    });
+    this.megadropdownOpen = false;
+  }
 
     this.mobileMenuAnimation = this.mobileMenuExtended
       ? slideUp(this.mobileMenu)

--- a/packages/components/src/components/post-megadropdown/post-megadropdown.tsx
+++ b/packages/components/src/components/post-megadropdown/post-megadropdown.tsx
@@ -76,9 +76,8 @@ export class PostMegadropdown {
     if (PostMegadropdown.activeDropdown && PostMegadropdown.activeDropdown !== this) {
       // Close the previously active dropdown without animation
       PostMegadropdown.activeDropdown.forceClose();
-    } else {
-      this.animationClass = 'slide-in';
     }
+    this.animationClass = 'slide-in';
 
     this.isVisible = true;
     PostMegadropdown.activeDropdown = this;


### PR DESCRIPTION
## 📄 Description

This regression was introduced by the fix for [#5747](https://github.com/swisspost/design-system/pull/5747/files), which closed all open `<post-megadropdown>` components when switching from desktop to mobile. That change updated the menu toggle logic so that if a megadropdown was open, it would close the dropdown and then return early, skipping the rest of the mobile menu toggle. As a result, after opening a megadropdown, you now have to `click` the menu button `twice` to fully close the mobile menu—once to close the dropdown, and again to close the menu itself.

Why were changes needed in `<post-megadropdown>`?
When a megadropdown was forcibly closed (like during a breakpoint change), its animation state wasn’t reset. If you opened it again, the opening animation wouldn’t play. The dropdown now always sets its animation class when opening, so the animation works every time.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
