### PR TITLE
chore(docs): add EOL banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
   "engines": {
     "node": ">=16",
     "pnpm": ">=7.13"
-  }
+  },
+  "packageManager": "pnpm@7.13.6"
 }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "start-server-and-test": "1.15.4"
   },
   "engines": {
-    "node": ">=16",
+    "node": "16",
     "pnpm": ">=7.13"
   },
   "packageManager": "pnpm@7.13.6"

--- a/packages/documentation/.storybook/components/docs/header.tsx
+++ b/packages/documentation/.storybook/components/docs/header.tsx
@@ -1,13 +1,24 @@
 import React from "react";
 
 export default () => (
-  <header className="docs-header bg-yellow">
-    <div className="container py-5">
-      <h1 className="mt-0 bold font-curve-large">Swiss Post<br/>Design System</h1>
-      <p>
-        The Swiss Post Design System pattern library for a unified and accessible user experience
-        across the web platform.
-      </p>
+  <>
+    <div className="docs-eol">
+      <div className="container text-center py-4">
+        <p className="mb-0">
+          This version is no longer actively maintained and has reached{' '}
+          <span className="fw-bold">End-of-Life (EOL)</span>. For new and ongoing projects, please
+          refer to the <a href="https://design-system.post.ch/">latest Design System version</a>.
+        </p>
+      </div>
     </div>
-  </header>
+    <header className="docs-header bg-yellow">
+      <div className="container py-5">
+        <h1 className="mt-0 bold font-curve-large">Swiss Post<br/>Design System</h1>
+        <p>
+          The Swiss Post Design System pattern library for a unified and accessible user experience
+          across the web platform.
+        </p>
+      </div>
+    </header>
+  </>
 );

--- a/packages/documentation/.storybook/components/docs/layout.scss
+++ b/packages/documentation/.storybook/components/docs/layout.scss
@@ -1,5 +1,12 @@
 @use '@swisspost/design-system-styles/core' as post;
 
+.docs-eol {
+  background-color: post.$warning;
+  font-size: 1rem;
+  margin-bottom: 4rem;
+  margin-top: -4rem;
+}
+
 .docs-header {
   margin-top: -4rem;
   background-image: url('../../../public/images/header.png');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13251,7 +13251,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
     requiresBuild: true
     dependencies:
       bindings: 1.5.0


### PR DESCRIPTION
## 📄 Description

Added a EOL banner on v5's design system documentation

## 🚀 Demo

<img width="1308" height="922" alt="Capture d'écran 2025-09-02 113701" src="https://github.com/user-attachments/assets/45d8b60a-f901-4af2-8ed1-d20275ba5b9d" />
