### PR TITLE
chore(docs): add back select multiple default snapshots

### DIFF
--- a/packages/documentation/src/stories/components/select/select.snapshot.stories.ts
+++ b/packages/documentation/src/stories/components/select/select.snapshot.stories.ts
@@ -113,17 +113,19 @@ export const Select: Story = {
               `,
           )}
           <h2>Multiple - Default</h2>
-          ${bombArgsGeneratedMultiple.map(
-            (args: Args) =>
-              html`
-                <div>
-                  ${Default.render?.(
-                    { ...context.args, ...Default.args, ...args },
-                    { ...context, id: `a-${crypto.randomUUID()}` },
-                  )}
-                </div>
-              `,
-          )}
+          ${bombArgsGeneratedMultiple
+            .map((args: Args) => ({ ...args, floatingLabel: false }))
+            .map(
+              (args: Args) =>
+                html`
+                  <div>
+                    ${Default.render?.(
+                      { ...context.args, ...Default.args, ...args },
+                      { ...context, id: `a-${crypto.randomUUID()}` },
+                    )}
+                  </div>
+                `,
+            )}
         </div>
       `,
     );


### PR DESCRIPTION
## 📄 Description

Snapshots for the `Select > Multiple - Default` (no floating label) was showing floating labels.

## Demo

[https://preview-6406--swisspost-design-system-next.netlify.app/iframe.html?id=snapshots--select&viewMode=story](https://preview-6406--swisspost-design-system-next.netlify.app/iframe.html?id=snapshots--select&viewMode=story)

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
