### PR TITLE
chore(docs): add deprecation warning for PrimeNg styles

### DIFF
--- a/.changeset/great-glasses-deliver.md
+++ b/.changeset/great-glasses-deliver.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Deprecated the `@swisspost/design-system-styles-primeng` package in preparation for the transition to AG Grid, it will be removed in the next major version.

--- a/packages/documentation/src/stories/getting-started/packages/styles-primeng/styles-primeng.docs.mdx
+++ b/packages/documentation/src/stories/getting-started/packages/styles-primeng/styles-primeng.docs.mdx
@@ -16,6 +16,12 @@ The Design System Styles for PrimeNG datatables.
   <p>Other PrimeNG components (buttons, forms, menus, etc.) are not styled by this package and will use their default PrimeNG appearance.</p>
 </div>
 
+<div className="alert alert-warning alert-lg">
+  <h2 className="alert-heading">Deprecation Notice</h2>
+  <p>The PrimeNG styles are deprecated and will be removed in the next major version.</p>
+  <p>As part of our transition to <a href="https://www.ag-grid.com/">AG Grid</a>, a dedicated theme will be provided. New implementations should avoid using PrimeNG styles and prepare for the upcoming AG Grid-based solution.</p>
+</div>
+
 ## Prerequisites
 
 Make sure you have already installed and configured **PrimeNG** in your Angular project.


### PR DESCRIPTION
## 📄 Description

This PR adds a deprecation message for the `@swisspost/design-system-styles-primeng` package.

## 🚀 Demo

https://preview-6938--swisspost-design-system.netlify.app/?path=/docs/d2112bed-c611-4098-a1ad-e654f7d622e7--docs

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
