### PR TITLE
fix(components): update `post-tooltip` arrow placement

### DIFF
--- a/.changeset/some-banks-end.md
+++ b/.changeset/some-banks-end.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Updated the arrow placement of the `<post-tooltip>` to fix the layout issue.

--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.tsx
@@ -252,7 +252,7 @@ export class PostPopovercontainer {
         Object.assign(this.arrowRef.style, {
           left: arrowX ? `${arrowX}px` : '',
           top: arrowY ? `${arrowY}px` : '',
-          [staticSide]: '-7px',
+          [staticSide]: '-5px',
         });
       }
     }


### PR DESCRIPTION
## 📄 Description

Updated the staticSide on the arrow as its placement was wrongly calculated.