### PR TITLE
fix: artifact-download/upload action to not use user-controlled data directly in a run block

### DIFF
--- a/.github/actions/artifact-download/action.yaml
+++ b/.github/actions/artifact-download/action.yaml
@@ -44,28 +44,34 @@ runs:
         path: ${{ runner.temp }}/artifact_download
 
     - name: Ensure target directory exists
+      env:
+        FOLDER: ${{ inputs.folder }}
       shell: bash
-      run: mkdir -p ${{ inputs.folder }}
-      
+      run: mkdir -p $FOLDER
+
     - name: Unzip artifacts
+      env:
+        FOLDER: ${{ inputs.folder }}
       shell: bash
-      run: unzip ${{ runner.temp }}/artifact_download/artifacts.zip -d ${{ inputs.folder }}
+      run: unzip ${{ runner.temp }}/artifact_download/artifacts.zip -d $FOLDER
 
     - name: Validate artifact contents
+      env:
+        FOLDER: ${{ inputs.folder }}
       shell: bash
       run: |
-        if [[ ! -f "${{ inputs.folder }}/GHA-EVENT-ID" ]]; then
+        if [[ ! -f "$FOLDER/GHA-EVENT-ID" ]]; then
           echo "Error: Event ID file missing"
           exit 1
         fi
-        
-        if [[ ! -f "${{ inputs.folder }}/GHA-EVENT-ACTION" ]]; then
+
+        if [[ ! -f "$FOLDER/GHA-EVENT-ACTION" ]]; then
           echo "Error: Event Action file missing"
           exit 1
         fi
-        
+
         # Validate ID is numeric
-        EVENT_ID=$(cat ${{ inputs.folder }}/GHA-EVENT-ID)
+        EVENT_ID=$(cat $FOLDER/GHA-EVENT-ID)
         if ! [[ "$EVENT_ID" =~ ^[0-9]*$ ]]; then
           echo "Error: Invalid Event ID format"
           exit 1
@@ -76,14 +82,16 @@ runs:
       run: rm -rf ${{ runner.temp }}/artifact_download
 
     - name: Create outputs
+      env:
+        FOLDER: ${{ inputs.folder }}
       id: build
       shell: bash
       run: |
-        EVENT_ID=$(cat ${{ inputs.folder }}/GHA-EVENT-ID)
-        EVENT_ACTION=$(cat ${{ inputs.folder }}/GHA-EVENT-ACTION)
-        
+        EVENT_ID=$(cat $FOLDER/GHA-EVENT-ID)
+        EVENT_ACTION=$(cat $FOLDER/GHA-EVENT-ACTION)
+
         SANITIZED_ID=$(echo "$EVENT_ID" | tr -cd '[:digit:]')
         SANITIZED_ACTION=$(echo "$EVENT_ACTION" | tr -cd '[:alnum:]-_')
-        
+
         echo "id=$SANITIZED_ID" >> $GITHUB_OUTPUT
         echo "action=$SANITIZED_ACTION" >> $GITHUB_OUTPUT

--- a/.github/actions/artifact-upload/action.yaml
+++ b/.github/actions/artifact-upload/action.yaml
@@ -21,30 +21,36 @@ runs:
   using: composite
   steps:
     - name: Validate folder exists
+      env:
+        FOLDER: ${{ inputs.folder }}
       shell: bash
       run: |
-        if [[ ! -d "${{ inputs.folder }}" ]]; then
-          echo "Error: Folder ${{ inputs.folder }} does not exist"
+        if [[ ! -d "$FOLDER" ]]; then
+          echo "Error: Folder $FOLDER does not exist"
           exit 1
         fi
 
     - name: Save Event Infos into the artifact folder
+      env:
+        FOLDER: ${{ inputs.folder }}
       shell: bash
       run: |
         if ! [[ "${{ github.event.number }}" =~ ^[0-9]*$ ]]; then
           echo "Warning: Invalid event number format, using default"
-          echo "0" > ${{ inputs.folder }}/GHA-EVENT-ID
+          echo "0" > $FOLDER/GHA-EVENT-ID
         else
-          echo "${{ github.event.number }}" > ${{ inputs.folder }}/GHA-EVENT-ID
+          echo "${{ github.event.number }}" > $FOLDER/GHA-EVENT-ID
         fi
-        
+
         ACTION="${{ github.event.action }}"
         SANITIZED_ACTION=$(echo "$ACTION" | tr -cd '[:alnum:]-_')
-        echo "$SANITIZED_ACTION" > ${{ inputs.folder }}/GHA-EVENT-ACTION
+        echo "$SANITIZED_ACTION" > $FOLDER/GHA-EVENT-ACTION
 
     - name: Zip artifact folder
+      env:
+        FOLDER: ${{ inputs.folder }}
       shell: bash
-      run: cd ${{ inputs.folder }} && zip artifacts.zip . -r
+      run: cd $FOLDER && zip artifacts.zip . -r
 
     - name: Upload artifacts
       uses: actions/upload-artifact@6027e3dd177782cd8ab9af838c04fd81a07f1d47


### PR DESCRIPTION
## 📄 Description

Sonar cloud reported, that we are using user-controlled data directly in `run` blocks in some of our github actions and that this is a security issue. This PR fixes it on `main`.
I will cherry pick the changes to v9 and v8 once it is merged.

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
