### PR TITLE
feat(components): add custom property to override tooltip and popover max width

### DIFF
--- a/.changeset/clean-frogs-unite.md
+++ b/.changeset/clean-frogs-unite.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Added the CSS variables `--post-tooltip-max-width` and `--post-popover-max-width` that enables configuring the max-width of the `post-tooltip` and `post-popover` component.

--- a/packages/components/src/components/post-popover/post-popover.scss
+++ b/packages/components/src/components/post-popover/post-popover.scss
@@ -22,7 +22,7 @@
   padding: 0.5em;
 
   min-width: 160px;
-  max-width: 280px;
+  max-width: var(--post-popover-max-width, 280px);
 
   // Max available width on mobile, popovercontainer will handle offsets
   @include post.media-breakpoint-down(rg) {

--- a/packages/components/src/components/post-tooltip/post-tooltip.scss
+++ b/packages/components/src/components/post-tooltip/post-tooltip.scss
@@ -27,7 +27,8 @@ post-popovercontainer {
 
   & > div {
     padding: spacing.$size-micro spacing.$size-mini;
-    max-width: 280px;
+    max-width: var(--post-tooltip-max-width, 280px);
+    width: inherit;
     min-height: 32px;
     word-wrap: break-word;
     white-space: normal;


### PR DESCRIPTION
## 📄 Description

- Added the `--post-tooltip-max-width` custom property to override the tooltip's width
- Added the `--post-popover-max-width` custom property to override the tooltip's width

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
