### PR TITLE
chore: fix icon health preview URL

### DIFF
--- a/.github/actions/preview/message/update/action.yaml
+++ b/.github/actions/preview/message/update/action.yaml
@@ -46,7 +46,9 @@ runs:
             });
 
             if (issue?.data?.title.includes(iconsUpdateTitle)) {
-              updates.push(`- ${PREVIEW_URL}?path=/docs/health-icons--docs\n`)
+              const iconHealthURL = URL.parse(PREVIEW_URL)
+              iconHealthURL.searchParams.set('path', '/docs/health-icons--docs')
+              updates.push(`- ${iconHealthURL.toString()}\n`)
             }
 
             await github.rest.issues.updateComment({


### PR DESCRIPTION
## 📄 Description

This PR fixes the URL to the icon health page automatically posted in the icon update PRs.

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
