### PR TITLE
chore(styles): replace `Post Icons` with `signal icons` in `toast` component

### DIFF
--- a/.changeset/flat-moments-sit.md
+++ b/.changeset/flat-moments-sit.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-styles': patch
 ---
 
-Updated the toast component icons.
+Updated the `toast` component icons.

--- a/.changeset/flat-moments-sit.md
+++ b/.changeset/flat-moments-sit.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Updated the toast component icons.

--- a/packages/styles/src/mixins/_notification.scss
+++ b/packages/styles/src/mixins/_notification.scss
@@ -2,7 +2,6 @@
 @use 'sass:list';
 
 @use './color' as color-mx;
-@use './icons' as icons-mx;
 @use './utilities' as utilities-mx;
 @use './../functions/contrast' as contrast-fn;
 
@@ -90,12 +89,10 @@ tokens.$default-map: components.$post-banner;
   color-scheme: $scheme;
 
   &::before {
-    @include icons-mx.icon($icon);
-    color: $icon-color;
-
-    @include utilities-mx.high-contrast-mode {
-      color: CanvasText;
-    }
+    background-image: #{$icon};
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
   }
 }
 

--- a/packages/styles/src/variables/components/_notification.scss
+++ b/packages/styles/src/variables/components/_notification.scss
@@ -71,13 +71,13 @@ $notification-variants: () !default;
 $notification-variants: list.join(
   $notification-variants,
   (
-    'info' tokens.get('banner-info-bg') 2106 tokens.get('banner-info-border-color')
+    'info' tokens.get('banner-info-bg') var(--post-signal-icon-info) tokens.get('banner-info-border-color')
       tokens.get('banner-info-icon-color') tokens.get('post-banner-info-bg-scheme'),
-    'success' tokens.get('banner-success-bg') 2105 tokens.get('banner-success-border-color')
+    'success' tokens.get('banner-success-bg') var(--post-signal-icon-success) tokens.get('banner-success-border-color')
       tokens.get('banner-success-icon-color') tokens.get('post-banner-success-bg-scheme'),
-    'warning' tokens.get('banner-warning-bg') 2104 tokens.get('banner-warning-border-color')
+    'warning' tokens.get('banner-warning-bg') var(--post-signal-icon-warning) tokens.get('banner-warning-border-color')
       tokens.get('banner-warning-icon-color') tokens.get('post-banner-warning-bg-scheme'),
-    'error' tokens.get('banner-error-bg') 2104 tokens.get('banner-error-border-color')
+    'error' tokens.get('banner-error-bg') var(--post-signal-icon-error) tokens.get('banner-error-border-color')
       tokens.get('banner-error-icon-color') tokens.get('post-banner-error-bg-scheme')
   )
 );


### PR DESCRIPTION
## 📄 Description

Replace 4-digit Post Icons with their corresponding signal icon equivalents in toast notifications to improve status/feedback communication.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
