### PR TITLE
fix(components): add megadropdown overview link to the focusable elements

### DIFF
--- a/.changeset/gold-islands-relax.md
+++ b/.changeset/gold-islands-relax.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Added the megadropdown overview link into the list of focusable elements in the `post-megadropdown`.

--- a/packages/components/src/components/post-megadropdown/post-megadropdown.tsx
+++ b/packages/components/src/components/post-megadropdown/post-megadropdown.tsx
@@ -35,7 +35,9 @@ export class PostMegadropdown {
 
   private get megadropdownTrigger(): Element | null {
     const hostId = this.host.getAttribute('id');
-    return hostId ? document.querySelector(`post-megadropdown-trigger[for="${hostId}"] > button`) : null;
+    return hostId
+      ? document.querySelector(`post-megadropdown-trigger[for="${hostId}"] > button`)
+      : null;
   }
 
   /**
@@ -191,6 +193,15 @@ export class PostMegadropdown {
   private getFocusableElements() {
     const focusableEls = Array.from(this.host.querySelectorAll('post-list-item, h3, .back-button'));
     const focusableChildren = focusableEls.flatMap(el => Array.from(getFocusableChildren(el)));
+
+    // Check for an overview link
+    const overviewLink = this.host.querySelector<HTMLAnchorElement>(
+      'a[slot="megadropdown-overview-link"]',
+    );
+
+    if (overviewLink) {
+      focusableChildren.unshift(overviewLink);
+    }
 
     this.firstFocusableEl = focusableChildren[0];
     this.lastFocusableEl = focusableChildren[focusableChildren.length - 1];


### PR DESCRIPTION
## 📄 Description

When navigating with keyboard navigation on the megadropdown, the newly added **overview link** was not getting focused as it had not been added to the loop of focusable elements.
This PR adds it at the start of the list so that if present, it becomes the first focusable element.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
