### PR TITLE
fix(styles): removed target-group button import

### DIFF
--- a/.changeset/lovely-words-sing.md
+++ b/.changeset/lovely-words-sing.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed an issue with button styles specificity where e.g. icon buttons got overwritten by the button styles. Button styles are now delivered in the correct source order, also when selectively importing component CSS.

--- a/packages/styles/src/components/target-group.scss
+++ b/packages/styles/src/components/target-group.scss
@@ -1,4 +1,3 @@
-@use 'button';
 @use './../mixins/media';
 @use '../functions/tokens';
 @use '../tokens/components';


### PR DESCRIPTION
## 📄 Description

This fixes an issue with button styles specificity where e.g. icon buttons got overwritten by the button styles. Button styles are now delivered in the correct source order, also when selectively importing component CSS. It also reduces target group styles output by 100 lines of code.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
