### PR TITLE
chore(components-angular): added missing `close-button-caption` prop for `<post-popover>` component

### DIFF
--- a/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.html
+++ b/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.html
@@ -58,7 +58,7 @@
   <button class="btn btn-secondary btn-large" data-popover-target="popover-one">
     Click here to see a popover
   </button>
-  <post-popover id="popover-one" placement="top" arrow="">
+  <post-popover closeButtonCaption="Close" id="popover-one" placement="top" arrow="">
     <h2 class="h6">Optional title</h2>
 
     <p class="mb-0">


### PR DESCRIPTION
## 📄 Description

<img width="726" height="202" alt="image" src="https://github.com/user-attachments/assets/ed7e0b0c-671b-434f-91ed-0bb84fa8eb48" />

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
