### PR TITLE
fix(styles): fix a token naming inconsistency in the `legend` component

### DIFF
--- a/packages/styles/src/elements/fieldset-legend.scss
+++ b/packages/styles/src/elements/fieldset-legend.scss
@@ -11,7 +11,7 @@ legend {
 
   &.large {
     font-size: tokens.get('legend-large-font-size');
-    padding-block-start: tokens.get('legend-large-padding-block-start');
+    margin-block-start: tokens.get('legend-large-margin-block-start');
     padding-block-end: calc(
       tokens.get('legend-large-padding-block-end') - tokens.get('legend-large-border-width')
     );


### PR DESCRIPTION
## 📄 Description

Fixes a token naming inconsistency in the legend large component where a margin token was incorrectly named as padding (I just tackled this ticket since it was sitting in the `stale` issues and only took a couple minutes to fix in the code).

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
