### PR TITLE
chore(docs): POC full width stories

### DIFF
--- a/packages/documentation/.storybook/blocks/layout/layout.tsx
+++ b/packages/documentation/.storybook/blocks/layout/layout.tsx
@@ -18,7 +18,7 @@ export default (props: PropsWithChildren<DocsContainerProps>) => {
   const { children, context } = props;
   const container =
     context.channel.data.docsPrepared[0].parameters.layout === 'fullscreen'
-      ? 'container-fluid'
+      ? 'container custom-container'
       : 'container';
   const pathToStoryFile = context?.storyIdToCSFFile?.values()?.next()?.value?.meta
     ?.parameters?.fileName;

--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -309,6 +309,14 @@ $monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier
   overflow-x: hidden;
 }
 
+@include media.min(xl) {
+  .custom-container {
+    .sbdocs-preview {
+      margin-inline: calc(-1 * ((100vw - var(--post-container-max-width)) / 2));
+    }
+  }
+}
+
 .sbdocs-preview {
   &:not([data-color-scheme]) {
     display: none;


### PR DESCRIPTION
## 📄 Description

POC to show what full width stories would look like on docs that are within a `container`.