### PR TITLE
chore(docs): updated the design reference link in accordion documentation to point to the current "Foundations - Components Next Level" Figma file

### DIFF
--- a/.changeset/fuzzy-mice-wait.md
+++ b/.changeset/fuzzy-mice-wait.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Updated the Figma link in the `<post-accordion>` component documentation to point to the current design specifications.

--- a/packages/documentation/src/stories/components/accordion/accordion.stories.ts
+++ b/packages/documentation/src/stories/components/accordion/accordion.stories.ts
@@ -13,7 +13,7 @@ const meta: MetaComponent<HTMLPostAccordionElement & HTMLPostCollapsibleElementE
     badges: [],
     design: {
       type: 'figma',
-      url: 'https://www.figma.com/file/xZ0IW0MJO0vnFicmrHiKaY/Components-Post?type=design&node-id=17964-20698&mode=design&t=3lniLiZhl7q9Gqgn-4',
+      url: 'https://www.figma.com/design/JIT5AdGYqv6bDRpfBPV8XR/Foundations---Components-Next-Level?node-id=17-159&p=f&t=obOoC1vsLoUDeGQh-0',
     },
   },
   args: {


### PR DESCRIPTION
## 📄 Description

Fixed the Figma design link for the post-accordion component documentation. The link was pointing to an outdated design file and has been updated to reference the current "Foundations - Components Next Level" Figma file

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
