### PR TITLE
feat(components): update post-avatar transition

### DIFF
--- a/.changeset/upset-sites-decide.md
+++ b/.changeset/upset-sites-decide.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Added foreground and background color transitions to `post-avatar` component.

--- a/packages/components/src/components/post-avatar/post-avatar.scss
+++ b/packages/components/src/components/post-avatar/post-avatar.scss
@@ -1,5 +1,6 @@
 @use '@swisspost/design-system-styles/tokens/components';
 @use '@swisspost/design-system-styles/functions/tokens';
+@use '@swisspost/design-system-styles/variables/components/button';
 @use '@swisspost/design-system-styles/core' as post;
 
 tokens.$default-map: components.$post-avatar;
@@ -64,6 +65,7 @@ img,
   color: var(--post-avatar-fg);
   text-transform: uppercase;
   font-weight: 400;
+  transition: button.$btn-transition;
 
   span {
     @include post.visuallyhidden();


### PR DESCRIPTION
## 📄 Description

The PR adds a transition to the `post-avatar` to match the one of a button.

## 🚀 Demo

https://preview-7072--swisspost-design-system-next.netlify.app/?path=/docs/27a2e64d-55ba-492d-ab79-5f7c5e818498--docs#logged-in

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
