### PR TITLE
feat(styles): add icons to header meta navigation links

### DIFF
--- a/.changeset/lemon-lamps-sniff.md
+++ b/.changeset/lemon-lamps-sniff.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-documentation': patch
+'@swisspost/design-system-styles': patch
+---
+
+Added icons to the header meta navigation links.

--- a/packages/documentation/src/stories/components/header/header.stories.ts
+++ b/packages/documentation/src/stories/components/header/header.stories.ts
@@ -47,7 +47,7 @@ const meta: MetaComponent = {
     metaNavigation: {
       name: 'Meta navigation',
       description:
-        'Whether or not the meta navigation is displayed ("jobs" and "create an account").',
+        'Whether or not the meta navigation is displayed ("Search", "Jobs", and "Create Account").',
       control: {
         type: 'boolean',
       },
@@ -94,8 +94,24 @@ function getHeaderRenderer(mainnavigation = renderMainnavigation()) {
       ? html`
           <!-- Meta navigation -->
           <ul class="list-inline" slot="meta-navigation">
-            <li><a href="">Jobs</a></li>
-            <li><a href="">Create an account</a></li>
+            <li>
+              <a href="">
+                Search
+                <post-icon name="search" aria-hidden="true"></post-icon>
+              </a>
+            </li>
+            <li>
+              <a href="">
+                Jobs
+                <post-icon name="jobs" aria-hidden="true"></post-icon>
+              </a>
+            </li>
+            <li>
+              <a href="">
+                Create Account
+                <post-icon name="adduser" aria-hidden="true"></post-icon>
+              </a>
+            </li>
           </ul>
         `
       : ''}

--- a/packages/styles/src/components/header/_post-header.scss
+++ b/packages/styles/src/components/header/_post-header.scss
@@ -106,10 +106,24 @@ post-header {
         }
       }
 
+      @include media.max(lg) {
+        a,
+        button {
+          flex-direction: row-reverse;
+          justify-content: flex-end;
+        }
+      }
+
       @include media.max(sm) {
         a,
         button {
           font-size: 14px;
+          gap: 0.5rem;
+
+          > post-icon {
+            height: 1rem;
+            width: 1rem;
+          }
         }
       }
     }


### PR DESCRIPTION
## 📄 Description

This PR adds icons to the meta navigation links in the header docs and adds styles so that these icons are shown before the text on tablet on mobile.

## 🚀 Demo

https://preview-6413--swisspost-design-system-next.netlify.app/?path=/docs/27a2e64d-55ba-492d-ab79-5f7c5e818498--docs

---

## 🔮 Design review

- [x] Design review done
- [ ] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
