### PR TITLE
chore(migration): added restricted max with on `tooltips` to migration docs of `v8 - v9`

### DIFF
--- a/packages/documentation/src/stories/getting-started/migration-guide/migrationv8-9.component.ts
+++ b/packages/documentation/src/stories/getting-started/migration-guide/migrationv8-9.component.ts
@@ -93,6 +93,16 @@ export class MigrationV89Component extends LitElement {
                   <code>arrow="true"</code> property on the component.
                 </p>
               </li>
+              <li class="mb-16">
+                <p>
+                  The <code>post-tooltip</code> component now has a restricted maximum width of
+                  <code>280px</code>, instead of taking the full available width as in v8.
+                  <span class="tag tag-sm tag-danger">breaking</span>
+                </p>
+                <p class="info">
+                  If you need to accomodate more content, we recommend switching to the <code>post-popover</code> component.
+                </p>
+              </li>
               ${this.angular
                 ? html`
                     <li class="mb-16">


### PR DESCRIPTION
## 📄 Description

Added documentation for the breaking change in `post-tooltip` component where the maximum width is now restricted to 280px in v9, compared to taking full available width in v8.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
