### PR TITLE
fix: update v9 icon branch name

### DIFF
--- a/.github/workflows/fetch-icons-v9.yaml
+++ b/.github/workflows/fetch-icons-v9.yaml
@@ -53,7 +53,7 @@ jobs:
           git checkout -b $BRANCH_NAME origin/release/v9
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
         env:
-          BRANCH_NAME: v9/${{ steps.current-date.outputs.date }}-update-icons
+          BRANCH_NAME: ${{ steps.current-date.outputs.date }}-update-icons-v9
 
       - name: Install icons & dependencies
         run: pnpm --filter design-system-icons... --filter design-system-styles... install


### PR DESCRIPTION
## 📄 Description

This PR fixes the workflow that fetches the icons for the `release/v9` branch.
The branch name is also used as a name for the changeset file therefore it cannot contain a `/` character.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
