### PR TITLE
chore(docs): add migration info regarding line height utility

### DIFF
--- a/.changeset/spotty-trees-allow.md
+++ b/.changeset/spotty-trees-allow.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added information in the migration guide regarding the removal of the line height utility classes.

--- a/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
+++ b/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
@@ -465,7 +465,7 @@ export class MigrationV99Component extends LitElement {
                 </li>
                 <li class="mb-16">
                   <p>
-                    Removed deprecated line-height variables
+                    Removed deprecated line-height SCSS variables and CSS classes
                     <span class="tag tag-sm tag-danger">breaking</span>
                   </p>
                   <ul>
@@ -481,7 +481,28 @@ export class MigrationV99Component extends LitElement {
                     <li><code>$line-height-bigger-big</code></li>
                     <li><code>$line-height-small-huge</code></li>
                     <li><code>$line-height-huge</code></li>
+                    <li><code>.lh-base</code></li>
+                    <li><code>.lh-hair</code></li>
+                    <li><code>.lh-line</code></li>
+                    <li><code>.lh-micro</code></li>
+                    <li><code>.lh-mini</code></li>
+                    <li><code>.lh-small-regular</code></li>
+                    <li><code>.lh-regular</code></li>
+                    <li><code>.lh-small-large</code></li>
+                    <li><code>.lh-large</code></li>
+                    <li><code>.lh-big</code></li>
+                    <li><code>.lh-bigger-big</code></li>
+                    <li><code>.lh-small-huge</code></li>
+                    <li><code>.lh-huge</code></li>
+                    <li><code>.lh-small-giant</code></li>
+                    <li><code>.lh-giant</code></li>
+                    <li><code>.lh-bigger-giant</code></li>
                   </ul>
+                  <p class="info">
+                    You can now use the following classes: <code>.lh-1</code>, <code>.lh-sm</code> and <code>.lh-lg</code> which are documented in the <a href="/?path=/docs/c55681df-4d21-469d-a5b3-c67686e7c104--docs"
+                      >text utilities</a
+                    >.
+                  </p>
                 </li>
                 <li class="mb-16">
                   <p>
@@ -546,12 +567,6 @@ export class MigrationV99Component extends LitElement {
                     The line height is now set to a default value for both paragraph elements and
                     headings. If a different value is needed, we recommend using the line height
                     text utility classes.
-                  </p>
-                </li>
-                <li class="mb-16">
-                  <p>
-                    The <code>.lh-base</code> class has been removed
-                    <span class="tag tag-sm tag-danger">breaking</span>
                   </p>
                 </li>
                 <li class="mb-16">


### PR DESCRIPTION
## 📄 Description

Added information regarding the removal of the line height classes in the migration guide.