### PR TITLE
fix(components): disable focus on the post-linkarea host

### DIFF
--- a/.changeset/forty-llamas-admire.md
+++ b/.changeset/forty-llamas-admire.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Removed `tabindex="0"` from the `post-linkarea` component.
+The link area is mouse-only and should not be focusable, only the button it contains can receive keyboard focus.

--- a/packages/components/src/components/post-linkarea/post-linkarea.tsx
+++ b/packages/components/src/components/post-linkarea/post-linkarea.tsx
@@ -46,7 +46,7 @@ export class PostLinkarea {
 
   render() {
     return (
-      <Host data-version={version} onClick={(e: MouseEvent) => this.dispatchClick(e)} tabindex="0">
+      <Host data-version={version} onClick={(e: MouseEvent) => this.dispatchClick(e)}>
         <slot></slot>
       </Host>
     );


### PR DESCRIPTION
## 📄 Description

Remove the possibility to set focus on the `post-linkarea` host.

## 🚀 Demo

https://preview-6937--swisspost-design-system-next.netlify.app/?path=/story/1d52b794-768b-464e-90eb-4fd15774aa90--default

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
