### PR TITLE
feat(components): add part `button` in the `post-accordion-item` component

### DIFF
--- a/.changeset/giant-poets-exist.md
+++ b/.changeset/giant-poets-exist.md
@@ -1,0 +1,5 @@
+---
+"@swisspost/design-system-components": minor
+---
+
+Added a `part="button"` attribute to `post-accordion-item` to enable custom styling of the accordion header button.

--- a/.changeset/giant-poets-exist.md
+++ b/.changeset/giant-poets-exist.md
@@ -1,5 +1,7 @@
 ---
 "@swisspost/design-system-components": minor
+"@swisspost/design-system-components-angular": minor
+"@swisspost/design-system-components-react": minor
 ---
 
-Added a `part="button"` attribute to `post-accordion-item` to enable custom styling of the accordion header button.
+Added a `button` part to the `post-accordion-item` component to enable custom styling of the accordion header button.

--- a/packages/components/src/components/post-accordion-item/post-accordion-item.tsx
+++ b/packages/components/src/components/post-accordion-item/post-accordion-item.tsx
@@ -4,6 +4,7 @@ import { HEADING_LEVELS, HeadingLevel } from '@/types';
 import { checkEmptyOrOneOf } from '@/utils';
 
 /**
+ * @part button - The element that toggles the accordion item (header button).
  * @part accordion-item - The container element that wraps the entire accordion item.
  * @part body - The container element that holds the accordion item's content.
  * @slot header - Slot for placing custom content within the accordion item's header.
@@ -77,7 +78,11 @@ export class PostAccordionItem {
         <div part="accordion-item" class="accordion-item">
           <post-collapsible-trigger for={`${this.id}--collapse`}>
             <HeadingTag class="accordion-header" id={`${this.id}--header`}>
-              <button type="button" class={`accordion-button${this.collapsed ? ' collapsed' : ''}`}>
+              <button
+                type="button"
+                class={`accordion-button${this.collapsed ? ' collapsed' : ''}`}
+                part="button"
+              >
                 <slot name="header" />
               </button>
             </HeadingTag>

--- a/packages/components/src/components/post-accordion-item/readme.md
+++ b/packages/components/src/components/post-accordion-item/readme.md
@@ -46,6 +46,7 @@ Type: `Promise<boolean>`
 | ------------------ | -------------------------------------------------------------- |
 | `"accordion-item"` | The container element that wraps the entire accordion item.    |
 | `"body"`           | The container element that holds the accordion item's content. |
+| `"button"`         | The element that toggles the accordion item (header button).   |
 
 
 ## Dependencies


### PR DESCRIPTION
## 📄 Description

This PR adds a "button" part for the accordion items header button, as already implemented in our "next" version.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- ✔️ New and existing unit tests pass locally with my changes
