### PR TITLE
chore(styles): fix Sass warnings

### DIFF
--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
@@ -138,7 +138,7 @@
     $border-width-rem: 0.125rem;
 
     // the actual offset when the 2px border is rotated by 45deg
-    $offset: -(math.cos($angle-rad) * $border-width-rem) - $arrow-size / 2;
+    $offset: -(math.cos($angle-rad) * $border-width-rem) - 0.5 * $arrow-size;
 
     @include utilities.high-contrast-mode {
       &[dynamic-placement='top'] {


### PR DESCRIPTION
## 📄 Description

Sass no longer allow for slash divisions.

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
