### PR TITLE
chore(doc): remove unused color utility tokens

### DIFF
--- a/packages/documentation/.storybook/styles/preview.scss
+++ b/packages/documentation/.storybook/styles/preview.scss
@@ -10,7 +10,7 @@
 @use '@swisspost/internet-header/dist/swisspost-internet-header/swisspost-internet-header.css';
 @use './components';
 
-tokens.$default-map: utilities.$post-color;
+tokens.$default-map: utilities.$post-spacing;
 
 @include post.custom-property(('chevrondown', 'resizeexpand', 'link', 'code'));
 
@@ -21,7 +21,7 @@ $toolbar-icons: (
   '.docblock-code-toggle': 'chevrondown',
   '.docblock-code-toggle + button': 'resizeexpand',
   '.docblock-code-toggle + button + button': 'link',
-  '.docblock-code-toggle + button + button + button': 'code'
+  '.docblock-code-toggle + button + button + button': 'code',
 );
 
 #storybook-root,
@@ -73,8 +73,6 @@ $toolbar-icons: (
     }
   }
 
-
-
   .sbdocs-content .container {
     // Support for autolink-headings
     .docs-title :is(h1, h2, h3, h4, h5, h6),
@@ -109,7 +107,7 @@ $toolbar-icons: (
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: tokens.get('utility-gap-8', utilities.$post-spacing);
+    gap: tokens.get('utility-gap-8');
   }
 
   // aligns figma button to the title
@@ -124,7 +122,7 @@ $toolbar-icons: (
   }
 
   .docs-title {
-    margin-bottom: tokens.get('utility-gap-8', utilities.$post-spacing);
+    margin-bottom: tokens.get('utility-gap-8');
 
     :first-child {
       margin-right: auto;


### PR DESCRIPTION
## 📄 Description

Removed the unused color utility tokens map in preview file of the docs.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
