### PR TITLE
feat(components): add focus ring to post-linkarea

### DIFF
--- a/.changeset/frank-cities-lick.md
+++ b/.changeset/frank-cities-lick.md
@@ -1,6 +1,5 @@
 ---
 '@swisspost/design-system-components': patch
-'@swisspost/design-system-styles': patch
 ---
 
 Updated the focus behavior of the `post-linkarea` component.

--- a/packages/components/src/components/post-linkarea/post-linkarea.tsx
+++ b/packages/components/src/components/post-linkarea/post-linkarea.tsx
@@ -25,10 +25,12 @@ export class PostLinkarea {
   private checkInteractiveElements() {
     this.interactiveElements = this.host.querySelectorAll(INTERACTIVE_ELEMENTS_SELECTOR);
 
-    if (this.interactiveElements.length > 1) {
+    if (this.interactiveElements.length !== 1) {
       console.error(
-        `The \`post-linkarea\` currently contains ${this.interactiveElements.length} interactive elements when it should contain only one.`,
+        `The \`post-linkarea\` currently contains ${this.interactiveElements.length} interactive elements when it should contain exactly one.`,
       );
+    } else {
+      this.interactiveElements[0].style.setProperty('outline', 'unset', 'important');
     }
   }
 

--- a/packages/documentation/src/stories/components/card/card.stories.ts
+++ b/packages/documentation/src/stories/components/card/card.stories.ts
@@ -164,7 +164,7 @@ export const Interactivity: Story = {
       title: 'Non-interactive card',
       body:
         'A non-interactive card is not clickable. ' +
-        'It contains however either none one or more interactive elements where each of them triggers different actions.',
+        'It contains however either none, one or more interactive elements where each of them triggers different actions.',
     })}
   `,
 };

--- a/packages/styles/src/components/card.scss
+++ b/packages/styles/src/components/card.scss
@@ -24,10 +24,6 @@ tokens.$default-map: components.$post-cards;
     border: 0;
     box-shadow: tokens.get('card-interactive-elevation');
 
-    a.btn {
-      @include utilities-mx.focus-style-none;
-    }
-
     &:hover {
       background-color: tokens.get('card-hover-bg');
 

--- a/packages/styles/src/elements/anchor.scss
+++ b/packages/styles/src/elements/anchor.scss
@@ -15,10 +15,6 @@ a {
 
   @include utilities.focus-style;
 
-  post-linkarea & {
-    @include utilities.focus-style-none;
-  }
-
   @include utilities.high-contrast-mode() {
     &,
     &:focus {


### PR DESCRIPTION
## 📄 Description

This PR adds a focus ring around the `post-linkarea` when the link it contains receives focus.

## 🚀 Demo

https://preview-7002--swisspost-design-system-next.netlify.app/?path=/docs/1d52b794-768b-464e-90eb-4fd15774aa90--docs

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
