### PR TITLE
fix(accordion): enforce top border for all accordions

### DIFF
--- a/.changeset/fast-frogs-pump.md
+++ b/.changeset/fast-frogs-pump.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed accordion to always show top border on all items.

--- a/packages/components/src/components/post-accordion-item/post-accordion-item.scss
+++ b/packages/components/src/components/post-accordion-item/post-accordion-item.scss
@@ -59,8 +59,7 @@ tokens.$default-map: components.$post-accordion;
     inset: 0;
     inset-block-end: auto;
 
-    // if needed the border can be added or removed by setting the custom property respectively to "unset" or "0"
-    border-block-start-width: var(--post-accordion-button-border-top-width, #{tokens.get('accordion-group-border-top-width')});
+    border-block-start-width: tokens.get('accordion-group-border-top-width');
     border-block-start-style: tokens.get('accordion-border-top-style');
     border-block-start-color: tokens.get('accordion-enabled-border');
   }

--- a/packages/components/src/components/post-footer/post-footer.scss
+++ b/packages/components/src/components/post-footer/post-footer.scss
@@ -156,15 +156,3 @@ footer {
   display: none;
 }
 
-post-accordion-item {
-  // make sure the first visible accordion item has a border top
-  &.d-none + & {
-    --post-accordion-button-border-top-width: unset;
-  }
-
-  // remove the border top if the accordion item is not the first visible or if it is the only visible
-  &:not(.d-none) ~ &,
-  &:not(&:not(.d-none) ~ *):not(:has(~ #{&}:not(.d-none))) {
-    --post-accordion-button-border-top-width: 0;
-  }
-}


### PR DESCRIPTION
## 📄 Description

Made sure even a single accordion item always shows a top border.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
