### PR TITLE
feat(eslint): automigration rules for font sizes

### DIFF
--- a/.changeset/twelve-camels-serve.md
+++ b/.changeset/twelve-camels-serve.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added information in the migration guide regarding the update of the font size classes.

--- a/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
+++ b/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
@@ -355,6 +355,7 @@ export class MigrationV99Component extends LitElement {
               <ul>
                 <li class="mb-16">
                   <p>
+                    <span data-info="automigration" class="tag tag-sm tag-info">🪄 migration rule</span>
                     Removed deprecated font size variables and classes
                   </p>
                   <ul>
@@ -371,15 +372,16 @@ export class MigrationV99Component extends LitElement {
                     <li><code>$font-size-56</code> and <code>.font-size-56</code></li>
                   </ul>
                   <p class="info">
-                    You can now use the font curves <code>.fs-1</code> to <code>.fs-11</code> that
+                    You can now either use the font curves <code>.fs-1</code> to <code>.fs-11</code> that
                     are documented in the
                     <a href="/?path=/docs/c55681df-4d21-469d-a5b3-c67686e7c104--docs"
                       >text utilities</a
-                    >.
+                    > for text content, or the <a href="/?path=/docs/e728de1f-0d71-4317-8bb8-cbef0bf8d5db--docs">sizing utility classes</a> for sizing <code>post-icon</code> components.
                   </p>
                 </li>
                 <li class="mb-16">
                   <p>
+                    <span data-info="automigration" class="tag tag-sm tag-info">🪄 migration rule</span>
                     Removed deprecated font curve variables and classes
                   </p>
                   <ul>
@@ -398,11 +400,11 @@ export class MigrationV99Component extends LitElement {
                     <li><code>$font-size-huge</code> and <code>.fs-huge</code></li>
                   </ul>
                   <p class="info">
-                    You can now use the font curves <code>.fs-1</code> to <code>.fs-11</code> that
+                    You can now either use the font curves <code>.fs-1</code> to <code>.fs-11</code> that
                     are documented in the
                     <a href="/?path=/docs/c55681df-4d21-469d-a5b3-c67686e7c104--docs"
                       >text utilities</a
-                    >.
+                    > for text content, or the <a href="/?path=/docs/e728de1f-0d71-4317-8bb8-cbef0bf8d5db--docs">sizing utility classes</a> for sizing <code>post-icon</code> components.
                   </p>
                 </li>
                 <li class="mb-16">

--- a/packages/eslint/docs/rules/html/migrations/no-deprecated-font-sizes.md
+++ b/packages/eslint/docs/rules/html/migrations/no-deprecated-font-sizes.md
@@ -1,0 +1,33 @@
+# `no-deprecated-font-sizes`
+
+Flags deprecated `fs-*` and `font-size-*` classes and replaces them with either font curves (new `fs-*` classes) for text content or sizing utility classes (`w-* h-*`) for `post-icon` components.
+
+- Type: problem
+- 🔧 Supports autofix (--fix)
+
+## Rule Options
+
+This rule does not have any configuration options.
+
+## Example
+
+### ❌ Invalid Code
+
+```html
+<post-icon name="save" class="fs-regular"></post-icon>
+<post-icon name="edit" class="fs-huge"></post-icon>
+<post-icon name="edit" class="font-size-12"></post-icon>
+<p class="font-size-14">Text content</p>
+<p class="font-size-big">Text content</p>
+<p class="font-size-tiny">Text content</p>
+```
+
+### ✅ Valid Code
+
+```html
+<post-icon name="save" class="w-24 h-24"></post-icon>
+<post-icon name="save" class="w-48 h-48"></post-icon>
+<p class="fs-6">Text content</p>
+<p class="fw-bold">My bold text</p>
+<p class="fw-regular">My regular text</p>
+```

--- a/packages/eslint/src/rules/html/migrations/index.ts
+++ b/packages/eslint/src/rules/html/migrations/index.ts
@@ -26,6 +26,9 @@ import noDeprecatedHClearfix, {
 import noDeprecatedHVisuallyhiddenRule, {
   name as noDeprecatedHVisuallyhiddenRuleName,
 } from './no-deprecated-h-visuallyhidden';
+import noDeprecatedFontSizesRule, {
+  name as noDeprecatedFontSizesRuleName,
+} from './no-deprecated-font-sizes';
 
 export const htmlMigrationRules = {
   [noDeprecatedBtnRgRuleName]: noDeprecatedBtnRgRule,
@@ -39,4 +42,5 @@ export const htmlMigrationRules = {
   [noDeprecatedFontWeightRuleName]: noDeprecatedFontWeightRule,
   [noDeprecatedHClearfixName]: noDeprecatedHClearfix,
   [noDeprecatedHVisuallyhiddenRuleName]: noDeprecatedHVisuallyhiddenRule,
+  [noDeprecatedFontSizesRuleName]: noDeprecatedFontSizesRule,
 };

--- a/packages/eslint/src/rules/html/migrations/no-deprecated-font-sizes.ts
+++ b/packages/eslint/src/rules/html/migrations/no-deprecated-font-sizes.ts
@@ -1,0 +1,91 @@
+import { createRule } from '../../../utils/create-rule';
+import { HtmlNode } from '../../../parsers/html/html-node';
+
+export const name = 'no-deprecated-font-sizes';
+
+interface FontSizeClassMap {
+  old: string;
+  size: string;
+  font: string;
+}
+
+// Size (sizing utility classes) is for post-icon components; font (font curve utilities) is for the rest (text content)
+export const classesMap: Array<FontSizeClassMap> = [
+  { old: 'font-size-12', size: 'w-12 h-12', font: 'fs-11' },
+  { old: 'font-size-14', size: 'w-12 h-12', font: 'fs-9' },
+  { old: 'font-size-16', size: 'w-16 h-16', font: 'fs-8' },
+  { old: 'font-size-18', size: 'w-16 h-16', font: 'fs-6' },
+  { old: 'font-size-20', size: 'w-24 h-24', font: 'fs-6' },
+  { old: 'font-size-24', size: 'w-24 h-24', font: 'fs-5' },
+  { old: 'font-size-28', size: 'w-32 h-32', font: 'fs-4' },
+  { old: 'font-size-32', size: 'w-32 h-32', font: 'fs-3' },
+  { old: 'font-size-40', size: 'w-40 h-40', font: 'fs-2' },
+  { old: 'font-size-48', size: 'w-48 h-48', font: 'fs-1' },
+  { old: 'font-size-56', size: 'w-56 h-56', font: 'fs-1' },
+  { old: 'fs-tiny', size: 'w-12 h-12', font: 'fs-10' },
+  { old: 'fs-small', size: 'w-16 h-16', font: 'fs-9' },
+  { old: 'fs-regular', size: 'w-16 h-16', font: 'fs-8' },
+  { old: 'fs-bigger-regular', size: 'w-16 h-16', font: 'fs-8' },
+  { old: 'fs-medium', size: 'w-24 h-24', font: 'fs-6' },
+  { old: 'fs-large', size: 'w-24 h-24', font: 'fs-6' },
+  { old: 'fs-small-big', size: 'w-24 h-24', font: 'fs-5' },
+  { old: 'fs-big', size: 'w-32 h-32', font: 'fs-4' },
+  { old: 'fs-bigger-big', size: 'w-32 h-32', font: 'fs-3' },
+  { old: 'fs-small-huge', size: 'w-40 h-40', font: 'fs-2' },
+  { old: 'fs-huge', size: 'w-48 h-48', font: 'fs-1' },
+];
+
+function generateMessages(classesMap: Array<FontSizeClassMap>): Record<string, string> {
+  return classesMap.reduce(
+    (o, key) =>
+      Object.assign(o, {
+        [key.old]: `The "${key.old}" class has been deleted. Please remove it or replace it with either "${key.font}" for text elements or the sizing utilities "${key.size}" for icons.`,
+      }),
+    {},
+  );
+}
+
+export default createRule({
+  name,
+  meta: {
+    docs: {
+      dir: 'html',
+      description:
+        'Flags deprecated "fs-*" and "font-size-*" classes and replaces them with either font curves for text content or sizing utility classes for icons.',
+    },
+    messages: generateMessages(classesMap),
+    type: 'problem',
+    fixable: 'code',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      tag(node: HtmlNode) {
+        if (node.name) {
+          const $node = node.toCheerio();
+          const isIcon = node.name === 'post-icon';
+
+          classesMap.forEach(classMap => {
+            if ($node.hasClass(classMap.old)) {
+              context.report({
+                messageId: classMap.old,
+                loc: node.loc,
+                ...(classMap.font
+                  ? {
+                      fix(fixer) {
+                        const fixedNode = $node
+                          .removeClass(classMap.old)
+                          .addClass(isIcon ? classMap.size : classMap.font);
+                        return fixer.replaceTextRange(node.range, fixedNode.toString());
+                      },
+                    }
+                  : {}),
+              });
+            }
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint/test/rules/html/migrations/no-deprecated-font-sizes.spec.ts
+++ b/packages/eslint/test/rules/html/migrations/no-deprecated-font-sizes.spec.ts
@@ -1,0 +1,26 @@
+import rule, { name } from '../../../../src/rules/html/migrations/no-deprecated-font-sizes';
+import { classesMap } from '../../../../src/rules/html/migrations/no-deprecated-font-sizes';
+import { htmlRuleTester } from '../../../utils/html-rule-tester';
+
+htmlRuleTester.run(name, rule, {
+  valid: [
+    {
+      code: '<post-icon name="save" class="w-24 h-24"></post-icon>',
+    },
+    {
+      code: '<p class="fs-6">Text content</p>',
+    },
+  ],
+  invalid: [
+    ...classesMap.map(classMap => ({
+      code: `<post-icon name="save" class="${classMap.old}"></post-icon>`,
+      output: `<post-icon name="save" class="${classMap.size}"></post-icon>`,
+      errors: [{ messageId: classMap.old }],
+    })),
+    ...classesMap.map(classMap => ({
+      code: `<p class="${classMap.old}">Text content</p>`,
+      output: `<p class="${classMap.font}">Text content</p>`,
+      errors: [{ messageId: classMap.old }],
+    })),
+  ],
+});


### PR DESCRIPTION
## 📄 Description

Automigration rules for font sizes:
- If element is a `post-icon`, replace the class with width and height classes
- If element is not a `post-icon`, replace with equivalent font curve class