### PR TITLE
feat(docs): document input with datalist

### DIFF
--- a/.changeset/twelve-trams-remain.md
+++ b/.changeset/twelve-trams-remain.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': minor
+---
+
+Added documentation describing how inputs can be combined with a datalist to offer suggested values, replacing the previous typeahead approach.

--- a/packages/documentation/src/stories/components/input/input.docs.mdx
+++ b/packages/documentation/src/stories/components/input/input.docs.mdx
@@ -27,9 +27,7 @@ Custom input elements need only the class `.form-control` to trigger the custom 
 
 <StylesPackageImport components={['form-input']} required={{ validation: true }} />
 
-## Concrete Examples of Application
-
-The following examples show the different characteristics of the component. These can differ in the type of visualization, the HTML structure, as well as when, how and why they are displayed.
+## Examples
 
 ### Floating Label
 
@@ -39,3 +37,16 @@ But note that the `<input>` element must come first, so we can ensure the correc
 Ensure that `placeholder` attribute is set (even with an empty value) so the label can act as a placeholder when no value is set.
 
 <Canvas of={InputStories.FloatingLabel} />
+
+### Autocomplete
+
+You can provide users with a list of suggested options for an input field using a standard HTML `<input>` paired with a `<datalist>`.
+
+The `list` attribute links the input to the datalist, allowing suggestions to appear as the user types while still permitting custom values.
+The browser handles filtering automatically, so no additional scripts are required for basic functionality.
+
+This approach is supported in most modern browsers and can be extended for dynamic options by generating `<option>` elements programmatically.
+
+You can find more information in the [MDN documentation for the datalist element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/datalist).
+
+<Canvas of={InputStories.Autocomplete} />

--- a/packages/documentation/src/stories/components/input/input.stories.ts
+++ b/packages/documentation/src/stories/components/input/input.stories.ts
@@ -14,6 +14,9 @@ const meta: MetaComponent = {
       type: 'figma',
       url: 'https://www.figma.com/design/JIT5AdGYqv6bDRpfBPV8XR/Foundations---Components-Next-Level?node-id=21-168',
     },
+    controls: {
+      exclude: ['List id'],
+    },
   },
   args: {
     label: 'Label',
@@ -105,6 +108,16 @@ const meta: MetaComponent = {
         category: 'General',
       },
     },
+    list: {
+      name: 'List id',
+      description: 'The id of the datalist providing options to the user.',
+      control: {
+        type: 'text',
+      },
+      table: {
+        category: 'General',
+      },
+    },
     disabled: {
       name: 'Disabled',
       description:
@@ -157,7 +170,7 @@ export default meta;
 type Story = StoryObj;
 
 function render(args: Args, context: StoryContext) {
-  const id = context.id ?? `ExampleTextarea_${context.name}`;
+  const id = context.id ?? `ExampleInput_${context.name}`;
   const classes = ['form-control', args.validation].filter(c => c && c !== 'null').join(' ');
 
   const useAriaLabel = !args.floatingLabel && args.hiddenLabel;
@@ -186,6 +199,7 @@ function render(args: Args, context: StoryContext) {
       class="${classes}"
       type="${args.type}"
       placeholder="${args.placeholder || nothing}"
+      list="${args.list || nothing}"
       ?disabled="${args.disabled}"
       aria-label="${useAriaLabel ? args.label : nothing}"
       ?aria-invalid="${VALIDATION_STATE_MAP[args.validation]}"
@@ -227,5 +241,28 @@ export const Validation: Story = {
     validation: 'is-invalid',
     hint: '',
     floatingLabel: true,
+  },
+};
+
+export const Autocomplete: Story = {
+  args: {
+    id: 'postal-option',
+    list: 'postal-options',
+    label: 'Postal Option',
+    placeholder: 'Start typing...',
+    hint: 'Start typing to see suggested options, for example “Registered” or “Express”.',
+  },
+  render: (args, context) => {
+    return html`
+      ${render(args, context)}
+
+      <datalist id=${args.list}>
+        <option value="Standard"></option>
+        <option value="Express"></option>
+        <option value="Registered"></option>
+        <option value="International"></option>
+        <option value="Parcel Pickup"></option>
+      </datalist>
+    `;
   },
 };

--- a/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
+++ b/packages/documentation/src/stories/misc/migration-guide/migrationv9-10.component.ts
@@ -271,7 +271,13 @@ export class MigrationV99Component extends LitElement {
                           <li>pagination → <i>coming soon</i></li>
                           <li>progressbar → <i>coming soon</i></li>
                           <li>timepicker → <i>coming soon</i></li>
-                          <li>typeahead → <i>coming soon</i></li>
+                          <li>
+                            typeahead →
+                            <a
+                              href="/?path=/docs/2df77c32-5e33-402e-bd2e-54d54271ce19--docs#autocomplete"
+                              >input with datalist</a
+                            >
+                          </li>
                         </ul>
                         <span class="info"
                           >Each removed Ng-Bootstrap component has (or will have) an equivalent in


### PR DESCRIPTION
## 📄 Description

This PR adds documentation for inputs with datalist.

## 🚀 Demo

https://preview-6941--swisspost-design-system-next.netlify.app/?path=/docs/2df77c32-5e33-402e-bd2e-54d54271ce19--docs#autocomplete

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
