### PR TITLE
feat(eslint): add automigration rules to update `h-visibilityhidden` and `h-clearfix` to their new equivalent

### DIFF
--- a/.changeset/cruel-hands-listen.md
+++ b/.changeset/cruel-hands-listen.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-eslint': minor
+---
+
+Added the automigration rule to update the HTML class `h-visibilityhidden` to `visibility-hidden`.

--- a/.changeset/tasty-radios-think.md
+++ b/.changeset/tasty-radios-think.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-eslint': minor
+---
+
+Added the automigration rule to update the HTML class `h-clearfix` to `clearfix`.

--- a/packages/eslint/docs/rules/html/migrations/no-class-h-clearfix.md
+++ b/packages/eslint/docs/rules/html/migrations/no-class-h-clearfix.md
@@ -1,0 +1,30 @@
+# `no-class-h-clearfix`
+
+Flags deprecated `h-clearfix` class and suggests removal or replacement with `clearfix`.
+
+- Type: suggestion
+- 🔧 Supports autofix (--fix)
+
+## Rule Options
+
+This rule does not have any configuration options.
+
+## Example
+
+### ❌ Invalid Code
+
+```html
+<div class="h-clearfix">Content</div>
+```
+
+### ✅ Valid Code
+
+```html
+<button class="clearfix">Content</button>
+```
+
+Or simply remove the `h-clearfix` class:
+
+```html
+<div>Content</div>
+```

--- a/packages/eslint/docs/rules/html/migrations/no-class-h-visuallyhidden.md
+++ b/packages/eslint/docs/rules/html/migrations/no-class-h-visuallyhidden.md
@@ -1,0 +1,30 @@
+# `no-class-h-visuallyhidden`
+
+Flags deprecated `h-visuallyhidden` class and suggests removal or replacement with `visually-hidden`.
+
+- Type: suggestion
+- 🔧 Supports autofix (--fix)
+
+## Rule Options
+
+This rule does not have any configuration options.
+
+## Example
+
+### ❌ Invalid Code
+
+```html
+<div class="h-visuallyhidden">Invisible text</div>
+```
+
+### ✅ Valid Code
+
+```html
+<button class="visually-hidden">Invisible text</button>
+```
+
+Or simply remove the `h-visuallyhidden` class:
+
+```html
+<div>Visible text</div>
+```

--- a/packages/eslint/src/rules/html/migrations/no-class-h-clearfix.ts
+++ b/packages/eslint/src/rules/html/migrations/no-class-h-clearfix.ts
@@ -1,0 +1,42 @@
+import { createRule } from '../../../utils/create-rule';
+import { HtmlNode } from '../../../parsers/html/html-node';
+
+export const name = 'no-class-h-clearfix';
+
+// Type: RuleModule<"uppercase", ...>
+export default createRule({
+  name,
+  meta: {
+    docs: {
+      dir: 'html',
+      description:
+        'Flags deprecated "h-clearfix" class and suggests removal or replacement with "clearfix".',
+    },
+    messages: {
+      noClassHClearfix:
+        'The "h-clearfix" class is deprecated. Please remove it or replace it with "clearfix".',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      tag(node: HtmlNode) {
+        const $node = node.toCheerio();
+
+        if ($node.hasClass('h-clearfix')) {
+          context.report({
+            messageId: 'noClassHClearfix',
+            loc: node.loc,
+            fix(fixer) {
+              const fixedNode = $node.removeClass('h-clearfix').addClass('clearfix');
+              return fixer.replaceTextRange(node.range, fixedNode.toString());
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint/src/rules/html/migrations/no-class-h-visuallyhidden.ts
+++ b/packages/eslint/src/rules/html/migrations/no-class-h-visuallyhidden.ts
@@ -1,0 +1,42 @@
+import { createRule } from '../../../utils/create-rule';
+import { HtmlNode } from '../../../parsers/html/html-node';
+
+export const name = 'no-class-h-visuallyhidden';
+
+// Type: RuleModule<"uppercase", ...>
+export default createRule({
+  name,
+  meta: {
+    docs: {
+      dir: 'html',
+      description:
+        'Flags deprecated "h-visuallyhidden" class and suggests removal or replacement with "visually-hidden".',
+    },
+    messages: {
+      noClassHVisuallyhidden:
+        'The "h-visuallyhidden" class is deprecated. Please remove it or replace it with "visually-hidden".',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      tag(node: HtmlNode) {
+        const $node = node.toCheerio();
+
+        if ($node.hasClass('h-visuallyhidden')) {
+          context.report({
+            messageId: 'noClassHVisuallyhidden',
+            loc: node.loc,
+            fix(fixer) {
+              const fixedNode = $node.removeClass('h-visuallyhidden').addClass('visually-hidden');
+              return fixer.replaceTextRange(node.range, fixedNode.toString());
+            },
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint/test/rules/html/migrations/no-class-h-clearfix.spec.ts
+++ b/packages/eslint/test/rules/html/migrations/no-class-h-clearfix.spec.ts
@@ -1,0 +1,17 @@
+import rule, { name } from '../../../../src/rules/html/migrations/no-class-h-clearfix';
+import { htmlRuleTester } from '../../../utils/html-rule-tester';
+
+htmlRuleTester.run(name, rule, {
+  valid: [
+    {
+      code: '<div class="clearfix">Content</div>',
+    },
+  ],
+  invalid: [
+    {
+      code: '<div class="h-clearfix">Content</div>',
+      output: '<div class="clearfix">Content</div>',
+      errors: [{ messageId: 'noClassHClearfix' }],
+    },
+  ],
+});

--- a/packages/eslint/test/rules/html/migrations/no-class-h-visuallyhidden.spec.ts
+++ b/packages/eslint/test/rules/html/migrations/no-class-h-visuallyhidden.spec.ts
@@ -1,0 +1,17 @@
+import rule, { name } from '../../../../src/rules/html/migrations/no-class-h-visuallyhidden';
+import { htmlRuleTester } from '../../../utils/html-rule-tester';
+
+htmlRuleTester.run(name, rule, {
+  valid: [
+    {
+      code: '<div class="visually-hidden">Invisible text</div>',
+    },
+  ],
+  invalid: [
+    {
+      code: '<div class="h-visuallyhidden">Invisible text</div>',
+      output: '<div class="visually-hidden">Invisible text</div>',
+      errors: [{ messageId: 'noClassHVisuallyhidden' }],
+    },
+  ],
+});


### PR DESCRIPTION
## 📄 Description

Adds two migration rules to update `h-visibilityhidden` to `visibility-hidden` and `h-clearfix` to `clearfix`.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
