### PR TITLE
fix(components): null check on `post-stepper`

### DIFF
--- a/.changeset/modern-rockets-jam.md
+++ b/.changeset/modern-rockets-jam.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Added null guard when reading step label during initial render.

--- a/packages/components/src/components/post-stepper/post-stepper.tsx
+++ b/packages/components/src/components/post-stepper/post-stepper.tsx
@@ -99,8 +99,10 @@ export class PostStepper {
     this.updateActiveStepNumber();
 
     this.stepItems.forEach((el, i) => {
-      if (this.currentIndex === i) {
-        this.mobileActiveStepName = el.querySelector('.label').innerHTML;
+      const labelEl = el.querySelector('.label');
+
+      if (this.currentIndex === i && labelEl) {
+        this.mobileActiveStepName = labelEl.innerHTML;
       }
 
       // Update "post-stepper-item" classes to show correct status


### PR DESCRIPTION
## 📄 Description

Fixed an error in the console that occured because the label was being read even though it was not yet present in the DOM.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
