### PR TITLE
fix(workflow): allow cache miss on main/release for baseline generation

### DIFF
--- a/.github/workflows/visual-tests.yaml
+++ b/.github/workflows/visual-tests.yaml
@@ -51,6 +51,15 @@ jobs:
         working-directory: packages/components
         run: npx playwright install --with-deps
 
+      - name: Check if baseline branch
+        id: is-baseline-branch
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" =~ ^release/v[0-9]+$ ]]; then
+            echo "result=true" >> $GITHUB_OUTPUT
+          else
+            echo "result=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Get baseline snapshots from cache
         id: snapshot-cache
         uses: actions/cache@v4
@@ -59,14 +68,14 @@ jobs:
           key: ${{ runner.os }}-vrt-snapshots-${{ hashFiles('packages/components/src/**/*.scss') }}
           restore-keys: |
             ${{ runner.os }}-vrt-snapshots-
-          # Allow cache miss on main and release/v* branches so baselines can be generated
+          # Allow cache miss on main and release/v[0-9]+ branches so baselines can be generated
           # Fail on cache miss for all other branches (PRs) to ensure they test against existing baselines
-          fail-on-cache-miss: ${{ github.ref_name != 'main' && !startsWith(github.ref_name, 'release/v') }}
+          fail-on-cache-miss: ${{ steps.is-baseline-branch.outputs.result != 'true' }}
       
       - name: Check if baseline update needed
         id: should-update
         run: |
-          if [[ ("${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" =~ ^release/v) && "${{ steps.snapshot-cache.outputs.cache-hit }}" != "true" ]] || [[ "${{ github.event.inputs.update-snapshots }}" == "true" ]]; then
+          if [[ "${{ steps.is-baseline-branch.outputs.result }}" == "true" && "${{ steps.snapshot-cache.outputs.cache-hit }}" != "true" ]] || [[ "${{ github.event.inputs.update-snapshots }}" == "true" ]]; then
             echo "update=true" >> $GITHUB_OUTPUT
           else
             echo "update=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## The Problem:
The workflow is currently failing on main because of a circular dependency:

- It requires a cache to exist (fail-on-cache-miss: true)
- But it can't create the cache because it fails before generating baselines
- This means we can never create or regenerate baselines on main
<img width="1531" height="944" alt="Screenshot 2026-02-03 134308" src="https://github.com/user-attachments/assets/298cb141-11b5-44b7-93a9-396d5f2c00ca" />


## The Fix:
I've made the cache requirement conditional:

- Main/release branches: Allow cache miss (so we can generate baselines)
- Other branches: Require cache (so PRs test against known baselines)

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
