### PR TITLE
chore: update engines field to allow node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "@web-types/lit": "2.0.0-3"
   },
   "engines": {
-    "node": "22"
+    "node": "22||24"
   },
   "packageManager": "pnpm@10.6.5+sha512.cdf928fca20832cd59ec53826492b7dc25dc524d4370b6b4adbf65803d32efaa6c1c88147c0ae4e8d579a6c9eec715757b50d4fa35eea179d868eada4ed043af",
   "pnpm": {


### PR DESCRIPTION
## 📄 Description

Updates the engines field in the root package.json to allow node v24. When we're ready to move to 24 proper, v22 can be removed from the field.