### PR TITLE
fix(styles): add validation icon to non-floating inputs

### DIFF
--- a/.changeset/perky-eyes-throw.md
+++ b/.changeset/perky-eyes-throw.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Added missing validation icons on valid and invalid form inputs that are not floating.

--- a/packages/styles/src/components/form-input.scss
+++ b/packages/styles/src/components/form-input.scss
@@ -1,6 +1,7 @@
 @use './../functions/tokens';
 @use './../tokens/components';
 @use './../mixins/utilities';
+@use './../mixins/forms' as forms-mx;
 
 tokens.$default-map: components.$post-text-input;
 
@@ -222,6 +223,9 @@ input.form-control {
   &.is-valid,
   &.is-invalid {
     &:not(:disabled) {
+      background-size: tokens.get('input-sizing-icon') tokens.get('input-sizing-icon');
+      background-position: top 50% right tokens.get('input-validation-icon-position-inline-end');
+      background-repeat: no-repeat;
       padding-inline-end: calc(
         #{tokens.get('input-padding-inline-end')} +
           #{tokens.get('input-validation-icon-position-inline-end')} +
@@ -229,6 +233,11 @@ input.form-control {
       );
     }
   }
+}
+
+// Only adds validation icons as background-image on none floating elements
+*:not(.form-floating) > input.form-control {
+  @include forms-mx.validation-icons;
 }
 
 .form-label:has(+ input.form-control[disabled]) {


### PR DESCRIPTION
## 📄 Description

This PR adds missing validation icons on valid and invalid form inputs that are not floating.

## 🚀 Demo

https://preview-7200--swisspost-design-system-next.netlify.app/?path=/docs/2df77c32-5e33-402e-bd2e-54d54271ce19--docs&story=Default&args=floatingLabel:false;validation:is-invalid#2df77c32-5e33-402e-bd2e-54d54271ce19--default

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
