### PR TITLE
fix(docs): change button hover background for better readability

### DIFF
--- a/.changeset/shaky-grapes-sniff.md
+++ b/.changeset/shaky-grapes-sniff.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Changed hover background color of buttons in previews for better readability.

--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -213,7 +213,7 @@ $toolbar-icons: (
 
       button {
         &:hover {
-          background-color: rgba(0, 115, 188, 0.08);
+          background-color: post.$white;
         }
 
         &:nth-of-type(2) {


### PR DESCRIPTION

## 📄 Description

If a preview had an image or any background that was not plain white (visible on "Sections" page), the almost transparent background on buttons on hover made the text not readable.

Before:
<img width="371" height="152" alt="Capture d&#39;écran 2025-11-26 170552" src="https://github.com/user-attachments/assets/cdeb467d-6b81-4851-a9b6-cf881f36f375" />

Now:
<img width="259" height="102" alt="Capture d&#39;écran 2025-11-26 171513" src="https://github.com/user-attachments/assets/6c98a978-ff90-4488-93fe-7fafa3d7154e" />


## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
