### PR TITLE
fix(docs): improve the copy deep link functionality

### DIFF
--- a/.changeset/empty-pants-brake.md
+++ b/.changeset/empty-pants-brake.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed the "Copy deep link" feature so that the full URL is now copied correctly.

--- a/packages/documentation/.storybook/helpers/open-full-screen-demo.ts
+++ b/packages/documentation/.storybook/helpers/open-full-screen-demo.ts
@@ -23,7 +23,7 @@ export const fullScreenUrlDecorator = (story: StoryFn, context: StoryContext) =>
   let linkConfigBaseURL = `/?path=/docs/${id.split('--')[0]}--docs&story=${context.story}`;
 
   if (args.length) linkConfigBaseURL += `&args=${args}`;
-  const linkConfigURL = window.location.host + linkConfigBaseURL.replace(':!', ':') + '#' + id;
+  const linkConfigURL = window.location.origin + linkConfigBaseURL.replace(':!', ':') + '#' + id;
 
   return html`
     <p class="linkConfigURL" hidden>${linkConfigURL}</p>


### PR DESCRIPTION
## 📄 Description

The "Copy deep link" button now copies the full URL, including `https://`.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
