### PR TITLE
chore(components, styles): remove custom icon and neutral type from banners and toasts

### DIFF
--- a/.changeset/few-humans-dream.md
+++ b/.changeset/few-humans-dream.md
@@ -1,0 +1,9 @@
+---
+'@swisspost/design-system-components-angular': major
+'@swisspost/design-system-components-react': major
+'@swisspost/design-system-components': major
+'@swisspost/design-system-styles': major
+'@swisspost/design-system-documentation': patch
+---
+
+Removed the `icon` property and `neutral` type from the banner and toast components. They now default to type `info`, and their icons are no longer configurable.

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -83,21 +83,13 @@ export namespace Components {
          */
         "dismiss": () => Promise<void>;
         /**
-          * The label to use for the close button of a dismissible banner.
-         */
-        "dismissLabel"?: string;
-        /**
           * If `true`, a close button (×) is displayed and the banner can be dismissed by the user.
           * @default false
          */
         "dismissible": boolean;
         /**
-          * The icon to display in the banner. By default, the icon depends on the banner type.  If `none`, no icon is displayed.
-         */
-        "icon"?: string;
-        /**
           * The type of the banner.
-          * @default 'neutral'
+          * @default 'info'
          */
         "type": BannerType;
     }
@@ -980,25 +972,17 @@ declare namespace LocalJSX {
     }
     interface PostBanner {
         /**
-          * The label to use for the close button of a dismissible banner.
-         */
-        "dismissLabel"?: string;
-        /**
           * If `true`, a close button (×) is displayed and the banner can be dismissed by the user.
           * @default false
          */
         "dismissible"?: boolean;
-        /**
-          * The icon to display in the banner. By default, the icon depends on the banner type.  If `none`, no icon is displayed.
-         */
-        "icon"?: string;
         /**
           * An event emitted when the banner element is dismissed, after the transition. It has no payload and only relevant for dismissible banners.
          */
         "onPostDismissed"?: (event: PostBannerCustomEvent<void>) => void;
         /**
           * The type of the banner.
-          * @default 'neutral'
+          * @default 'info'
          */
         "type"?: BannerType;
     }

--- a/packages/components/src/components/post-banner/banner-types.ts
+++ b/packages/components/src/components/post-banner/banner-types.ts
@@ -1,3 +1,3 @@
-export const BANNER_TYPES = ['neutral', 'success', 'warning', 'danger', 'info'] as const;
+export const BANNER_TYPES = ['success', 'warning', 'danger', 'info'] as const;
 
 export type BannerType = (typeof BANNER_TYPES)[number];

--- a/packages/components/src/components/post-banner/post-banner.tsx
+++ b/packages/components/src/components/post-banner/post-banner.tsx
@@ -51,25 +51,9 @@ export class PostBanner {
   }
 
   /**
-   * The label to use for the close button of a dismissible banner.
-   */
-  @Prop() readonly dismissLabel?: string;
-  /**
-   * The icon to display in the banner. By default, the icon depends on the banner type.
-   *
-   * If `none`, no icon is displayed.
-   */
-  @Prop() readonly icon?: string;
-
-  @Watch('icon')
-  validateIcon() {
-    checkEmptyOrType(this, 'icon', 'string');
-  }
-
-  /**
    * The type of the banner.
    */
