### PR TITLE
feat(eslint): automigration rules for the loader

### DIFF
--- a/.changeset/large-dragons-find.md
+++ b/.changeset/large-dragons-find.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added information in the migration guide regarding auto migration for the loader.

--- a/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
+++ b/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
@@ -608,7 +608,7 @@ export class MigrationV99Component extends LitElement {
                 <li class="mb-16">
                   <p>
                     The following spinner classes have been renamed
-                    <span class="tag tag-sm tag-danger">breaking</span>
+                    <span class="tag tag-sm tag-danger">breaking</span> <span class="tag tag-sm tag-info">🪄 migration rule</span>
                   </p>
                   <ul>
                     <li><code>.loading-modal</code> is now <code>.spinner-modal</code></li>

--- a/packages/eslint/docs/rules/html/migrations/no-deprecated-loader.md
+++ b/packages/eslint/docs/rules/html/migrations/no-deprecated-loader.md
@@ -1,9 +1,9 @@
 # `no-deprecated-loader`
 
-Flags deprecated `loader-xs` and `loader-sm` classes and replaces them with `loader-16` and `loader-40` respectively.
+Flags deprecated `loader` and `loader-*` classes and replace them with `spinner` and `spinner-*` classes. Sizes `loader-xs` and `loader-sm` are being replaced with `spinner-16` and `spinner-40` respectively.
+
 - Type: problem
 - 🔧 Supports autofix (--fix)
-
 
 ## Rule Options
 
@@ -22,7 +22,7 @@ This rule does not have any configuration options.
 ### ✅ Valid Code
 
 ```html
-<div role="status" aria-live="polite" class="loader loader-16">
+<div role="status" aria-live="polite" class="spinner spinner-16">
   <span class="visually-hidden">Loading…</span>
 </div>
 ```

--- a/packages/eslint/src/rules/html/migrations/no-deprecated-loader.ts
+++ b/packages/eslint/src/rules/html/migrations/no-deprecated-loader.ts
@@ -1,56 +1,29 @@
-import { createRule } from '../../../utils/create-rule';
-import { HtmlNode } from '../../../parsers/html/html-node';
+import { createClassUpdateRule } from '../../../utils/create-class-update-rule';
+import { generateReplacedClassMutations } from '../../../utils/generate-mutations';
+import { generateReplacedClassMessages } from '../../../utils/generate-messages';
 
 export const name = 'no-deprecated-loader';
 
-// Type: RuleModule<"uppercase", ...>
-export default createRule({
+const classesMap = [
+  { old: 'loader', new: 'spinner' },
+  { old: 'loading-modal', new: 'spinner-modal' },
+  { old: 'loader-xs', new: 'spinner-16' },
+  { old: 'loader-sm', new: 'spinner-40' },
+  { old: 'loader-12', new: 'spinner-12' },
+  { old: 'loader-16', new: 'spinner-16' },
+  { old: 'loader-24', new: 'spinner-24' },
+  { old: 'loader-32', new: 'spinner-32' },
+  { old: 'loader-40', new: 'spinner-40' },
+  { old: 'loader-48', new: 'spinner-48' },
+  { old: 'loader-80', new: 'spinner-80' },
+];
+
+export const data = generateReplacedClassMutations(classesMap);
+
+export default createClassUpdateRule({
   name,
-  meta: {
-    docs: {
-      dir: 'html',
-      description:
-        'Flags deprecated "loader-xs" and "loader-sm" classes and replaces them with "loader-16" and "loader-40" respectively.',
-    },
-    messages: {
-      deprecatedLoaderXS:
-        'The "loader-xs" class is deprecated. Please replace it with "loader-16".',
-      deprecatedLoaderSM:
-        'The "loader-sm" class is deprecated. Please replace it with "loader-40".',
-    },
-    type: 'problem',
-    fixable: 'code',
-    schema: [],
-  },
-  defaultOptions: [],
-  create(context) {
-    return {
-      tag(node: HtmlNode) {
-        const $node = node.toCheerio();
-
-        if ($node.hasClass('loader-xs')) {
-          context.report({
-            messageId: 'deprecatedLoaderXS',
-            loc: node.loc,
-            fix(fixer) {
-              const fixedNode = $node.removeClass('loader-xs').addClass('loader-16');
-              return fixer.replaceTextRange(node.range, fixedNode.toString());
-            },
-          });
-        }
-
-        if ($node.hasClass('loader-sm')) {
-          context.report({
-            messageId: 'deprecatedLoaderSM',
-            loc: node.loc,
-            fix(fixer) {
-              const fixedNode = $node.removeClass('loader-sm').addClass('loader-40');
-              return fixer.replaceTextRange(node.range, fixedNode.toString());
-            },
-          });
-        }
-
-      },
-    };
-  },
+  type: 'problem',
+  description: 'Flags deprecated "loader-*" classes and replace them with "spinner-*" classes.',
+  messages: generateReplacedClassMessages(classesMap),
+  mutations: data,
 });

--- a/packages/eslint/src/utils/generate-messages.ts
+++ b/packages/eslint/src/utils/generate-messages.ts
@@ -1,0 +1,11 @@
+export function generateReplacedClassMessages(
+  classesMap: Array<{ old: string; new: string }>,
+): Record<string, string> {
+  return classesMap.reduce(
+    (o, key) =>
+      Object.assign(o, {
+        [key.old]: `The "${key.old}" class has been deleted. Please remove it or replace it with "${key.new}".`,
+      }),
+    {},
+  );
+}

--- a/packages/eslint/src/utils/generate-mutations.ts
+++ b/packages/eslint/src/utils/generate-mutations.ts
@@ -1,0 +1,11 @@
+export function generateReplacedClassMutations(
+  classesMap: Array<{ old: string; new: string }>,
+): Record<string, [string, string]> {
+  return classesMap.reduce(
+    (o, key) =>
+      Object.assign(o, {
+        [key.old]: [key.old, key.new],
+      }),
+    {},
+  );
+}

--- a/packages/eslint/test/rules/html/migrations/no-deprecated-loader.spec.ts
+++ b/packages/eslint/test/rules/html/migrations/no-deprecated-loader.spec.ts
@@ -1,49 +1,6 @@
-import rule, { name } from '../../../../src/rules/html/migrations/no-deprecated-loader';
-import { htmlRuleTester } from '../../../utils/html-rule-tester';
+import rule, { data, name } from '../../../../src/rules/html/migrations/no-deprecated-loader';
+import { generatedDataTester } from '../../../utils/generated-data-tester';
 
-htmlRuleTester.run(name, rule, {
-  valid: [
-    {
-      code: `
-        <div role="status" aria-live="polite" class="loader">
-          <span class="visually-hidden">Loading…</span>
-        </div>
-      `,
-    },
-    {
-      code: `
-        <div role="status" aria-live="polite" class="loader loader-16">
-          <span class="visually-hidden">Loading…</span>
-        </div>
-      `,
-    },
-  ],
-  invalid: [
-    {
-      code: `
-        <div role="status" aria-live="polite" class="loader loader-xs">
-          <span class="visually-hidden">Loading…</span>
-        </div>
-      `,
-      output: `
-        <div role="status" aria-live="polite" class="loader loader-16">
-          <span class="visually-hidden">Loading…</span>
-        </div>
-      `,
-      errors: [{ messageId: 'deprecatedLoaderXS' }],
-    },
-    {
-      code: `
-        <div role="status" aria-live="polite" class="loader loader-sm">
-          <span class="visually-hidden">Loading…</span>
-        </div>
-      `,
-      output: `
-        <div role="status" aria-live="polite" class="loader loader-40">
-          <span class="visually-hidden">Loading…</span>
-        </div>
-      `,
-      errors: [{ messageId: 'deprecatedLoaderSM' }],
-    },
-  ],
-});
+const validData = ['spinner', 'spinner-modal', 'spinner-16', 'spinner-40'];
+
+generatedDataTester(name, rule, data, validData);


### PR DESCRIPTION
## 📄 Description

Updated automigration for the loader to add the renaming from `loader` to `spinner`