### PR TITLE
fix(docs): fix `post-banner` becoming unstyled when changing the type control in Storybook

### DIFF
--- a/.changeset/evil-states-follow.md
+++ b/.changeset/evil-states-follow.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed `post-banner` becoming unstyled when changing the type control in Storybook.

--- a/packages/components/src/components/post-banner/post-banner.scss
+++ b/packages/components/src/components/post-banner/post-banner.scss
@@ -26,6 +26,11 @@ tokens.$default-map: components.$post-banner;
   border-width: tokens.get('banner-border-width');
   border-radius: tokens.get('banner-border-radius');
   box-shadow: tokens.get('banner-elevation');
+  
+  // Default to info styles when no type attribute is present
+  background-color: tokens.get('banner-info-bg');
+  border-color: tokens.get('banner-info-border-color');
+  @include color-scheme.set(tokens.get('post-banner-info-bg-scheme'));
 
   &::before {
     content: '';
@@ -35,6 +40,7 @@ tokens.$default-map: components.$post-banner;
     width: tokens.get('banner-icon-size');
     inset-block-start: tokens.get('banner-padding');
     inset-inline-start: tokens.get('banner-padding');
+    background-image: var(--post-signal-icon-info);
   }
 }
 


### PR DESCRIPTION
## 📄 Description

Applied the default info styles directly to the base `:host` selector, ensuring the banner is always styled correctly regardless of whether the `type` attribute is present or not.

## 🚀 Demo

[Banner docs](https://preview-6756--swisspost-design-system-next.netlify.app/?path=/docs/105e67d8-31e9-4d0b-87ff-685aba31fd4c--docs&devModeEnabled=true)
---

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
