### PR TITLE
fix(docs): removed nested heading markup in dialog header (#6149)

### DIFF
--- a/.changeset/fine-berries-burn.md
+++ b/.changeset/fine-berries-burn.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Corrected nested heading in the dialog main example.

--- a/packages/documentation/src/stories/components/dialog/dialog.stories.ts
+++ b/packages/documentation/src/stories/components/dialog/dialog.stories.ts
@@ -113,10 +113,6 @@ const meta: Meta = {
 
 export default meta;
 
-const getHeader = (text: string) => {
-  return html`<h2>${text}</h2>`;
-};
-
 const getCloseButton = () => {
   return html`<button class="btn btn-close">
     <span class="visually-hidden">Close</span>
@@ -130,9 +126,6 @@ const getControls = () => {
 
 const Template = {
   render: (args: Args) => {
-    const header = getHeader(args.title);
-    const body = html`${args.content}`;
-    const controls = getControls();
     const postDialogIcon =
       args.icon && args.icon !== 'none'
         ? html`<post-icon name="${args.icon}"></post-icon>`
@@ -155,9 +148,9 @@ const Template = {
       >
         <form method="dialog" class="dialog-grid">
           ${postDialogIcon}
-          <h3 class="dialog-header">${header}</h3>
-          <div class="dialog-body">${body}</div>
-          <div class="dialog-controls">${controls}</div>
+          <h3 class="dialog-header">${args.title}</h3>
+          <div class="dialog-body">${args.content}</div>
+          <div class="dialog-controls">${getControls()}</div>
           ${postDialogCloseButton}
         </form>
       </dialog>


### PR DESCRIPTION
## 📄 Description

Removed the nested `h2` heading markup within the dialog header (Cherry-pick from #6149)