### PR TITLE
chore(docs, styles): remove multiple and multiple size controls from form select docs

### DIFF
--- a/packages/documentation/src/stories/components/select/select.stories.ts
+++ b/packages/documentation/src/stories/components/select/select.stories.ts
@@ -28,8 +28,6 @@ const meta: MetaComponent = {
     hiddenLabel: false,
     value: undefined,
     options: 5,
-    multiple: false,
-    multipleSize: 4,
     hint: 'This is helpful text that provides guidance or additional information to assist the user in filling out this field correctly.',
     disabled: false,
     validation: 'null',
@@ -87,33 +85,6 @@ const meta: MetaComponent = {
       control: {
         type: 'number',
         min: 1,
-        step: 1,
-      },
-      table: {
-        category: 'General',
-      },
-    },
-    multiple: {
-      name: 'Multiple',
-      description: 'When set, allows multiple options to be selected (multi-select).',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        category: 'General',
-      },
-    },
-    multipleSize: {
-      name: 'Multiple Size',
-      description:
-        'When set to a number larger than 0, will set the number of display option rows.<post-banner type="error" data-size="sm"><p>Note: not all browser will respect this setting.</p></post-banner>',
-      if: {
-        arg: 'multiple',
-      },
-      control: {
-        type: 'number',
-        min: 0,
-        max: 10,
         step: 1,
       },
       table: {
@@ -226,8 +197,6 @@ const Template: Story = {
       <select
         id="${context.id}"
         class="${classes}"
-        ?multiple="${args.multiple}"
-        size="${args.multipleSize ?? nothing}"
         ?disabled="${args.disabled}"
         aria-label="${useAriaLabel ? args.label : nothing}"
         aria-invalid="${ifDefined(VALIDATION_STATE_MAP[args.validation])}"
@@ -272,7 +241,7 @@ export const FloatingLabel: Story = {
   ...Template,
   parameters: {
     controls: {
-      exclude: ['Hidden Label', 'Options', 'Multiple', 'Helper Text', 'Disabled', 'Validation'],
+      exclude: ['Hidden Label', 'Options', 'Helper Text', 'Disabled', 'Validation'],
     },
   },
   args: {
@@ -285,7 +254,7 @@ export const FloatingLabelPlaceholder: Story = {
   ...Template,
   parameters: {
     controls: {
-      exclude: ['Hidden Label', 'Options', 'Multiple', 'Helper Text', 'Disabled', 'Validation'],
+      exclude: ['Hidden Label', 'Options', 'Helper Text', 'Disabled', 'Validation'],
     },
   },
   args: {
@@ -304,7 +273,6 @@ export const Validation: Story = {
         'Floating Label',
         'Hidden Label',
         'Options',
-        'Multiple',
         'Helper Text',
         'Disabled',
       ],

--- a/packages/documentation/src/stories/guidelines/forms/forms.stories.ts
+++ b/packages/documentation/src/stories/guidelines/forms/forms.stories.ts
@@ -167,34 +167,6 @@ export const Validation: Story = {
         </div>
       </div>
 
-      <!-- Form Select Multiple-->
-      <div class="row mb-16">
-        <div class="col-md-6">
-          <div class="form-floating">
-            <select
-              id="FormSelectMultipleInvalid"
-              class="form-select is-invalid"
-              multiple
-              required
-            ></select>
-            <label class="form-label" for="FormSelectMultipleInvalid">
-              Invalid Select Multiple
-            </label>
-            <p class="invalid-feedback">Error message</p>
-          </div>
-        </div>
-        <div class="col-md-6">
-          <div class="form-floating">
-            <select id="FormSelectMultipleValid" class="form-select is-valid" multiple>
-              <option value="1">Value 1</option>
-              <option value="2">Value 2</option>
-            </select>
-            <label class="form-label" for="FormSelectMultipleValid">Valid Select Multiple</label>
-            <p class="valid-feedback">Success message (optional)</p>
-          </div>
-        </div>
-      </div>
-
       <!-- Form File -->
       <div class="row mb-16">
         <div class="col-md-6">

--- a/packages/styles/src/components/form-input.scss
+++ b/packages/styles/src/components/form-input.scss
@@ -134,20 +134,6 @@ input.form-control {
           content: 'Scegli file';
         }
       }
-
-      &[multiple] {
-        &::after {
-          content: 'Choose Files';
-
-          [lang='de'] & {
-            content: 'Dateien auswählen';
-          }
-
-          [lang='fr'] & {
-            content: 'Choisir des fichiers';
-          }
-        }
-      }
     }
 
     &.is-valid,

--- a/packages/styles/src/components/form-select.scss
+++ b/packages/styles/src/components/form-select.scss
@@ -33,10 +33,6 @@ tokens.$default-map: components.$post-select;
     background-color: tokens.get('select-color-disabled-bg');
     border-color: tokens.get('select-color-disabled-border');
     border-style: tokens.get('select-border-style-disabled');
-
-    &:not([multiple]) {
-      background-image: forms-fx.select-arrow-icon('disabled');
-    }
   }
 
   &:not(:disabled) {
@@ -61,18 +57,6 @@ tokens.$default-map: components.$post-select;
       background-color: tokens.get('select-color-hover-bg');
       color: tokens.get('select-color-enabled-fg');
       border-color: tokens.get('select-color-hover-border');
-
-      &:not([multiple]) {
-        background-image: forms-fx.select-arrow-icon('hover');
-
-        @include utilities.high-contrast-mode-light() {
-          background-image: forms-fx.select-arrow-icon('hover-hcm', $mode: light);
-        }
-
-        @include utilities.high-contrast-mode-dark() {
-          background-image: forms-fx.select-arrow-icon('hover-hcm', $mode: dark);
-        }
-      }
 
       @include utilities.high-contrast-mode {
         border-color: Highlight;
@@ -116,13 +100,11 @@ tokens.$default-map: components.$post-select;
     }
 
     &:hover {
-      &:not([multiple]) {
-        background-image: forms-fx.select-arrow-icon('hover'), forms-fx.success-icon();
-      }
+      background-image: forms-fx.select-arrow-icon('hover'), forms-fx.success-icon();
     }
 
     &,
-    &:hover:not([multiple]),
+    &:hover,
     &:focus {
       @include utilities.high-contrast-mode-dark() {
         background-image: forms-fx.select-arrow-icon('enabled'), forms-fx.success-icon(#e0e0e0);
@@ -142,13 +124,11 @@ tokens.$default-map: components.$post-select;
     }
 
     &:hover {
-      &:not([multiple]) {
-        background-image: forms-fx.select-arrow-icon('hover'), forms-fx.warning-icon();
-      }
+      background-image: forms-fx.select-arrow-icon('hover'), forms-fx.warning-icon();
     }
 
     &,
-    &:hover:not([multiple]),
+    &:hover,
     &:focus {
       @include utilities.high-contrast-mode-dark() {
         background-image: forms-fx.select-arrow-icon('enabled'), forms-fx.warning-icon(#e0e0e0);
@@ -158,18 +138,6 @@ tokens.$default-map: components.$post-select;
         background-image: forms-fx.select-arrow-icon('enabled'), forms-fx.warning-icon(#333);
       }
     }
-  }
-
-  &[multiple],
-  &[size]:not([size='1']) {
-    background-image: none;
-
-    &.is-valid,
-    &.is-invalid {
-      background-position: center right tokens.get('select-validation-icon-position-inline-end');
-    }
-
-    @include forms-mx.validation-icons();
   }
 }
 
@@ -227,40 +195,11 @@ tokens.$default-map: components.$post-select;
         font-size: unset;
       }
     }
-
-    &[multiple] {
-      padding-block-end: 0;
-      height: auto;
-
-      option {
-        color: tokens.get('select-color-enabled-fg');
-      }
-
-      ~ label {
-        // Add some distance on the right to leave space for the scrollbar
-        width: calc(100% - (#{tokens.get('select-padding-inline-end')} * 2));
-      }
-
-      &:disabled option {
-        color: tokens.get('select-color-disabled-fg');
-      }
-
-      &:empty {
-        ~ label {
-          padding-block: tokens.get('select-standalone-padding-block');
-          width: calc(
-            100% - (#{tokens.get('select-border-width')} * 2) - #{tokens.get(
-                'select-label-empty-padding-inline-start'
-              )}
-          );
-        }
-      }
-    }
   }
 }
 
 [data-color-scheme='dark'] {
-  .form-select:not([multiple]) {
+  .form-select {
     background-image: forms-fx.select-arrow-icon('enabled', 'dark');
 
     &:disabled {


### PR DESCRIPTION
## 📄 Description

- The `Multiple`and `Multiple Size`controls have been removed from the Form Select stories. 
Recursively, the `[multiple]` and `&:not([multiple]` CSS selector, and all **multiple** references have been removed from styles.

- The `Multiple` control for **valid** and **invalid** select has been removed from the Form Creation guideline.
