### PR TITLE
chore: update devcontainer to node 22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,7 @@
 {
   "name": "Node.js & TypeScript",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20",
-  "features": {
-    "ghcr.io/devcontainers-extra/features/pnpm:2": {
-      "version": "9"
-    }
-  },
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},


### PR DESCRIPTION
The right pnpm version will automatically be installed by corepack, using the packageManager field in the package.json file.

This will update the provided devcontainer to node@22 on main. So that the setup matches our local setup.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
