### PR TITLE
fix(styles): correctly style header nav items when not in lists

### DIFF
--- a/.changeset/moody-moose-wait.md
+++ b/.changeset/moody-moose-wait.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Fixed an issue where certain header navigation items were not styled correctly when they were not contained within lists.

--- a/packages/styles/src/components/header/_post-header.scss
+++ b/packages/styles/src/components/header/_post-header.scss
@@ -51,14 +51,16 @@ post-header {
   }
 
   // audience
-  > ul[slot='audience'] {
-    @include media.only(tablet) {
-      flex-direction: row;
-      margin-block: 1rem;
-    }
+  > [slot='audience'] {
+    &:where(ul) {
+      @include media.only(tablet) {
+        flex-direction: row;
+        margin-block: 1rem;
+      }
 
-    @include media.only(mobile) {
-      gap: 0.5rem;
+      @include media.only(mobile) {
+        gap: 0.5rem;
+      }
     }
 
     @include interactive-elements {
@@ -67,7 +69,7 @@ post-header {
   }
 
   // meta navigation on desktop
-  > ul[slot='global-nav-secondary'] {
+  > [slot='global-nav-secondary'] {
     @include media.max(desktop) {
       &:where(ul) {
         flex-direction: column;


### PR DESCRIPTION
## 📄 Description

This PR fixes style for the header navigation items when not contained within lists.

## 🚀 Demo

https://preview-6943--swisspost-design-system-next.netlify.app/iframe.html?viewMode=story&id=27a2e64d-55ba-492d-ab79-5f7c5e818498--jobs

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
