### PR TITLE
fix(components): make @stencil/core a dependency

### DIFF
--- a/.changeset/thick-squids-hunt.md
+++ b/.changeset/thick-squids-hunt.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-components': patch
+'@swisspost/design-system-components-angular': patch
+---
+
+Fixed an issue with dependency managemant around @stencil/core. This package no longer has to be installed as a dependency by projects using the Design System Components or Components Angular packages as it's now declared a dependency of the components package (was a devDependency before).

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "@floating-ui/dom": "1.7.3",
     "@oddbird/popover-polyfill": "0.6.0",
+    "@stencil/core": "4.35.0",
     "@swisspost/design-system-icons": "workspace:10.0.0-next.51",
     "@swisspost/design-system-styles": "workspace:10.0.0-next.51",
     "ally.js": "1.4.1",
@@ -103,7 +104,6 @@
     "@percy/cypress": "3.1.6",
     "@stencil-community/eslint-plugin": "0.10.0",
     "@stencil/angular-output-target": "0.10.2",
-    "@stencil/core": "4.35.0",
     "@stencil/react-output-target": "=0.8.2",
     "@stencil/sass": "3.0.12",
     "@swisspost/design-system-eslint": "workspace:1.1.0-next.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@oddbird/popover-polyfill':
         specifier: 0.6.0
         version: 0.6.0
+      '@stencil/core':
+        specifier: 4.35.0
+        version: 4.35.0
       '@swisspost/design-system-icons':
         specifier: workspace:10.0.0-next.51
         version: link:../icons
@@ -101,9 +104,6 @@ importers:
       '@stencil/angular-output-target':
         specifier: 0.10.2
         version: 0.10.2(@stencil/core@4.35.0)
-      '@stencil/core':
-        specifier: 4.35.0
-        version: 4.35.0
       '@stencil/react-output-target':
         specifier: '=0.8.2'
         version: 0.8.2(@stencil/core@4.35.0)(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)


### PR DESCRIPTION
## 📄 Description

Fixed an issue with dependency managemant around @stencil/core. This package no longer has to be installed as a dependency by projects using the Design System Components or Components Angular packages as it's now declared a dependency of the components package (was a devDependency before).

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
