### PR TITLE
chore(deps): update `@stencil/angular-output-target` to `v1.1.1`

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -103,7 +103,7 @@
     "@percy/cli": "1.31.4",
     "@percy/cypress": "3.1.6",
     "@stencil-community/eslint-plugin": "0.10.0",
-    "@stencil/angular-output-target": "0.10.2",
+    "@stencil/angular-output-target": "1.1.1",
     "@stencil/react-output-target": "=0.8.2",
     "@stencil/sass": "3.0.12",
     "@swisspost/design-system-eslint": "workspace:10.0.0-next.54",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: 0.10.0
         version: 0.10.0(@typescript-eslint/eslint-plugin@8.22.0(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.18.0(jiti@2.6.1))(typescript@5.8.3))(@typescript-eslint/parser@7.18.0(eslint@9.18.0(jiti@2.6.1))(typescript@5.8.3))(eslint-plugin-react@7.37.5(eslint@9.18.0(jiti@2.6.1)))(eslint@9.18.0(jiti@2.6.1))(typescript@5.8.3)
       '@stencil/angular-output-target':
-        specifier: 0.10.2
-        version: 0.10.2(@stencil/core@4.35.0)
+        specifier: 1.1.1
+        version: 1.1.1(@stencil/core@4.35.0)
       '@stencil/react-output-target':
         specifier: '=0.8.2'
         version: 0.8.2(@stencil/core@4.35.0)(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -4782,8 +4782,8 @@ packages:
       eslint-plugin-react: ^7.0.0
       typescript: ^4.9.4 || ^5.0.0
 
-  '@stencil/angular-output-target@0.10.2':
-    resolution: {integrity: sha512-jPRa2NMAPtm/iMY+mUaWATbIhgY5zPJfUNQyF8nwC0rMrfXifPoRCf6BbH2S4Gy7SX0X4hlP+jAbVUjQNg/P+Q==}
+  '@stencil/angular-output-target@1.1.1':
+    resolution: {integrity: sha512-NMZjnbNi+gfUjlLRAWPLzwUuX1dGzkaIi/OqoVbElmZfxNI+kihZTW2EvDsA3SJx6bSJBsFNrIMx3tW9TQ3v6Q==}
     peerDependencies:
       '@stencil/core': '>=2.0.0 || >=3 || >= 4.0.0-beta.0 || >= 4.0.0'
 
@@ -17141,7 +17141,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@stencil/angular-output-target@0.10.2(@stencil/core@4.35.0)':
+  '@stencil/angular-output-target@1.1.1(@stencil/core@4.35.0)':
     dependencies:
       '@stencil/core': 4.35.0
 


### PR DESCRIPTION
## 📄 Description

This PR upgrades `@stencil/angular-output-target` from 0.10.2 to 1.1.1 for better Angular 20 compatibility.

**Changes:**

- Update @stencil/angular-output-target dependency to 1.1.1
- No configuration changes needed; the output target is already explicitly configured with outputType: 'standalone'

---

## Follow up

Will cherry-pick to `version 9` branch once this PR is merged

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
