### PR TITLE
fix(styles): update select arrow color in dark mode

### DIFF
--- a/.changeset/light-toys-behave.md
+++ b/.changeset/light-toys-behave.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Updated form select arrow's color to be visible in dark mode.

--- a/packages/styles/src/functions/_forms.scss
+++ b/packages/styles/src/functions/_forms.scss
@@ -35,20 +35,19 @@
   // Hardcoded colors because CSS variables cannot be used as fill color of background-image
   $arrow-color-map: (
     'enabled-light': #050400,
-    'enabled-dark': #fff,
+    'enabled-dark': #050400,
     'hover-light': #504f4b,
-    'hover-dark': #fff,
+    'hover-dark': #504f4b,
     'selected-light': #050400,
-    'selected-dark': #fff,
+    'selected-dark': #050400,
     'disabled-light': #696864,
-    'disabled-dark': #fff,
+    'disabled-dark': #fcfcfc99,
     'enabled-hcm-light': #050400,
     'enabled-hcm-dark': #fff,
     'selected-hcm-dark': #fff,
     'hover-hcm-dark': #fff,
     'hover-hcm-light': #050400,
   );
-
   @if ($state) {
     $icon: icons.get-colored-svg-url('2052', map.get($arrow-color-map, '#{$state}-#{$mode}'));
     $state: url('#{$icon}');


### PR DESCRIPTION
## 📄 Description

Form select arrow's color has been updated to be visible in dark mode.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
