### PR TITLE
fix(components): update close button focus styles

### DIFF
--- a/.changeset/puny-kids-return.md
+++ b/.changeset/puny-kids-return.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Updated `post-closebutton` focus styles to always match other buttons, ensuring a consistent focus ring.

--- a/packages/components/src/components/post-closebutton/post-closebutton.scss
+++ b/packages/components/src/components/post-closebutton/post-closebutton.scss
@@ -28,6 +28,8 @@ post-closebutton .btn {
     height: tokens.get('close-icon-size');
   }
 
+  @include utilities.focus-style;
+
   @include utilities.not-disabled-hover() {
     cursor: pointer;
     background-color: tokens.get('close-hover-bg');


### PR DESCRIPTION
## 📄 Description

Add focus style to the `post-closebutton` component so that it is properly styled when used in a shadow DOM.

## 🚀 Demo

Before:
<img width="1442" height="472" alt="image" src="https://github.com/user-attachments/assets/b31d6d24-84b4-42d7-ae71-14c4277e5050" />

After:
<img width="1442" height="472" alt="image" src="https://github.com/user-attachments/assets/ae2bc557-014b-4cad-95f2-8e4bdc3197b4" />

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
