### PR TITLE
chore(component): remove unnecessary event in the post-closebutton

### DIFF
--- a/.changeset/spicy-radios-behave.md
+++ b/.changeset/spicy-radios-behave.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Added accessibility checks to the `post-closebutton` component.

--- a/.changeset/spicy-radios-behave.md
+++ b/.changeset/spicy-radios-behave.md
@@ -1,5 +1,0 @@
----
-'@swisspost/design-system-components': minor
----
-
-Added a `postClick` event and accessibility checks to the `post-closebutton` component.

--- a/packages/components/eslint.config.js
+++ b/packages/components/eslint.config.js
@@ -96,6 +96,7 @@ export default [
       'semi': ['error', 'always'],
       'react/jsx-no-bind': 'off',
       '@stencil-community/strict-boolean-conditions': 'off',
+      '@stencil-community/prefer-vdom-listener': 'off',
       '@stencil-community/required-prefix': ['error', ['post-']],
       '@stencil-community/class-pattern': [
         'error',

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -640,7 +640,7 @@ declare global {
         new (): HTMLPostCardControlElement;
     };
     interface HTMLPostClosebuttonElementEventMap {
-        "postClick": void;
+        "click": void;
     }
     interface HTMLPostClosebuttonElement extends Components.PostClosebutton, HTMLStencilElement {
         addEventListener<K extends keyof HTMLPostClosebuttonElementEventMap>(type: K, listener: (this: HTMLPostClosebuttonElement, ev: PostClosebuttonCustomEvent<HTMLPostClosebuttonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1063,7 +1063,7 @@ declare namespace LocalJSX {
         /**
           * An event emitted when the close button is clicked. It has no payload.
          */
-        "onPostClick"?: (event: PostClosebuttonCustomEvent<void>) => void;
+        "onclick"?: (event: PostClosebuttonCustomEvent<void>) => void;
     }
     interface PostCollapsible {
         /**

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -532,10 +532,6 @@ export interface PostCardControlCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPostCardControlElement;
 }
-export interface PostClosebuttonCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLPostClosebuttonElement;
-}
 export interface PostCollapsibleCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPostCollapsibleElement;
@@ -639,18 +635,7 @@ declare global {
         prototype: HTMLPostCardControlElement;
         new (): HTMLPostCardControlElement;
     };
-    interface HTMLPostClosebuttonElementEventMap {
-        "click": void;
-    }
     interface HTMLPostClosebuttonElement extends Components.PostClosebutton, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLPostClosebuttonElementEventMap>(type: K, listener: (this: HTMLPostClosebuttonElement, ev: PostClosebuttonCustomEvent<HTMLPostClosebuttonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLPostClosebuttonElementEventMap>(type: K, listener: (this: HTMLPostClosebuttonElement, ev: PostClosebuttonCustomEvent<HTMLPostClosebuttonElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLPostClosebuttonElement: {
         prototype: HTMLPostClosebuttonElement;
@@ -1060,10 +1045,6 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface PostClosebutton {
-        /**
-          * An event emitted when the close button is clicked. It has no payload.
-         */
-        "onclick"?: (event: PostClosebuttonCustomEvent<void>) => void;
     }
     interface PostCollapsible {
         /**

--- a/packages/components/src/components/post-banner/post-banner.tsx
+++ b/packages/components/src/components/post-banner/post-banner.tsx
@@ -77,7 +77,7 @@ export class PostBanner {
     this.postDismissed.emit();
   }
 
-  @Listen('postClick')
+  @Listen('click')
   @EventFrom('post-closebutton')
   onCloseButtonClick(): void {
     void this.dismiss();

--- a/packages/components/src/components/post-closebutton/post-closebutton.tsx
+++ b/packages/components/src/components/post-closebutton/post-closebutton.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Host } from '@stencil/core';
+import { Component, Element, h, Host } from '@stencil/core';
 import { version } from '@root/package.json';
 
 /**
@@ -11,12 +11,6 @@ import { version } from '@root/package.json';
 })
 export class PostClosebutton {
   @Element() host: HTMLPostClosebuttonElement;
-
-  /**
-   * An event emitted when the close button is clicked.
-   * It has no payload.
-   */
-  @Event() postClick: EventEmitter<void>;
 
   componentDidLoad() {
     this.checkHiddenLabel();
@@ -31,7 +25,7 @@ export class PostClosebutton {
   render() {
     return (
       <Host data-version={version}>
-        <button class="btn btn-icon-close" type="button" onClick={() => this.postClick.emit()}>
+        <button class="btn btn-icon-close" type="button">
           <post-icon aria-hidden="true" name="closex"></post-icon>
           <span class="visually-hidden">
             <slot onSlotchange={() => this.checkHiddenLabel()}></slot>

--- a/packages/components/src/components/post-closebutton/readme.md
+++ b/packages/components/src/components/post-closebutton/readme.md
@@ -5,13 +5,6 @@
 <!-- Auto Generated Below -->
 
 
-## Events
-
-| Event       | Description                                                           | Type                |
-| ----------- | --------------------------------------------------------------------- | ------------------- |
-| `click` | An event emitted when the close button is clicked. It has no payload. | `CustomEvent<void>` |
-
-
 ## Slots
 
 | Slot        | Description                                                 |

--- a/packages/components/src/components/post-closebutton/readme.md
+++ b/packages/components/src/components/post-closebutton/readme.md
@@ -9,7 +9,7 @@
 
 | Event       | Description                                                           | Type                |
 | ----------- | --------------------------------------------------------------------- | ------------------- |
-| `postClick` | An event emitted when the close button is clicked. It has no payload. | `CustomEvent<void>` |
+| `click` | An event emitted when the close button is clicked. It has no payload. | `CustomEvent<void>` |
 
 
 ## Slots


### PR DESCRIPTION
## 📄 Description
Remove the `postCLick` event since we con simply use `click`.
This event is not yet released this I simply updated the related changeset file.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
