### PR TITLE
fix(components): update automatic readme of `post-accordion-item`

### DIFF
--- a/packages/components/src/components/post-accordion-item/readme.md
+++ b/packages/components/src/components/post-accordion-item/readme.md
@@ -34,11 +34,11 @@ Type: `Promise<boolean>`
 
 ## Slots
 
-| Slot        | Description                                                         |
-| ----------- | ------------------------------------------------------------------- |
-| `"default"` | Slot for placing content within the accordion item's body.          |
-| `"header"`  | Slot for placing custom content within the accordion item's header. |
-| `"logo"`    | Slot for placing a logo before the header.                          |
+| Slot        | Description                                                                 |
+| ----------- | --------------------------------------------------------------------------- |
+| `"default"` | Slot for placing content within the accordion item's body.                  |
+| `"header"`  | Slot for placing custom content within the accordion item's header.         |
+| `"logo"`    | Slot for placing a logo in the accordion item’s header, before the content. |
 
 
 ## Shadow Parts


### PR DESCRIPTION
## 📄 Description

In the last merged PR which changed some content in the `post-accordion-item`, the automatically updated readme was not added to the PR.