### PR TITLE
chore(nextjs): update `post-mainnavigation` markup after `post-list` removal

### DIFF
--- a/packages/nextjs-integration/src/app/ssr/layout.tsx
+++ b/packages/nextjs-integration/src/app/ssr/layout.tsx
@@ -102,19 +102,17 @@ export default function Layout({ children }: { readonly children: React.ReactNod
 
       {/* Main navigation */}
       <PostMainnavigation slot="main-nav">
-        <PostList title-hidden="">
-          <p>Main Navigation</p>
-
+        <ul>
           {/* Link only level 1 */}
-          <PostListItem slot="post-list-item">
+          <li>
             <a href="/letters">Letters</a>
-          </PostListItem>
-          <PostListItem slot="post-list-item">
+          </li>
+          <li>
             <a href="/packages">Packages</a>
-          </PostListItem>
+          </li>
 
             {/* Level 1 with megadropdown - Letters */}
-            <PostListItem slot="post-list-item">
+            <li>
               <PostMegadropdownTrigger for="letters">Letters</PostMegadropdownTrigger>
               <PostMegadropdown id="letters">
                 <button slot="back-button" className="btn btn-tertiary px-0 btn-sm">
@@ -158,10 +156,10 @@ export default function Layout({ children }: { readonly children: React.ReactNod
                   </PostListItem>
                 </PostList>
               </PostMegadropdown>
-            </PostListItem>
+            </li>
 
             {/* Level 1 with megadropdown - Packages */}
-            <PostListItem slot="post-list-item">
+            <li>
               <PostMegadropdownTrigger for="packages">Packages</PostMegadropdownTrigger>
               <PostMegadropdown id="packages">
                 <button slot="back-button" className="btn btn-tertiary px-0 btn-sm">
@@ -205,8 +203,8 @@ export default function Layout({ children }: { readonly children: React.ReactNod
                   </PostListItem>
                 </PostList>
               </PostMegadropdown>
-            </PostListItem>
-          </PostList>
+            </li>
+          </ul>
         </PostMainnavigation>
       </PostHeader>
 


### PR DESCRIPTION
## 📄 Description

Completes the cleanup from PR #6706 by removing remaining PostList and PostListItem usage in the Next.js integration package that wasn't updated when post-mainnavigation was simplified.

## Changes

- Replaced `<PostList>` wrapper with standard `<ul>` element inside `<PostMainnavigation>`
- Replaced `<PostListItem>` elements with standard `<li>` elements for main navigation items

## Testing

- [ ] Verify main navigation renders correctly
- [ ] Verify megadropdowns still function properly
- [ ] Check both desktop and mobile layouts

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
