### PR TITLE
feat(components): add custom property to override tooltip max-width

### DIFF
--- a/.changeset/big-spiders-lie.md
+++ b/.changeset/big-spiders-lie.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Added the CSS variable `--post-tooltip-max-width` that enables configuring the max-width of the `post-tooltip` component.

--- a/packages/components/src/components/post-popover/post-popover.scss
+++ b/packages/components/src/components/post-popover/post-popover.scss
@@ -21,7 +21,7 @@
   padding: 0.5em;
 
   min-width: 160px;
-  max-width: min(var(--post-popover-max-width, 280px), 100vw);
+  max-width: var(--post-popover-max-width, 280px);
 }
 
 .popover-content {

--- a/packages/components/src/components/post-tooltip/post-tooltip.scss
+++ b/packages/components/src/components/post-tooltip/post-tooltip.scss
@@ -31,7 +31,8 @@ post-popovercontainer {
     color: var(--post-current-fg);
     background-color: var(--post-current-bg);
     padding: tokens.get('utility-gap-4') tokens.get('utility-gap-8');
-    max-width: 280px;
+    max-width: var(--post-tooltip-max-width, 280px);
+    width: inherit;
     min-height: 32px;
     word-wrap: break-word;
     white-space: normal;


### PR DESCRIPTION
## 📄 Description

- Added the `--post-tooltip-max-width` custom property to override the tooltip's width
- Updated the `max-width` on the `post-popover` to remove the `min(..., 100w)` as the popover container component is already calculating the max width to 100vw minus the side gaps so that was not necessary there.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