-  @Prop() readonly type: BannerType = 'neutral';
+  @Prop() readonly type: BannerType = 'info';
 
   @Watch('type')
   validateType() {
@@ -95,7 +79,6 @@ export class PostBanner {
     this.classes = `banner ${this.type ? 'banner-' + this.type : ''}`;
     if (this.dismissible) this.classes += ' banner-dismissible';
     if (this.hasActions) this.classes += ' banner-action';
-    if (this.icon === 'none') this.classes += ' no-icon';
   }
 
   /**
@@ -137,10 +120,6 @@ export class PostBanner {
             <button class="btn-close" onClick={this.onDismissButtonClick}>
               <span class="visually-hidden">{this.dismissLabel}</span>
             </button>
-          )}
-
-          {this.icon && this.icon !== 'none' && (
-            <post-icon key={`${this.bannerId}-icon`} name={this.icon} />
           )}
 
           {this.hasActions ? actionBannerContent : defaultBannerContent}

--- a/packages/components/src/components/post-banner/readme.md
+++ b/packages/components/src/components/post-banner/readme.md
@@ -7,12 +7,10 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                           | Type                                                        | Default     |
-| -------------- | --------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | ----------- |
-| `dismissLabel` | `dismiss-label` | The label to use for the close button of a dismissible banner.                                                        | `string`                                                    | `undefined` |
-| `dismissible`  | `dismissible`   | If `true`, a close button (×) is displayed and the banner can be dismissed by the user.                               | `boolean`                                                   | `false`     |
-| `icon`         | `icon`          | The icon to display in the banner. By default, the icon depends on the banner type.  If `none`, no icon is displayed. | `string`                                                    | `undefined` |
-| `type`         | `type`          | The type of the banner.                                                                                               | `"danger" \| "info" \| "neutral" \| "success" \| "warning"` | `'neutral'` |
+| Property      | Attribute     | Description                                                                             | Type                                           | Default  |
+| ------------- | ------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------- | -------- |
+| `dismissible` | `dismissible` | If `true`, a close button (×) is displayed and the banner can be dismissed by the user. | `boolean`                                      | `false`  |
+| `type`        | `type`        | The type of the banner.                                                                 | `"danger" \| "info" \| "success" \| "warning"` | `'info'` |
 
 
 ## Events
@@ -43,19 +41,6 @@ Type: `Promise<void>`
 | `"default"` | Slot for placing the main content/message of the banner.                  |
 | `"heading"` | Slot for placing custom content within the banner's heading.              |
 
-
-## Dependencies
-
-### Depends on
-
-- [post-icon](../post-icon)
-
-### Graph
-```mermaid
-graph TD;
-  post-banner --> post-icon
-  style post-banner fill:#f9f,stroke:#333,stroke-width:4px
-```
 
 ----------------------------------------------
 

--- a/packages/components/src/components/post-icon/readme.md
+++ b/packages/components/src/components/post-icon/readme.md
@@ -24,7 +24,6 @@ some content
 
  - [post-accordion-item](../post-accordion-item)
  - [post-back-to-top](../post-back-to-top)
- - [post-banner](../post-banner)
  - [post-breadcrumb-item](../post-breadcrumb-item)
  - [post-breadcrumbs](../post-breadcrumbs)
  - [post-card-control](../post-card-control)
@@ -38,7 +37,6 @@ some content
 graph TD;
   post-accordion-item --> post-icon
   post-back-to-top --> post-icon
-  post-banner --> post-icon
   post-breadcrumb-item --> post-icon
   post-breadcrumbs --> post-icon
   post-card-control --> post-icon

--- a/packages/documentation/src/stories/components/banner/banner.docs.mdx
+++ b/packages/documentation/src/stories/components/banner/banner.docs.mdx
@@ -54,18 +54,6 @@ Banners are intended to attract the user's attention without interrupting their 
 
       <Canvas of={BannerStories.AdditionalContent} />
 
-      ### Custom Icon
-
-      Banners come with a preassigned icon based on their type.
-      You have the option to customize this icon by using a `post-icon` element inside the banner.
-      For more information, read the [getting started with icons guide](/?path=/docs/40ed323b-9c1a-42ab-91ed-15f97f214608--docs).
-
-      <Canvas of={BannerStories.CustomIcon} />
-
-      If you prefer not to display any icon, you can add the `.no-icon` class to the banner.
-
-      <Canvas of={BannerStories.NoIcon} />
-
       ### Action Buttons
 
       To include action buttons within a banner, apply the `.banner-action` class to the banner element,
@@ -96,18 +84,6 @@ Banners are intended to attract the user's attention without interrupting their 
       Learn more about <a rel="noopener" href="https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_templates_and_slots#adding_flexibility_with_slots">slots in the mdn web docs</a>.
 
       <Canvas of={PostBannerStories.Contents} />
-
-      ### Custom Icon
-
-      Banners come with a preassigned icon based on their type.
-      You have the option to customize this icon by assigning the desired icon's name to the `icon` property of the banner.
-      Find the icon you need with the [icon search page](/?path=/docs/0dcfe3c0-bfc0-4107-b43b-7e9d825b805f--docs).
-
-      <Canvas of={PostBannerStories.CustomIcon} />
-
-      If you prefer not to display any icon, you can set the `icon` property to `none`.
-
-      <Canvas of={PostBannerStories.NoIcon} />
 
       ### Dismissal
 

--- a/packages/documentation/src/stories/components/banner/banner.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/banner/banner.snapshot.stories.ts
@@ -24,14 +24,10 @@ export const Banner: Story = {
         <div class="d-flex flex-column gap-16 flex-wrap">
           ${bombArgs({
             type: bannerMeta?.argTypes?.type?.options,
-            icon: ['no-icon', undefined, '1001'],
             action: [true, false],
             dismissible: [true, false],
           })
             .map(args => {
-              if (args.icon === 'no-icon') {
-                args.noIcon = true;
-              }
               return { ...args, show: true } as Args;
             })
             .map(
@@ -42,15 +38,6 @@ export const Banner: Story = {
                         <button class="btn-close">
                           <span class="visually-hidden">Close</span>
                         </button>
-                      `
-                    : null}
-                  ${args.icon && !args.noIcon
-                    ? html`
-                        <post-icon
-                          aria-hidden="true"
-                          class="banner-icon"
-                          name="${args.icon}"
-                        ></post-icon>
                       `
                     : null}
                   ${args.action
@@ -103,15 +90,13 @@ export const PostBanner: Story = {
       () => html`
         <div class="d-flex flex-column gap-16 flex-wrap">
           ${bombArgs({
-            type: ['neutral', 'success', 'error', 'warning', 'info'],
-            icon: ['none', undefined, '1001'],
+            type: ['success', 'error', 'warning', 'info'],
             dismissible: [true, false],
             hasButtons: [true, false],
           }).map(
             args => html`
               <post-banner
                 type=${args.type}
-                icon=${args.icon}
                 dismissible=${args.dismissible}
                 dismiss-label="${args.dismissible ? 'Dismiss' : undefined}"
               >

--- a/packages/documentation/src/stories/components/banner/standard-html/banner.stories.ts
+++ b/packages/documentation/src/stories/components/banner/standard-html/banner.stories.ts
@@ -24,9 +24,7 @@ const meta: MetaComponent = {
       '<p>This is the content of the banner. It helps to draw attention to critical messages.</p>',
     show: true,
     action: true,
-    noIcon: false,
-    icon: undefined,
-    type: 'banner-neutral',
+    type: 'banner-info',
     dialog: false,
     dismissible: false,
     dismissLabel: 'Dismiss',
@@ -102,43 +100,6 @@ const meta: MetaComponent = {
         category: 'Content',
       },
     },
-    noIcon: {
-      name: 'No Icon',
-      description: 'If `true`, no icon is displayed on the left side of the banner.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        category: 'Content',
-      },
-    },
-    icon: {
-      name: 'Icon',
-      description:
-        'The icon to display in the banner. By default, the icon depends on the banner type.' +
-        '<span className="mt-8 banner banner-info banner-sm">' +
-        '<span>To use a custom icon, you must first ' +
-        '<a href="/?path=/docs/40ed323b-9c1a-42ab-91ed-15f97f214608--docs">set up the icons in your project</a>' +
-        '.</span></span>',
-      if: {
-        arg: 'noIcon',
-        truthy: false,
-      },
-      control: {
-        type: 'select',
-        labels: {
-          '1001': '1001 (Envelope)',
-          '2023': '2023 (Cog)',
-          '2025': '2025 (Send)',
-          '2035': '2035 (Home)',
-          '2101': '2101 (Bubble)',
-        },
-      },
-      options: ['1001', '2023', '2025', '2035', '2101'],
-      table: {
-        category: 'Content',
-      },
-    },
     type: {
       name: 'Type',
       description: 'The type of the banner.',
@@ -146,7 +107,6 @@ const meta: MetaComponent = {
         type: 'select',
       },
       options: [
-        'banner-neutral',
         'banner-info',
         'banner-success',
         'banner-error',
@@ -172,7 +132,6 @@ function renderBanner(args: Args) {
   `;
 
   const body = html`
-    ${args.icon ? html` <post-icon name=${args.icon}></post-icon> ` : nothing}
     ${args.action ? html` <div class="banner-content">${content}</div> ` : content}
     ${args.action
       ? html`
@@ -220,18 +179,6 @@ export const AdditionalContent: Story = {
   </ul>
 <hr />
 <p>Additional content follows the separator to provide further context or instructions as needed.</p>`,
-  },
-};
-
-export const CustomIcon: Story = {
-  args: {
-    icon: '1001',
-  },
-};
-
-export const NoIcon: Story = {
-  args: {
-    noIcon: true,
   },
 };
 

--- a/packages/documentation/src/stories/components/banner/web-component/post-banner.stories.ts
+++ b/packages/documentation/src/stories/components/banner/web-component/post-banner.stories.ts
@@ -19,6 +19,7 @@ const meta: MetaComponent<HTMLPostBannerElement> = {
   },
   args: {
     innerHTML: '<p>This is the content of the banner. It helps to draw attention to critical messages.</p>',
+    type: 'info',
     dismissible: false,
     dismissLabel: 'Dismiss',
   },
@@ -31,19 +32,6 @@ const meta: MetaComponent<HTMLPostBannerElement> = {
         name: 'string',
         required: true,
       },
-    },
-    icon: {
-      control: {
-        type: 'select',
-        labels: {
-          '1001': '1001 (Envelope)',
-          '2023': '2023 (Cog)',
-          '2025': '2025 (Send)',
-          '2035': '2035 (Home)',
-          '2101': '2101 (Bubble)',
-        },
-      },
-      options: ['none', '1001', '2023', '2025', '2035', '2101'],
     },
     innerHTML: {
       description: 'Defines the HTML markup contained in the banner.',
@@ -119,18 +107,6 @@ export const Contents: Story = {
       '<p>This is the banner content that provides important information to the user.</p>' +
       '<button slot="actions" class="btn btn-secondary"><span>Cancel</span></button>' +
       '<button slot="actions" class="btn btn-primary"><span>Accept</span></button>',
-  },
-};
-
-export const CustomIcon: Story = {
-  args: {
-    icon: '1001',
-  },
-};
-
-export const NoIcon: Story = {
-  args: {
-    icon: 'none',
   },
 };
 

--- a/packages/documentation/src/stories/components/toast/toast.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/toast/toast.snapshot.stories.ts
@@ -26,7 +26,6 @@ export const Toast: Story = {
             title: ['Title', shortText],
             content: [shortText, longText],
             variant: context.argTypes.variant.options,
-            noIcon: [false, true],
             dismissible: [false, true],
           })
             .filter(

--- a/packages/documentation/src/stories/components/toast/toast.stories.ts
+++ b/packages/documentation/src/stories/components/toast/toast.stories.ts
@@ -17,9 +17,7 @@ const meta: MetaComponent = {
   args: {
     title: 'Title',
     content: 'This is a sample toast message to demonstrate the component functionality.',
-    variant: 'toast-neutral',
-    noIcon: false,
-    icon: 'null',
+    variant: 'toast-info',
     dismissible: true,
     position: 'static',
     alignV: 'bottom',
@@ -57,52 +55,13 @@ const meta: MetaComponent = {
       control: {
         type: 'radio',
         labels: {
-          'toast-neutral': 'Neutral',
           'toast-info': 'Info',
           'toast-success': 'Success',
           'toast-danger': 'Danger',
           'toast-warning': 'Warning',
         },
       },
-      options: ['toast-neutral', 'toast-info', 'toast-success', 'toast-danger', 'toast-warning'],
-      table: {
-        category: 'General',
-      },
-    },
-    noIcon: {
-      name: 'No Icon',
-      description: 'Removes the predefined icon completely.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        category: 'General',
-      },
-    },
-    icon: {
-      name: 'Icon',
-      description:
-        'Defines a custom icon.' +
-        '<span className="mt-8 banner banner-info banner-sm">' +
-        '<span>To use a custom icon, you must first ' +
-        '<a href="/?path=/docs/40ed323b-9c1a-42ab-91ed-15f97f214608--docs">set up the icons in your project</a>' +
-        '.</span></span>',
-      if: {
-        arg: 'noIcon',
-        truthy: false,
-      },
-      control: {
-        type: 'select',
-        labels: {
-          'null': 'Default',
-          '1001': 'Envelope (1001)',
-          '2023': 'Cog (2023)',
-          '2025': 'Send (2025)',
-          '2035': 'Home (2035)',
-          '2101': 'Bubble (2101)',
-        },
-      },
-      options: ['null', '1001', '2023', '2025', '2035', '2101'],
+      options: ['toast-info', 'toast-success', 'toast-danger', 'toast-warning'],
       table: {
         category: 'General',
       },
@@ -346,12 +305,6 @@ function killAutoHideTimeout(timeoutStore: ReturnType<typeof setTimeout>[], args
   }
 }
 
-function getToastIcon(args: Args) {
-  return !args.noIcon && args.icon !== 'null'
-    ? html` <post-icon aria-hidden="true" name="${args.icon}"></post-icon> `
-    : null;
-}
-
 function getDismissButton(args: Args, isFixed: boolean) {
   return args.dismissible || isFixed
     ? html` <button type="button" class="toast-close-button" aria-label="close"></button> `
@@ -371,7 +324,6 @@ function render(args: Args, context: StoryContext) {
   const classes = [
     'toast',
     args.variant,
-    args.noIcon && 'no-icon',
     (args.dismissible || isFixed) && 'toast-dismissible',
   ]
     .filter(c => c && c !== 'null')
@@ -389,8 +341,6 @@ function render(args: Args, context: StoryContext) {
     ariaLive = 'polite';
   }
 
-  const toastIcon = getToastIcon(args);
-
   const dismissButton = getDismissButton(args, isFixed);
 
   const component = html`
@@ -403,7 +353,7 @@ function render(args: Args, context: StoryContext) {
       @mouseenter="${() => killAutoHideTimeout(timeoutStore, args)}"
       @mouseleave="${() => createAutoHideTimeout(timeoutStore, args, updateArgs)}"
     >
-      ${toastIcon} ${dismissButton}
+      ${dismissButton}
       <div class="toast-title">${args.title}</div>
       ${args.content ? html` <div class="toast-message">${args.content}</div> ` : null}
     </div>

--- a/packages/styles/src/components/banner.scss
+++ b/packages/styles/src/components/banner.scss
@@ -65,11 +65,6 @@ tokens.$default-map: components.$post-banner;
       padding-inline-end: tokens.get('banner-gap') + close.$close-size;
     }
 
-    &.no-icon > .banner-content,
-    &.no-icon > .alert-content {
-      padding-inline-start: 0;
-    }
-
     > .banner-buttons,
     > .alert-buttons {
       display: flex;

--- a/packages/styles/src/mixins/_notification.scss
+++ b/packages/styles/src/mixins/_notification.scss
@@ -35,7 +35,7 @@ tokens.$default-map: components.$post-banner;
   position: relative;
   color: var(--post-current-fg);
 
-  // Set the neutral notification as the default color
+  // Set the info notification as the default color
   @include notification-variant(
     list.nth($default-var, 2),
     list.nth($default-var, 3),
@@ -49,26 +49,12 @@ tokens.$default-map: components.$post-banner;
     display: block;
   }
 
-  &::before,
-  > post-icon {
+  &::before {
     position: absolute;
     height: $icon-size;
     width: $icon-size;
     left: $padding-x;
     top: $padding-y;
-  }
-
-  &.no-icon {
-    min-height: calc(2 * $padding-y + close.$close-size);
-    padding-inline-start: $padding-x;
-
-    &::before {
-      content: unset;
-    }
-
-    > post-icon {
-      display: none;
-    }
   }
 
   @include utilities-mx.high-contrast-mode {
@@ -106,25 +92,13 @@ tokens.$default-map: components.$post-banner;
   border-color: $border-color;
   color-scheme: $scheme;
 
-  // default icon (mask-image)
-  &:not(.no-icon)::before {
+  &::before {
     @include icons-mx.icon($icon);
     color: $icon-color;
 
     @include utilities-mx.high-contrast-mode {
       color: CanvasText;
     }
-  }
-
-  // Prevent flashing when using post-icon
-  &:has(> post-icon)::before {
-    content: none;
-  }
-
-  // icon override (post-icon), needed when :has is not supported
-  > post-icon {
-    background-color: $color;
-    color: $icon-color;
   }
 }
 

--- a/packages/styles/src/variables/components/_notification.scss
+++ b/packages/styles/src/variables/components/_notification.scss
@@ -67,23 +67,17 @@ $notification-icon-size-map: map.merge(
   )
 );
 
-//TODO: Note that primary, and gray have been deleted (.banner by default is now neutral) and that danger is back to error
 $notification-variants: () !default;
 $notification-variants: list.join(
   $notification-variants,
   (
-    'neutral' tokens.get('banner-neutral-bg') 2201 tokens.get('banner-neutral-border-color')
-      tokens.get('banner-neutral-icon-color') tokens.get('post-banner-neutral-bg-scheme'),
+    'info' tokens.get('banner-info-bg') 2106 tokens.get('banner-info-border-color')
+      tokens.get('banner-info-icon-color') tokens.get('post-banner-info-bg-scheme'),
     'success' tokens.get('banner-success-bg') 2105 tokens.get('banner-success-border-color')
       tokens.get('banner-success-icon-color') tokens.get('post-banner-success-bg-scheme'),
     'warning' tokens.get('banner-warning-bg') 2104 tokens.get('banner-warning-border-color')
       tokens.get('banner-warning-icon-color') tokens.get('post-banner-warning-bg-scheme'),
     'error' tokens.get('banner-error-bg') 2104 tokens.get('banner-error-border-color')
-      tokens.get('banner-error-icon-color') tokens.get('post-banner-error-bg-scheme'),
-    'info' tokens.get('banner-info-bg') 2106 tokens.get('banner-info-border-color')
-      tokens.get('banner-info-icon-color') tokens.get('post-banner-info-bg-scheme'),
-    // duplicate
-    'danger' tokens.get('banner-error-bg') 2104 tokens.get('banner-error-border-color')
       tokens.get('banner-error-icon-color') tokens.get('post-banner-error-bg-scheme')
   )
 );


### PR DESCRIPTION
## 📄 Description

Following recent design changes, the neutral banners and toasts are no longer available. It is also no longer possible to customize the banner and toast icons.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
