### PR TITLE
chore(tokens): add Tailwind `v3` token output alongside the existing `v4` format to support both Tailwind versions

### DIFF
--- a/.changeset/eager-chairs-sin.md
+++ b/.changeset/eager-chairs-sin.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Added Tailwind v3 token output alongside the existing v4 format to support both Tailwind versions.

--- a/packages/tokens/src/_build/configs/tailwind.ts
+++ b/packages/tokens/src/_build/configs/tailwind.ts
@@ -3,6 +3,7 @@ import { TOKENSET_LAYERS, TOKENSET_NAMES, TOKENSET_PREFIX } from '../constants.j
 import StyleDictionary from '../style-dictionary.js';
 import { registerConfigMethod, getTokenValue } from '../methods.js';
 import { TokenProperty } from '_build/types.js';
+import { objectDeepmerge, objectTextoutput } from '../utils/index.js';
 
 const TAILWIND_TOKENSET_NAMES = [TOKENSET_NAMES.Utilities, TOKENSET_NAMES.Helpers];
 
@@ -31,6 +32,14 @@ registerConfigMethod((tokenSets, { sourcePath, buildPath }) => {
             buildPath: `${buildPath}tailwind/`,
             files: [
               {
+                destination: `${name}.tailwind.js`,
+                filter: 'swisspost/source-tokens-filter',
+                format: 'swisspost/tailwind-v3-format',
+                options: {
+                  outputReferences: true,
+                },
+              },
+              {
                 destination: `${name}.tailwind.css`,
                 filter: 'swisspost/source-tokens-filter',
                 format: 'swisspost/tailwind-v4-format',
@@ -54,8 +63,41 @@ registerConfigMethod((tokenSets, { sourcePath, buildPath }) => {
  *   format: (dictionary: Dictionary, file: File, options: Config & LocalOptions, platform: PlatformConfig) => string
  * }
  *
+ * swisspost/tailwind-v3-format:
+ * Used to declare the format of the tailwind v3 output files (JavaScript module).
+ */
+StyleDictionary.registerFormat({
+  name: 'swisspost/tailwind-v3-format',
+  format: async ({ dictionary, options, file }) => {
+    const header = await fileHeader({ file, commentStyle: 'short' });
+    const tailwindTokensObject = dictionary.allTokens.reduce<Record<string, TokenProperty>>(
+      (allTokens, token) => {
+        const tokenObj = token.path
+          .slice(token.path.indexOf(TOKENSET_PREFIX) + 1)
+          .reverse()
+          .reduce((res, p) => ({ [p]: res }), getTokenValue(options, token)) as {
+          [key: string]: TokenProperty;
+        };
+        return objectDeepmerge(allTokens, tokenObj);
+      },
+      {},
+    );
+
+    return header + `export default {${objectTextoutput(tailwindTokensObject)}\n};\n`;
+  },
+});
+
+/**
+ * @function StyleDictionary.registerFormat()
+ * Defines a custom StyleDictionary format to be used at specific places in the build process.
+ *
+ * @param object {
+ *   name: string,
+ *   format: (dictionary: Dictionary, file: File, options: Config & LocalOptions, platform: PlatformConfig) => string
+ * }
+ *
  * swisspost/tailwind-v4-format:
- * Used to declare the format of the tailwind output files.
+ * Used to declare the format of the tailwind v4 output files (CSS with @theme directive).
  */
 StyleDictionary.registerFormat({
   name: 'swisspost/tailwind-v4-format',


### PR DESCRIPTION
## 📄 Description

This PR adds Tailwind v3 token output alongside the existing v4 format to support both Tailwind versions.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
