### PR TITLE
chore: fix all package versions but the one from the documentation package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,14 +7,19 @@
   "commit": false,
   "fixed": [
     [
-      "@swisspost/design-system-styles",
-      "@swisspost/design-system-tokens",
+      "@swisspost/design-system-changelog-github",
       "@swisspost/design-system-components",
+      "@swisspost/design-system-components-angular-workspace",
       "@swisspost/design-system-components-angular",
       "@swisspost/design-system-components-react",
+      "@swisspost/design-system-eslint",
       "@swisspost/design-system-icons",
+      "@swisspost/internet-header",
+      "@swisspost/design-system-nextjs-integration",
+      "@swisspost/design-system-styles",
+      "@swisspost/design-system-styles-primeng-workspace",
       "@swisspost/design-system-styles-primeng",
-      "@swisspost/internet-header"
+      "@swisspost/design-system-tokens"
     ]
   ],
   "linked": [],


### PR DESCRIPTION
## 📄 Description

This change will align all the package versions in our monorepo to the same version (read more [here](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#fixed-array-of-arrays-of-package-names)) and make sure, all packages with a flag `public: true` in their `package.json` will be published to npm with the new version, no matter if there is a changeset for them or not.

The only exception is the `@swisspost/design-system-documentation` package, since a version bump can be used there, to deploy the docs whenever want.

---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
