### PR TITLE
chore: tell dependabot to use the pnpm ecosystem for updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+# Basic dependabot configuration file
+version: 2
+updates:
+  - package-ecosystem: 'pnpm'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
## 📄 Description

Dependabot opened a PR that failed all checks because it did not update the lockfile (https://github.com/swisspost/design-system/pull/6683). Adding this config should tell dependabot to use the pnpm ecosystem for updates and hopefully update the lockfile.