### PR TITLE
chore(docs): add removal of text color utility classes in migration documentation

### DIFF
--- a/.changeset/bumpy-insects-arrive.md
+++ b/.changeset/bumpy-insects-arrive.md
@@ -2,13 +2,4 @@
 '@swisspost/design-system-documentation': patch
 ---
 
-Added the documentation about the removal of `.text-*`utility classes in the migration guide.
-The list of the removed classes has been documentated:
-- `.text-primary`
-- `.text-secondary`
-- `.text-light`
-- `.text-dark`
-- `.text-success`
-- `.text-warning`
-- `.text-error`
-- `.text-info`
+Added the documentation about the removal of `.text-*` color utility classes in the migration guide.

--- a/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
+++ b/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
@@ -330,7 +330,7 @@ export class MigrationV99Component extends LitElement {
                 </li>
                 <li class="mb-16">
                   <p>
-                    Removed all text utility classes (<code>.text-*</code>)
+                    Removed all text color utility classes (<code>.text-*</code>)
                   </p>
                   <ul>
                     <li><code>.text-primary</code></li>


### PR DESCRIPTION
## 📄 Description

The documentation about the removal of `.text-*`utility classes in the migration guide has been added.
The list of the removed classes has been documentated:
- `.text-primary`
- `.text-secondary`
- `.text-light`
- `.text-dark`
- `.text-success`
- `.text-warning`
- `.text-error`
- `.text-info`
