### PR TITLE
chore(styles): add font face for swiss post sans extra black

### DIFF
--- a/.changeset/pretty-glasses-ring.md
+++ b/.changeset/pretty-glasses-ring.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': minor
+---
+
+Extended Swiss Post Sans font support with Extra Black (950) weight.

--- a/packages/styles/src/components/fonts.scss
+++ b/packages/styles/src/components/fonts.scss
@@ -2,6 +2,13 @@ $font-base-path: 'https://fonts.post.ch/swiss-post-sans/v1';
 
 @font-face {
   font-family: 'Swiss Post Sans';
+  font-weight: 950;
+  font-display: swap;
+  src: url('#{$font-base-path}/SwissPostSans-ExtraBlack.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Swiss Post Sans';
   font-weight: 900;
   font-display: swap;
   src: url('#{$font-base-path}/SwissPostSans-Black.woff2') format('woff2');


### PR DESCRIPTION
## 📄 Description

The PR adds a font-face for the Swiss Post Sans Extra Black already used in the `post-header` component.

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
