### PR TITLE
chore: extend release workflow permissions to enable trusted publishing through changesets

### DIFF
--- a/.github/actions/configure-github-user/action.yaml
+++ b/.github/actions/configure-github-user/action.yaml
@@ -1,0 +1,11 @@
+name: Configure GitHub User
+description: Configure the GitHub user name and email to be the Swiss Post bot
+
+runs:
+  using: composite
+  steps:
+    - name: Configure GitHub User
+      shell: bash
+      run: |
+        git config user.name "Swiss Post Bot"
+        git config user.email "103635272+swisspost-bot@users.noreply.github.com"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,6 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: write
-  pull-requests: write
   id-token: write
 
 jobs:
@@ -33,6 +31,9 @@ jobs:
 
       - name: Install & build Dependencies
         run: pnpm bootstrap
+
+      - name: Configure GitHub User
+        uses: ./.github/actions/configure-github-user
 
       # This will fail the build if something in the publish setup is not correct
       # before changeset magic is starting to run


### PR DESCRIPTION
## 📄 Description

Extends the release workflow permissions, so changesets action and/or gitub-actions[bot] can do their duty.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
