### PR TITLE
fix(styles): fixbottom margin for buttons inside `<dialog>` element when content becomes scrollable

### DIFF
--- a/.changeset/eleven-towns-camp.md
+++ b/.changeset/eleven-towns-camp.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed bottom margin for buttons inside `<dialog>` element when content becomes scrollable.

--- a/packages/styles/src/components/dialog.scss
+++ b/packages/styles/src/components/dialog.scss
@@ -75,7 +75,7 @@ dialog {
 }
 
 dialog > .dialog-grid {
-  padding: tokens.get('utility-gap-16');
+  padding: tokens.get('utility-gap-16') tokens.get('utility-gap-16') 0 tokens.get('utility-gap-16');
   display: grid;
   column-gap: tokens.get('utility-gap-16');
   grid-template-columns: auto 1fr auto;
@@ -160,6 +160,8 @@ dialog > .dialog-grid {
   position: sticky;
   bottom: 0;
   padding-top: tokens.get('utility-gap-16');
+  padding-bottom: tokens.get('utility-gap-16');
+  margin-block-end: 0;
   display: flex;
   flex-wrap: wrap;
   flex-direction: row-reverse;


### PR DESCRIPTION
## 📄 Description

This PR fixes bottom margin for buttons inside <dialog> element when content becomes scrollable

## 🚀 Preview link:

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
