### PR TITLE
GenAI PoC1: feat(components): add post-autocomplete component [DUMMY - AI Validation]

### DIFF
--- a/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.html
+++ b/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.html
@@ -1,4 +1,23 @@
 <div class="my-24">
+  <h2>Autocomplete</h2>
+  <label for="country-input" class="form-label">Country</label>
+  <post-autocomplete label="Search countries">
+    <input
+      id="country-input"
+      type="text"
+      class="form-control"
+      placeholder="Type to search..."
+      autocomplete="off"
+    />
+    <div slot="options">
+      @for (country of countries; track country) {
+        <post-option [value]="country">{{ country }}</post-option>
+      }
+    </div>
+  </post-autocomplete>
+</div>
+
+<div class="my-24">
   <h2>Accordion</h2>
   <post-accordion [headingLevel]="3">
     <post-accordion-item>

--- a/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.ts
+++ b/packages/components-angular/projects/consumer-app/src/app/routes/home/home.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import {
   PostAccordion,
   PostAccordionItem,
+  PostAutocomplete,
   PostAvatar,
   PostBanner,
   PostCardControl,
@@ -10,9 +11,11 @@ import {
   PostDatepicker,
   PostIcon,
   PostLinkarea,
+  PostListbox,
   PostMenu,
   PostMenuTrigger,
   PostMenuItem,
+  PostOption,
   PostPagination,
   PostPopover,
   PostPopovercontainer,
@@ -37,6 +40,7 @@ import {
   imports: [
     PostAccordion,
     PostAccordionItem,
+    PostAutocomplete,
     PostAvatar,
     PostBanner,
     PostCardControl,
@@ -46,9 +50,11 @@ import {
     PostDatepicker,
     PostIcon,
     PostLinkarea,
+    PostListbox,
     PostMenu,
     PostMenuTrigger,
     PostMenuItem,
+    PostOption,
     PostPagination,
     PostPopover,
     PostPopovercontainer,
@@ -67,4 +73,10 @@ import {
 })
 export class HomeComponent {
   isCollapsed = false;
+  
+  // Sample countries for autocomplete
+  countries = [
+    'Switzerland', 'Germany', 'France', 'Italy', 'Austria',
+    'Belgium', 'Netherlands', 'Spain', 'Portugal', 'United Kingdom'
+  ];
 }

--- a/packages/components/cypress/e2e/autocomplete.cy.ts
+++ b/packages/components/cypress/e2e/autocomplete.cy.ts
@@ -1,0 +1,209 @@
+const AUTOCOMPLETE_ID = 'f8e3a1b2-4c5d-6e7f-8a9b-0c1d2e3f4a5b';
+
+describe('autocomplete', () => {
+  describe('default', () => {
+    beforeEach(() => {
+      cy.getComponents(AUTOCOMPLETE_ID, 'default', 'post-autocomplete');
+
+      // Ensure the component is hydrated
+      cy.get('post-autocomplete[data-hydrated]');
+      cy.get('post-autocomplete').as('autocomplete');
+      cy.get('post-autocomplete input').as('input');
+    });
+
+    it('should have an autocomplete component', () => {
+      cy.get('@autocomplete').should('exist');
+    });
+
+    it('should have an input element', () => {
+      cy.get('@input').should('exist');
+    });
+
+    it('should have combobox role on input', () => {
+      cy.get('@input').should('have.attr', 'role', 'combobox');
+    });
+
+    it('should have aria-autocomplete attribute', () => {
+      cy.get('@input').should('have.attr', 'aria-autocomplete', 'list');
+    });
+
+    it('should be initially collapsed', () => {
+      cy.get('@input').should('have.attr', 'aria-expanded', 'false');
+    });
+
+    it('should show dropdown when typing', () => {
+      cy.get('@input').type('Swi');
+      cy.get('@autocomplete')
+        .shadow()
+        .find('post-popovercontainer')
+        .should('not.have.css', 'display', 'none');
+    });
+
+    it('should update aria-expanded when dropdown opens', () => {
+      cy.get('@input').type('Swi');
+      cy.get('@input').should('have.attr', 'aria-expanded', 'true');
+    });
+
+    it('should filter options based on input', () => {
+      cy.get('@input').type('Swi');
+      cy.get('post-option[value="Switzerland"]').should('be.visible');
+      cy.get('post-option[value="Germany"]').should('have.css', 'display', 'none');
+    });
+
+    it('should close dropdown when pressing Escape', () => {
+      cy.get('@input').type('Swi');
+      cy.get('@input').should('have.attr', 'aria-expanded', 'true');
+      cy.get('@input').type('{esc}');
+      cy.get('@input').should('have.attr', 'aria-expanded', 'false');
+    });
+
+    it('should select option with Enter key', () => {
+      cy.get('@input').type('Swi');
+      cy.get('@input').type('{downarrow}');
+      cy.get('@input').type('{enter}');
+      cy.get('@input').should('have.value', 'Switzerland');
+    });
+
+    it('should close dropdown after selection', () => {
+      cy.get('@input').type('Swi');
+      cy.get('@input').type('{enter}');
+      cy.get('@input').should('have.attr', 'aria-expanded', 'false');
+    });
+
+    it('should navigate options with arrow keys', () => {
+      cy.get('@input').type('A');
+      // Wait for dropdown to open
+      cy.get('@input').should('have.attr', 'aria-expanded', 'true');
+      
+      // Navigate down
+      cy.get('@input').type('{downarrow}');
+      cy.get('@input').should('have.attr', 'aria-activedescendant');
+    });
+
+    it('should select option when clicking', () => {
+      cy.get('@input').type('Swi');
+      cy.get('post-option[value="Switzerland"]').click();
+      cy.get('@input').should('have.value', 'Switzerland');
+    });
+  });
+
+  describe('with disabled options', () => {
+    beforeEach(() => {
+      cy.getComponents(AUTOCOMPLETE_ID, 'with-disabled-options', 'post-autocomplete');
+      cy.get('post-autocomplete[data-hydrated]');
+      cy.get('post-autocomplete').as('autocomplete');
+      cy.get('post-autocomplete input').as('input');
+    });
+
+    it('should not select disabled options', () => {
+      cy.get('@input').type('Phone');
+      cy.get('post-option[value="phone"]').should('have.attr', 'aria-disabled', 'true');
+      cy.get('post-option[value="phone"]').click();
+      cy.get('@input').should('not.have.value', 'Phone (Out of stock)');
+    });
+
+    it('should skip disabled options during keyboard navigation', () => {
+      cy.get('@input').type('p');
+      // First option should be highlighted, then skip disabled to next enabled
+      cy.get('@input').type('{downarrow}');
+      cy.get('@input').type('{downarrow}');
+      // Should skip 'phone' which is disabled
+    });
+  });
+
+  describe('with min-chars', () => {
+    beforeEach(() => {
+      cy.getComponents(AUTOCOMPLETE_ID, 'with-min-chars', 'post-autocomplete');
+      cy.get('post-autocomplete[data-hydrated]');
+      cy.get('post-autocomplete').as('autocomplete');
+      cy.get('post-autocomplete input').as('input');
+    });
+
+    it('should not show dropdown with less than min-chars', () => {
+      cy.get('@input').type('Sw');
+      cy.get('@autocomplete')
+        .shadow()
+        .find('post-popovercontainer')
+        .should('have.css', 'display', 'none');
+    });
+
+    it('should show dropdown when min-chars is reached', () => {
+      cy.get('@input').type('Swi');
+      cy.get('@autocomplete')
+        .shadow()
+        .find('post-popovercontainer')
+        .should('not.have.css', 'display', 'none');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    beforeEach(() => {
+      cy.getComponents(AUTOCOMPLETE_ID, 'default', 'post-autocomplete');
+      cy.get('post-autocomplete[data-hydrated]');
+      cy.get('post-autocomplete').as('autocomplete');
+      cy.get('post-autocomplete input').as('input');
+    });
+
+    it('should open dropdown with ArrowDown when closed', () => {
+      cy.get('@input').focus();
+      cy.get('@input').type('{downarrow}');
+      // Dropdown should open but might be empty if no value
+    });
+
+    it('should jump to first option with Home key', () => {
+      cy.get('@input').type('A');
+      cy.get('@input').type('{downarrow}');
+      cy.get('@input').type('{downarrow}');
+      cy.get('@input').type('{home}');
+      // Should be back at first option
+    });
+
+    it('should jump to last option with End key', () => {
+      cy.get('@input').type('A');
+      cy.get('@input').type('{end}');
+      // Should be at last matching option
+    });
+
+    it('should close dropdown with Tab', () => {
+      cy.get('@input').type('Swi');
+      cy.get('@input').should('have.attr', 'aria-expanded', 'true');
+      cy.get('@input').tab();
+      cy.get('@input').should('have.attr', 'aria-expanded', 'false');
+    });
+  });
+
+  describe('accessibility', () => {
+    beforeEach(() => {
+      cy.getComponents(AUTOCOMPLETE_ID, 'default', 'post-autocomplete');
+      cy.get('post-autocomplete[data-hydrated]');
+      cy.get('post-autocomplete').as('autocomplete');
+      cy.get('post-autocomplete input').as('input');
+    });
+
+    it('should have aria-owns pointing to listbox', () => {
+      cy.get('@input').should('have.attr', 'aria-owns');
+    });
+
+    it('should have aria-haspopup attribute', () => {
+      cy.get('@input').should('have.attr', 'aria-haspopup', 'listbox');
+    });
+
+    it('should update aria-activedescendant during navigation', () => {
+      cy.get('@input').type('A');
+      cy.get('@input').type('{downarrow}');
+      cy.get('@input')
+        .should('have.attr', 'aria-activedescendant')
+        .and('not.be.empty');
+    });
+
+    it('should have role=option on post-option elements', () => {
+      cy.get('@input').type('A');
+      cy.get('post-option').first().should('have.attr', 'role', 'option');
+    });
+
+    it('should have aria-selected on options', () => {
+      cy.get('@input').type('A');
+      cy.get('post-option').first().should('have.attr', 'aria-selected');
+    });
+  });
+});

--- a/packages/components/src/components.d.ts
+++ b/packages/components/src/components.d.ts
@@ -81,6 +81,52 @@ export namespace Components {
          */
         "userid"?: string;
     }
+    interface PostAutocomplete {
+        /**
+          * If `true`, automatically highlights the first matching option.
+          * @default false
+         */
+        "autoHighlight": boolean;
+        /**
+          * Clears the current value.
+         */
+        "clear": () => Promise<void>;
+        /**
+          * Closes the autocomplete dropdown.
+         */
+        "close": () => Promise<void>;
+        /**
+          * A descriptive label for assistive technologies.
+         */
+        "label"?: string;
+        /**
+          * The minimum number of characters required before showing suggestions.
+          * @default 1
+         */
+        "minChars": number;
+        /**
+          * Opens the autocomplete dropdown.
+         */
+        "open": () => Promise<void>;
+        /**
+          * Defines the position of the dropdown relative to the input.
+          * @default 'bottom-start'
+         */
+        "placement"?: Placement1;
+        /**
+          * Sets the value programmatically.
+         */
+        "setValue": (value: string) => Promise<void>;
+        /**
+          * Toggles the autocomplete dropdown.
+         */
+        "toggle": () => Promise<void>;
+        /**
+          * The current value of the autocomplete input.
+          * @default ''
+         */
+        "value": string;
+    }
     interface PostBackToTop {
         /**
           * The label of the back-to-top button, intended solely for accessibility purposes. This label is always hidden from view.
@@ -395,6 +441,45 @@ export namespace Components {
          */
         "url"?: string | URL;
     }
+    interface PostListbox {
+        /**
+          * Clears the current selection.
+         */
+        "clearSelection": () => Promise<void>;
+        /**
+          * Focuses the first non-disabled option.
+         */
+        "focusFirst": () => Promise<void>;
+        /**
+          * Focuses the last non-disabled option.
+         */
+        "focusLast": () => Promise<void>;
+        /**
+          * Returns all post-option elements in the listbox.
+         */
+        "getOptions": () => Promise<HTMLElement[]>;
+        /**
+          * A descriptive label for the listbox for assistive technologies.
+         */
+        "label"?: string;
+        /**
+          * If `true`, multiple options can be selected.
+          * @default false
+         */
+        "multiple": boolean;
+        /**
+          * Selects an option by value.
+         */
+        "selectValue": (value: string) => Promise<void>;
+        /**
+          * Sets the active (focused) option by index.
+         */
+        "setActiveIndex": (index: number) => Promise<void>;
+        /**
+          * The currently selected value.
+         */
+        "value"?: string;
+    }
     interface PostMainnavigation {
         /**
           * Defines the accessible label for the navigation element. This text is used as the `aria-label` attribute to provide screen reader users with a description of the navigation's purpose.
@@ -471,6 +556,22 @@ export namespace Components {
         "for": string;
     }
     interface PostNumberInput {
+    }
+    interface PostOption {
+        /**
+          * If `true`, the option cannot be selected.
+          * @default false
+         */
+        "disabled": boolean;
+        /**
+          * If `true`, the option is currently selected.
+          * @default false
+         */
+        "selected": boolean;
+        /**
+          * The value of the option. This is what gets submitted when the option is selected.
+         */
+        "value": string;
     }
     interface PostPagination {
         /**
@@ -751,6 +852,18 @@ export interface PostTabsCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLPostTabsElement;
 }
+export interface PostAutocompleteCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPostAutocompleteElement;
+}
+export interface PostListboxCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPostListboxElement;
+}
+export interface PostOptionCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLPostOptionElement;
+}
 declare global {
     interface HTMLPostAccordionElement extends Components.PostAccordion, HTMLStencilElement {
     }
@@ -769,6 +882,26 @@ declare global {
     var HTMLPostAvatarElement: {
         prototype: HTMLPostAvatarElement;
         new (): HTMLPostAvatarElement;
+    };
+    interface HTMLPostAutocompleteElementEventMap {
+        "postSelect": { value: string; label: string };
+        "postInput": string;
+        "postOpen": void;
+        "postClose": void;
+    }
+    interface HTMLPostAutocompleteElement extends Components.PostAutocomplete, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLPostAutocompleteElementEventMap>(type: K, listener: (this: HTMLPostAutocompleteElement, ev: PostAutocompleteCustomEvent<HTMLPostAutocompleteElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLPostAutocompleteElementEventMap>(type: K, listener: (this: HTMLPostAutocompleteElement, ev: PostAutocompleteCustomEvent<HTMLPostAutocompleteElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLPostAutocompleteElement: {
+        prototype: HTMLPostAutocompleteElement;
+        new (): HTMLPostAutocompleteElement;
     };
     interface HTMLPostBackToTopElement extends Components.PostBackToTop, HTMLStencilElement {
     }
@@ -935,6 +1068,24 @@ declare global {
         prototype: HTMLPostLogoElement;
         new (): HTMLPostLogoElement;
     };
+    interface HTMLPostListboxElementEventMap {
+        "postChange": string | string[];
+        "postFocus": { value: string; index: number };
+    }
+    interface HTMLPostListboxElement extends Components.PostListbox, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLPostListboxElementEventMap>(type: K, listener: (this: HTMLPostListboxElement, ev: PostListboxCustomEvent<HTMLPostListboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLPostListboxElementEventMap>(type: K, listener: (this: HTMLPostListboxElement, ev: PostListboxCustomEvent<HTMLPostListboxElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLPostListboxElement: {
+        prototype: HTMLPostListboxElement;
+        new (): HTMLPostListboxElement;
+    };
     interface HTMLPostMainnavigationElement extends Components.PostMainnavigation, HTMLStencilElement {
     }
     var HTMLPostMainnavigationElement: {
@@ -998,6 +1149,23 @@ declare global {
     var HTMLPostNumberInputElement: {
         prototype: HTMLPostNumberInputElement;
         new (): HTMLPostNumberInputElement;
+    };
+    interface HTMLPostOptionElementEventMap {
+        "postOptionSelect": string;
+    }
+    interface HTMLPostOptionElement extends Components.PostOption, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLPostOptionElementEventMap>(type: K, listener: (this: HTMLPostOptionElement, ev: PostOptionCustomEvent<HTMLPostOptionElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLPostOptionElementEventMap>(type: K, listener: (this: HTMLPostOptionElement, ev: PostOptionCustomEvent<HTMLPostOptionElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLPostOptionElement: {
+        prototype: HTMLPostOptionElement;
+        new (): HTMLPostOptionElement;
     };
     interface HTMLPostPaginationElementEventMap {
         "postChange": number;
@@ -1214,6 +1382,48 @@ declare namespace LocalJSX {
           * Defines the company internal userId.<post-banner type="warning" data-size="sm"><p>Can only be used on post.ch domains!</p></post-banner>
          */
         "userid"?: string;
+    }
+    interface PostAutocomplete {
+        /**
+          * If `true`, automatically highlights the first matching option.
+          * @default false
+         */
+        "autoHighlight"?: boolean;
+        /**
+          * A descriptive label for assistive technologies.
+         */
+        "label"?: string;
+        /**
+          * The minimum number of characters required before showing suggestions.
+          * @default 1
+         */
+        "minChars"?: number;
+        /**
+          * Emitted when the dropdown closes.
+         */
+        "onPostClose"?: (event: PostAutocompleteCustomEvent<void>) => void;
+        /**
+          * Emitted when the input value changes.
+         */
+        "onPostInput"?: (event: PostAutocompleteCustomEvent<string>) => void;
+        /**
+          * Emitted when the dropdown opens.
+         */
+        "onPostOpen"?: (event: PostAutocompleteCustomEvent<void>) => void;
+        /**
+          * Emitted when an option is selected.
+         */
+        "onPostSelect"?: (event: PostAutocompleteCustomEvent<{ value: string; label: string }>) => void;
+        /**
+          * Defines the position of the dropdown relative to the input.
+          * @default 'bottom-start'
+         */
+        "placement"?: Placement1;
+        /**
+          * The current value of the autocomplete input.
+          * @default ''
+         */
+        "value"?: string;
     }
     interface PostBackToTop {
         /**
@@ -1520,6 +1730,25 @@ declare namespace LocalJSX {
          */
         "url"?: string | URL;
     }
+    interface PostListbox {
+        /**
+          * A descriptive label for the listbox for assistive technologies.
+         */
+        "label"?: string;
+        /**
+          * If `true`, multiple options can be selected.
+          * @default false
+         */
+        "multiple"?: boolean;
+        /**
+          * Emitted when the selection changes.
+         */
+        "onPostChange"?: (event: PostListboxCustomEvent<string>) => void;
+        /**
+          * The currently selected value.
+         */
+        "value"?: string;
+    }
     interface PostMainnavigation {
         /**
           * Defines the accessible label for the navigation element. This text is used as the `aria-label` attribute to provide screen reader users with a description of the navigation's purpose.
@@ -1575,6 +1804,26 @@ declare namespace LocalJSX {
         "for": string;
     }
     interface PostNumberInput {
+    }
+    interface PostOption {
+        /**
+          * If `true`, the option cannot be selected.
+          * @default false
+         */
+        "disabled"?: boolean;
+        /**
+          * Emitted when the option is selected.
+         */
+        "onPostOptionSelect"?: (event: PostOptionCustomEvent<{ value: string; label: string }>) => void;
+        /**
+          * If `true`, the option is currently selected.
+          * @default false
+         */
+        "selected"?: boolean;
+        /**
+          * The value of the option. This is what gets submitted when the option is selected.
+         */
+        "value"?: string;
     }
     interface PostPagination {
         /**
@@ -1801,6 +2050,7 @@ declare namespace LocalJSX {
         "post-accordion": PostAccordion;
         "post-accordion-item": PostAccordionItem;
         "post-avatar": PostAvatar;
+        "post-autocomplete": PostAutocomplete;
         "post-back-to-top": PostBackToTop;
         "post-banner": PostBanner;
         "post-breadcrumb-item": PostBreadcrumbItem;
@@ -1818,6 +2068,7 @@ declare namespace LocalJSX {
         "post-language-menu-item": PostLanguageMenuItem;
         "post-linkarea": PostLinkarea;
         "post-logo": PostLogo;
+        "post-listbox": PostListbox;
         "post-mainnavigation": PostMainnavigation;
         "post-megadropdown": PostMegadropdown;
         "post-megadropdown-trigger": PostMegadropdownTrigger;
@@ -1825,6 +2076,7 @@ declare namespace LocalJSX {
         "post-menu-item": PostMenuItem;
         "post-menu-trigger": PostMenuTrigger;
         "post-number-input": PostNumberInput;
+        "post-option": PostOption;
         "post-pagination": PostPagination;
         "post-popover": PostPopover;
         "post-popover-trigger": PostPopoverTrigger;
@@ -1847,6 +2099,7 @@ declare module "@stencil/core" {
             "post-accordion": LocalJSX.PostAccordion & JSXBase.HTMLAttributes<HTMLPostAccordionElement>;
             "post-accordion-item": LocalJSX.PostAccordionItem & JSXBase.HTMLAttributes<HTMLPostAccordionItemElement>;
             "post-avatar": LocalJSX.PostAvatar & JSXBase.HTMLAttributes<HTMLPostAvatarElement>;
+            "post-autocomplete": LocalJSX.PostAutocomplete & JSXBase.HTMLAttributes<HTMLPostAutocompleteElement>;
             "post-back-to-top": LocalJSX.PostBackToTop & JSXBase.HTMLAttributes<HTMLPostBackToTopElement>;
             "post-banner": LocalJSX.PostBanner & JSXBase.HTMLAttributes<HTMLPostBannerElement>;
             "post-breadcrumb-item": LocalJSX.PostBreadcrumbItem & JSXBase.HTMLAttributes<HTMLPostBreadcrumbItemElement>;
@@ -1870,6 +2123,7 @@ declare module "@stencil/core" {
             "post-language-menu-item": LocalJSX.PostLanguageMenuItem & JSXBase.HTMLAttributes<HTMLPostLanguageMenuItemElement>;
             "post-linkarea": LocalJSX.PostLinkarea & JSXBase.HTMLAttributes<HTMLPostLinkareaElement>;
             "post-logo": LocalJSX.PostLogo & JSXBase.HTMLAttributes<HTMLPostLogoElement>;
+            "post-listbox": LocalJSX.PostListbox & JSXBase.HTMLAttributes<HTMLPostListboxElement>;
             "post-mainnavigation": LocalJSX.PostMainnavigation & JSXBase.HTMLAttributes<HTMLPostMainnavigationElement>;
             "post-megadropdown": LocalJSX.PostMegadropdown & JSXBase.HTMLAttributes<HTMLPostMegadropdownElement>;
             "post-megadropdown-trigger": LocalJSX.PostMegadropdownTrigger & JSXBase.HTMLAttributes<HTMLPostMegadropdownTriggerElement>;
@@ -1877,6 +2131,7 @@ declare module "@stencil/core" {
             "post-menu-item": LocalJSX.PostMenuItem & JSXBase.HTMLAttributes<HTMLPostMenuItemElement>;
             "post-menu-trigger": LocalJSX.PostMenuTrigger & JSXBase.HTMLAttributes<HTMLPostMenuTriggerElement>;
             "post-number-input": LocalJSX.PostNumberInput & JSXBase.HTMLAttributes<HTMLPostNumberInputElement>;
+            "post-option": LocalJSX.PostOption & JSXBase.HTMLAttributes<HTMLPostOptionElement>;
             "post-pagination": LocalJSX.PostPagination & JSXBase.HTMLAttributes<HTMLPostPaginationElement>;
             "post-popover": LocalJSX.PostPopover & JSXBase.HTMLAttributes<HTMLPostPopoverElement>;
             "post-popover-trigger": LocalJSX.PostPopoverTrigger & JSXBase.HTMLAttributes<HTMLPostPopoverTriggerElement>;

--- a/packages/components/src/components/post-autocomplete/post-autocomplete.scss
+++ b/packages/components/src/components/post-autocomplete/post-autocomplete.scss
@@ -1,0 +1,35 @@
+@use '@swisspost/design-system-styles/core' as post;
+
+post-autocomplete {
+  display: block;
+  position: relative;
+}
+
+.autocomplete-input-wrapper {
+  display: block;
+  width: 100%;
+
+  // Style the slotted input
+  ::slotted(input) {
+    width: 100%;
+  }
+}
+
+.autocomplete-dropdown {
+  background-color: post.$white;
+  border: post.$size-line solid post.$gray-20;
+  border-radius: post.$border-radius;
+  box-shadow: post.$shadow-sm;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: post.$size-micro 0;
+
+  &:empty {
+    display: none;
+  }
+}
+
+// Highlighted option state (via keyboard navigation)
+::slotted(post-option[data-highlighted='true']) {
+  background-color: post.$gray-10;
+}

--- a/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
+++ b/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
@@ -55,7 +55,7 @@ export class PostAutocomplete {
     END: 'End',
   };
 
-  @Element() host: HTMLElement;
+  @Element() host: HTMLPostAutocompleteElement;
 
   /**
    * The current value of the autocomplete input.

--- a/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
+++ b/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
@@ -1,0 +1,563 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Method,
+  Prop,
+  State,
+  Watch,
+} from '@stencil/core';
+import { Placement } from '@floating-ui/dom';
+import { PLACEMENT_TYPES } from '@/types';
+import { version } from '@root/package.json';
+import { getRoot, checkEmptyOrOneOf, EventFrom } from '@/utils';
+
+let autocompleteId = 0;
+
+/**
+ * An autocomplete component that provides suggestions as the user types.
+ * It wraps a native input element (slotted) and displays matching options in a dropdown.
+ *
+ * @slot default - The input element to use for the autocomplete. Should be a native `<input>` element.
+ * @slot options - The post-option elements to display as suggestions.
+ */
+@Component({
+  tag: 'post-autocomplete',
+  styleUrl: 'post-autocomplete.scss',
+  shadow: true,
+})
+export class PostAutocomplete {
+  private internalId = `post-autocomplete-${autocompleteId++}`;
+  private popoverRef: HTMLPostPopovercontainerElement;
+  private listboxRef: HTMLPostListboxElement;
+  private inputElement: HTMLInputElement | null = null;
+  private liveRegion: HTMLElement | null = null;
+
+  private readonly KEYCODES = {
+    UP: 'ArrowUp',
+    DOWN: 'ArrowDown',
+    ENTER: 'Enter',
+    ESCAPE: 'Escape',
+    TAB: 'Tab',
+    HOME: 'Home',
+    END: 'End',
+  };
+
+  @Element() host: HTMLPostAutocompleteElement;
+
+  /**
+   * The current value of the autocomplete input.
+   */
+  @Prop({ mutable: true, reflect: true }) value = '';
+
+  /**
+   * A descriptive label for assistive technologies.
+   */
+  @Prop() label?: string;
+
+  /**
+   * Defines the position of the dropdown relative to the input.
+   */
+  @Prop() readonly placement?: Placement = 'bottom-start';
+
+  /**
+   * The minimum number of characters required before showing suggestions.
+   */
+  @Prop() minChars = 1;
+
+  /**
+   * If `true`, automatically highlights the first matching option.
+   */
+  @Prop() autoHighlight = true;
+
+  /**
+   * If `true`, the dropdown is currently open.
+   */
+  @State() isOpen = false;
+
+  /**
+   * Index of the currently highlighted option.
+   */
+  @State() highlightedIndex = -1;
+
+  /**
+   * The filtered options to display based on current input.
+   */
+  @State() visibleOptions: HTMLPostOptionElement[] = [];
+
+  /**
+   * Emitted when an option is selected.
+   */
+  @Event() postSelect: EventEmitter<{ value: string; label: string }>;
+
+  /**
+   * Emitted when the input value changes.
+   */
+  @Event() postInput: EventEmitter<string>;
+
+  /**
+   * Emitted when the dropdown opens.
+   */
+  @Event() postOpen: EventEmitter<void>;
+
+  /**
+   * Emitted when the dropdown closes.
+   */
+  @Event() postClose: EventEmitter<void>;
+
+  private root?: Document | ShadowRoot | null;
+
+  @Watch('placement')
+  validatePlacement() {
+    checkEmptyOrOneOf(this, 'placement', PLACEMENT_TYPES);
+  }
+
+  connectedCallback() {
+    this.host.setAttribute('data-version', version);
+    this.root = getRoot(this.host);
+    this.createLiveRegion();
+  }
+
+  componentDidLoad() {
+    this.validatePlacement();
+    this.setupInput();
+    this.setupAriaAttributes();
+  }
+
+  disconnectedCallback() {
+    this.cleanupInput();
+    this.removeLiveRegion();
+  }
+
+  private createLiveRegion() {
+    // Create a light DOM live region for screen reader announcements
+    // This needs to be in light DOM for aria-describedby to work across shadow boundaries
+    this.liveRegion = document.createElement('div');
+    this.liveRegion.setAttribute('role', 'status');
+    this.liveRegion.setAttribute('aria-live', 'polite');
+    this.liveRegion.setAttribute('aria-atomic', 'true');
+    this.liveRegion.className = 'sr-only visually-hidden';
+    this.liveRegion.id = `${this.internalId}-live`;
+    this.liveRegion.style.cssText = `
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    `;
+    this.host.appendChild(this.liveRegion);
+  }
+
+  private removeLiveRegion() {
+    if (this.liveRegion && this.liveRegion.parentNode) {
+      this.liveRegion.parentNode.removeChild(this.liveRegion);
+    }
+    this.liveRegion = null;
+  }
+
+  private announceToScreenReader(message: string) {
+    if (this.liveRegion) {
+      this.liveRegion.textContent = message;
+    }
+  }
+
+  private setupInput() {
+    // Find the slotted input element
+    const slot = this.host.shadowRoot?.querySelector('slot:not([name])') as HTMLSlotElement;
+    if (!slot) return;
+
+    const assigned = slot.assignedElements({ flatten: true });
+    this.inputElement = assigned.find(
+      (el): el is HTMLInputElement => el.tagName.toLowerCase() === 'input'
+    ) || null;
+
+    if (this.inputElement) {
+      this.inputElement.addEventListener('input', this.handleInput);
+      this.inputElement.addEventListener('keydown', this.handleKeyDown);
+      this.inputElement.addEventListener('focus', this.handleFocus);
+      this.inputElement.addEventListener('blur', this.handleBlur);
+      
+      // Set initial value
+      if (this.value) {
+        this.inputElement.value = this.value;
+      }
+    }
+  }
+
+  private cleanupInput() {
+    if (this.inputElement) {
+      this.inputElement.removeEventListener('input', this.handleInput);
+      this.inputElement.removeEventListener('keydown', this.handleKeyDown);
+      this.inputElement.removeEventListener('focus', this.handleFocus);
+      this.inputElement.removeEventListener('blur', this.handleBlur);
+    }
+  }
+
+  private setupAriaAttributes() {
+    const listboxId = `${this.internalId}-listbox`;
+    
+    if (this.inputElement) {
+      this.inputElement.setAttribute('role', 'combobox');
+      this.inputElement.setAttribute('aria-autocomplete', 'list');
+      this.inputElement.setAttribute('aria-expanded', 'false');
+      this.inputElement.setAttribute('aria-owns', listboxId);
+      this.inputElement.setAttribute('aria-haspopup', 'listbox');
+      
+      if (this.label) {
+        this.inputElement.setAttribute('aria-label', this.label);
+      }
+      
+      if (this.liveRegion) {
+        this.inputElement.setAttribute('aria-describedby', this.liveRegion.id);
+      }
+    }
+  }
+
+  private updateAriaExpanded() {
+    if (this.inputElement) {
+      this.inputElement.setAttribute('aria-expanded', String(this.isOpen));
+    }
+  }
+
+  private updateAriaActiveDescendant() {
+    if (!this.inputElement) return;
+    
+    if (this.highlightedIndex >= 0 && this.visibleOptions[this.highlightedIndex]) {
+      const activeOption = this.visibleOptions[this.highlightedIndex];
+      this.inputElement.setAttribute('aria-activedescendant', activeOption.id);
+    } else {
+      this.inputElement.removeAttribute('aria-activedescendant');
+    }
+  }
+
+  /**
+   * Opens the autocomplete dropdown.
+   */
+  @Method()
+  async open(): Promise<void> {
+    if (this.isOpen || !this.inputElement) return;
+    
+    this.updateVisibleOptions();
+    
+    if (this.visibleOptions.length === 0) return;
+    
+    if (this.popoverRef) {
+      await this.popoverRef.show(this.inputElement);
+    }
+  }
+
+  /**
+   * Closes the autocomplete dropdown.
+   */
+  @Method()
+  async close(): Promise<void> {
+    if (!this.isOpen) return;
+    
+    if (this.popoverRef) {
+      await this.popoverRef.hide();
+    }
+  }
+
+  /**
+   * Toggles the autocomplete dropdown.
+   */
+  @Method()
+  async toggle(): Promise<void> {
+    if (this.isOpen) {
+      await this.close();
+    } else {
+      await this.open();
+    }
+  }
+
+  /**
+   * Sets the value programmatically.
+   */
+  @Method()
+  async setValue(value: string): Promise<void> {
+    this.value = value;
+    if (this.inputElement) {
+      this.inputElement.value = value;
+    }
+  }
+
+  /**
+   * Clears the current value.
+   */
+  @Method()
+  async clear(): Promise<void> {
+    await this.setValue('');
+    this.postInput.emit('');
+  }
+
+  private getAllOptions(): HTMLPostOptionElement[] {
+    const optionsSlot = this.host.shadowRoot?.querySelector('slot[name="options"]') as HTMLSlotElement;
+    if (!optionsSlot) return [];
+
+    const assigned = optionsSlot.assignedElements({ flatten: true });
+    
+    // Handle both direct post-option children and post-listbox wrapper
+    const options: HTMLPostOptionElement[] = [];
+    
+    for (const el of assigned) {
+      if (el.tagName.toLowerCase() === 'post-option') {
+        options.push(el as HTMLPostOptionElement);
+      } else if (el.tagName.toLowerCase() === 'post-listbox') {
+        // Get options from inside the listbox
+        const listboxOptions = el.querySelectorAll('post-option');
+        options.push(...Array.from(listboxOptions) as HTMLPostOptionElement[]);
+      }
+    }
+    
+    return options;
+  }
+
+  private updateVisibleOptions() {
+    const allOptions = this.getAllOptions();
+    const query = this.value.toLowerCase().trim();
+    
+    if (query.length < this.minChars) {
+      this.visibleOptions = [];
+      return;
+    }
+    
+    // Filter options based on query
+    // Check both the value and the text content
+    this.visibleOptions = allOptions.filter(option => {
+      if (option.disabled) return false;
+      
+      const optionValue = option.value?.toLowerCase() || '';
+      const optionText = option.textContent?.toLowerCase() || '';
+      
+      return optionValue.includes(query) || optionText.includes(query);
+    });
+    
+    // Update visibility of options in the DOM
+    allOptions.forEach(option => {
+      const isVisible = this.visibleOptions.includes(option);
+      option.style.display = isVisible ? '' : 'none';
+    });
+    
+    // Announce results to screen reader
+    const count = this.visibleOptions.length;
+    if (count === 0) {
+      this.announceToScreenReader('No suggestions available');
+    } else if (count === 1) {
+      this.announceToScreenReader('1 suggestion available');
+    } else {
+      this.announceToScreenReader(`${count} suggestions available`);
+    }
+    
+    // Auto-highlight first option if enabled
+    if (this.autoHighlight && this.visibleOptions.length > 0) {
+      this.highlightedIndex = 0;
+      this.updateHighlight();
+    } else {
+      this.highlightedIndex = -1;
+    }
+  }
+
+  private updateHighlight() {
+    // Clear previous highlight
+    const allOptions = this.getAllOptions();
+    allOptions.forEach(opt => opt.removeAttribute('data-highlighted'));
+    
+    // Set new highlight
+    if (this.highlightedIndex >= 0 && this.visibleOptions[this.highlightedIndex]) {
+      const highlighted = this.visibleOptions[this.highlightedIndex];
+      highlighted.setAttribute('data-highlighted', 'true');
+      
+      // Scroll into view if needed
+      highlighted.scrollIntoView?.({ block: 'nearest' });
+    }
+    
+    this.updateAriaActiveDescendant();
+  }
+
+  private selectOption(option: HTMLPostOptionElement) {
+    const value = option.value;
+    const label = option.textContent?.trim() || value;
+    
+    this.value = label;
+    
+    if (this.inputElement) {
+      this.inputElement.value = label;
+    }
+    
+    this.postSelect.emit({ value, label });
+    this.close();
+    
+    // Announce selection
+    this.announceToScreenReader(`${label} selected`);
+  }
+
+  private readonly handleInput = (event: Event) => {
+    const input = event.target as HTMLInputElement;
+    this.value = input.value;
+    this.postInput.emit(this.value);
+    
+    if (this.value.length >= this.minChars) {
+      this.updateVisibleOptions();
+      if (this.visibleOptions.length > 0 && !this.isOpen) {
+        this.open();
+      } else if (this.visibleOptions.length === 0 && this.isOpen) {
+        this.close();
+      }
+    } else {
+      this.close();
+    }
+  };
+
+  private readonly handleKeyDown = (event: KeyboardEvent) => {
+    switch (event.key) {
+      case this.KEYCODES.DOWN:
+        event.preventDefault();
+        if (!this.isOpen) {
+          this.open();
+        } else {
+          this.highlightNext();
+        }
+        break;
+
+      case this.KEYCODES.UP:
+        event.preventDefault();
+        if (this.isOpen) {
+          this.highlightPrevious();
+        }
+        break;
+
+      case this.KEYCODES.ENTER:
+        if (this.isOpen && this.highlightedIndex >= 0 && this.visibleOptions[this.highlightedIndex]) {
+          event.preventDefault();
+          this.selectOption(this.visibleOptions[this.highlightedIndex]);
+        }
+        break;
+
+      case this.KEYCODES.ESCAPE:
+        if (this.isOpen) {
+          event.preventDefault();
+          this.close();
+          this.inputElement?.focus();
+        }
+        break;
+
+      case this.KEYCODES.TAB:
+        if (this.isOpen) {
+          this.close();
+        }
+        break;
+
+      case this.KEYCODES.HOME:
+        if (this.isOpen && this.visibleOptions.length > 0) {
+          event.preventDefault();
+          this.highlightedIndex = 0;
+          this.updateHighlight();
+        }
+        break;
+
+      case this.KEYCODES.END:
+        if (this.isOpen && this.visibleOptions.length > 0) {
+          event.preventDefault();
+          this.highlightedIndex = this.visibleOptions.length - 1;
+          this.updateHighlight();
+        }
+        break;
+    }
+  };
+
+  private highlightNext() {
+    if (this.visibleOptions.length === 0) return;
+    
+    this.highlightedIndex = (this.highlightedIndex + 1) % this.visibleOptions.length;
+    this.updateHighlight();
+  }
+
+  private highlightPrevious() {
+    if (this.visibleOptions.length === 0) return;
+    
+    this.highlightedIndex = this.highlightedIndex <= 0 
+      ? this.visibleOptions.length - 1 
+      : this.highlightedIndex - 1;
+    this.updateHighlight();
+  }
+
+  private readonly handleFocus = () => {
+    // Could auto-open on focus if desired
+  };
+
+  private readonly handleBlur = (event: FocusEvent) => {
+    // Check if focus moved to an option
+    const relatedTarget = event.relatedTarget as HTMLElement;
+    if (relatedTarget?.closest('post-autocomplete') === this.host) {
+      return;
+    }
+    
+    // Delay close to allow click events to fire
+    setTimeout(() => {
+      if (!this.host.contains(document.activeElement)) {
+        this.close();
+      }
+    }, 150);
+  };
+
+  @EventFrom('post-popovercontainer')
+  private handlePostBeforeToggle(event: CustomEvent<{ willOpen: boolean }>) {
+    this.isOpen = event.detail.willOpen;
+    this.updateAriaExpanded();
+    
+    if (this.isOpen) {
+      this.postOpen.emit();
+      if (this.autoHighlight && this.visibleOptions.length > 0) {
+        this.highlightedIndex = 0;
+        this.updateHighlight();
+      }
+    } else {
+      this.postClose.emit();
+      this.highlightedIndex = -1;
+      this.updateAriaActiveDescendant();
+    }
+  }
+
+  @EventFrom('post-option', { allowDescendants: true })
+  private handleOptionSelect(event: CustomEvent<string>) {
+    const option = this.visibleOptions.find(opt => opt.value === event.detail);
+    if (option) {
+      this.selectOption(option);
+    }
+  }
+
+  render() {
+    const listboxId = `${this.internalId}-listbox`;
+
+    return (
+      <Host>
+        <div class="autocomplete-input-wrapper">
+          <slot></slot>
+        </div>
+        
+        <post-popovercontainer
+          placement={this.placement}
+          ref={el => (this.popoverRef = el)}
+          onPostBeforeToggle={this.handlePostBeforeToggle.bind(this)}
+        >
+          <div 
+            class="autocomplete-dropdown"
+            id={listboxId}
+            role="listbox"
+            aria-label={this.label || 'Suggestions'}
+            onPostOptionSelect={this.handleOptionSelect.bind(this)}
+          >
+            <slot name="options"></slot>
+          </div>
+        </post-popovercontainer>
+      </Host>
+    );
+  }
+}

--- a/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
+++ b/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
@@ -13,7 +13,17 @@ import {
 import { Placement } from '@floating-ui/dom';
 import { PLACEMENT_TYPES } from '@/types';
 import { version } from '@root/package.json';
-import { getRoot, checkEmptyOrOneOf, EventFrom } from '@/utils';
+import { checkEmptyOrOneOf, EventFrom } from '@/utils';
+
+/**
+ * Interface representing the properties of a post-option element.
+ * Used for type safety when accessing option properties.
+ */
+interface PostOptionElement extends HTMLElement {
+  value: string;
+  disabled: boolean;
+  selected: boolean;
+}
 
 let autocompleteId = 0;
 
@@ -32,7 +42,6 @@ let autocompleteId = 0;
 export class PostAutocomplete {
   private internalId = `post-autocomplete-${autocompleteId++}`;
   private popoverRef: HTMLPostPopovercontainerElement;
-  private listboxRef: HTMLPostListboxElement;
   private inputElement: HTMLInputElement | null = null;
   private liveRegion: HTMLElement | null = null;
 
@@ -46,7 +55,7 @@ export class PostAutocomplete {
     END: 'End',
   };
 
-  @Element() host: HTMLPostAutocompleteElement;
+  @Element() host: HTMLElement;
 
   /**
    * The current value of the autocomplete input.
@@ -86,7 +95,7 @@ export class PostAutocomplete {
   /**
    * The filtered options to display based on current input.
    */
-  @State() visibleOptions: HTMLPostOptionElement[] = [];
+  @State() visibleOptions: PostOptionElement[] = [];
 
   /**
    * Emitted when an option is selected.
@@ -108,8 +117,6 @@ export class PostAutocomplete {
    */
   @Event() postClose: EventEmitter<void>;
 
-  private root?: Document | ShadowRoot | null;
-
   @Watch('placement')
   validatePlacement() {
     checkEmptyOrOneOf(this, 'placement', PLACEMENT_TYPES);
@@ -117,7 +124,6 @@ export class PostAutocomplete {
 
   connectedCallback() {
     this.host.setAttribute('data-version', version);
-    this.root = getRoot(this.host);
     this.createLiveRegion();
   }
 
@@ -297,22 +303,22 @@ export class PostAutocomplete {
     this.postInput.emit('');
   }
 
-  private getAllOptions(): HTMLPostOptionElement[] {
+  private getAllOptions(): PostOptionElement[] {
     const optionsSlot = this.host.shadowRoot?.querySelector('slot[name="options"]') as HTMLSlotElement;
     if (!optionsSlot) return [];
 
     const assigned = optionsSlot.assignedElements({ flatten: true });
     
     // Handle both direct post-option children and post-listbox wrapper
-    const options: HTMLPostOptionElement[] = [];
+    const options: PostOptionElement[] = [];
     
     for (const el of assigned) {
       if (el.tagName.toLowerCase() === 'post-option') {
-        options.push(el as HTMLPostOptionElement);
+        options.push(el as PostOptionElement);
       } else if (el.tagName.toLowerCase() === 'post-listbox') {
         // Get options from inside the listbox
         const listboxOptions = el.querySelectorAll('post-option');
-        options.push(...Array.from(listboxOptions) as HTMLPostOptionElement[]);
+        options.push(...Array.from(listboxOptions) as PostOptionElement[]);
       }
     }
     
@@ -381,7 +387,7 @@ export class PostAutocomplete {
     this.updateAriaActiveDescendant();
   }
 
-  private selectOption(option: HTMLPostOptionElement) {
+  private selectOption(option: PostOptionElement) {
     const value = option.value;
     const label = option.textContent?.trim() || value;
     
@@ -552,7 +558,6 @@ export class PostAutocomplete {
             id={listboxId}
             role="listbox"
             aria-label={this.label || 'Suggestions'}
-            onPostOptionSelect={this.handleOptionSelect.bind(this)}
           >
             <slot name="options"></slot>
           </div>

--- a/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
+++ b/packages/components/src/components/post-autocomplete/post-autocomplete.tsx
@@ -71,7 +71,7 @@ export class PostAutocomplete {
   /**
    * If `true`, automatically highlights the first matching option.
    */
-  @Prop() autoHighlight = true;
+  @Prop() autoHighlight = false;
 
   /**
    * If `true`, the dropdown is currently open.

--- a/packages/components/src/components/post-listbox/post-listbox.scss
+++ b/packages/components/src/components/post-listbox/post-listbox.scss
@@ -1,0 +1,18 @@
+@use '@swisspost/design-system-styles/core' as post;
+
+post-listbox {
+  display: block;
+  max-height: 16rem; // ~10 options visible
+  overflow-y: auto;
+  background-color: post.$white;
+  border-radius: post.$border-radius;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: post.$size-line solid post.$focus-color;
+    outline-offset: calc(-1 * post.$size-line);
+  }
+}

--- a/packages/components/src/components/post-listbox/post-listbox.tsx
+++ b/packages/components/src/components/post-listbox/post-listbox.tsx
@@ -11,7 +11,17 @@ import {
   Watch,
 } from '@stencil/core';
 import { version } from '@root/package.json';
-import { getRoot, EventFrom } from '@/utils';
+import { EventFrom } from '@/utils';
+
+/**
+ * Interface representing the properties of a post-option element.
+ * Used for type safety when accessing option properties.
+ */
+interface PostOptionElement extends HTMLElement {
+  value: string;
+  disabled: boolean;
+  selected: boolean;
+}
 
 let listboxId = 0;
 
@@ -26,7 +36,7 @@ let listboxId = 0;
 export class PostListbox {
   private internalId = `post-listbox-${listboxId++}`;
 
-  @Element() host: HTMLPostListboxElement;
+  @Element() host: HTMLElement;
 
   /**
    * The currently selected value.
@@ -58,8 +68,6 @@ export class PostListbox {
    */
   @Event() postFocus: EventEmitter<{ value: string; index: number }>;
 
-  private root?: Document | ShadowRoot | null;
-
   private readonly KEYCODES = {
     UP: 'ArrowUp',
     DOWN: 'ArrowDown',
@@ -71,7 +79,6 @@ export class PostListbox {
 
   connectedCallback() {
     this.host.setAttribute('data-version', version);
-    this.root = getRoot(this.host);
     this.setupAttributes();
     this.host.addEventListener('keydown', this.handleKeyDown);
   }
@@ -83,7 +90,7 @@ export class PostListbox {
   componentDidLoad() {
     // Set initial active index if value is set
     if (this.value) {
-      const options = this.getOptions();
+      const options = this.getOptionsSync();
       const index = options.findIndex(opt => opt.value === this.value);
       if (index >= 0) {
         this.activeIndex = index;
@@ -123,7 +130,7 @@ export class PostListbox {
 
   @Watch('activeIndex')
   updateActiveDescendant() {
-    const options = this.getOptions();
+    const options = this.getOptionsSync();
     if (this.activeIndex >= 0 && options[this.activeIndex]) {
       const activeOption = options[this.activeIndex];
       this.host.setAttribute('aria-activedescendant', activeOption.id);
@@ -136,17 +143,17 @@ export class PostListbox {
    * Returns all post-option elements in the listbox.
    */
   @Method()
-  async getOptions(): Promise<HTMLPostOptionElement[]> {
+  async getOptions(): Promise<PostOptionElement[]> {
     return this.getOptionsSync();
   }
 
-  private getOptionsSync(): HTMLPostOptionElement[] {
+  private getOptionsSync(): PostOptionElement[] {
     const slot = this.host.shadowRoot?.querySelector('slot');
     if (!slot) return [];
 
     const assignedElements = slot.assignedElements({ flatten: true });
     return assignedElements.filter(
-      (el): el is HTMLPostOptionElement => el.tagName.toLowerCase() === 'post-option'
+      (el): el is PostOptionElement => el.tagName.toLowerCase() === 'post-option'
     );
   }
 
@@ -211,7 +218,7 @@ export class PostListbox {
     }
   }
 
-  private selectOption(option: HTMLPostOptionElement) {
+  private selectOption(option: PostOptionElement) {
     if (option.disabled) return;
 
     const options = this.getOptionsSync();

--- a/packages/components/src/components/post-listbox/post-listbox.tsx
+++ b/packages/components/src/components/post-listbox/post-listbox.tsx
@@ -36,7 +36,7 @@ let listboxId = 0;
 export class PostListbox {
   private internalId = `post-listbox-${listboxId++}`;
 
-  @Element() host: HTMLElement;
+  @Element() host: HTMLPostListboxElement;
 
   /**
    * The currently selected value.

--- a/packages/components/src/components/post-listbox/post-listbox.tsx
+++ b/packages/components/src/components/post-listbox/post-listbox.tsx
@@ -1,0 +1,325 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Method,
+  Prop,
+  State,
+  Watch,
+} from '@stencil/core';
+import { version } from '@root/package.json';
+import { getRoot, EventFrom } from '@/utils';
+
+let listboxId = 0;
+
+/**
+ * @slot default - The post-option elements to display in the listbox
+ */
+@Component({
+  tag: 'post-listbox',
+  styleUrl: 'post-listbox.scss',
+  shadow: true,
+})
+export class PostListbox {
+  private internalId = `post-listbox-${listboxId++}`;
+
+  @Element() host: HTMLPostListboxElement;
+
+  /**
+   * The currently selected value.
+   */
+  @Prop({ mutable: true, reflect: true }) value?: string;
+
+  /**
+   * A descriptive label for the listbox for assistive technologies.
+   */
+  @Prop() label?: string;
+
+  /**
+   * If `true`, multiple options can be selected.
+   */
+  @Prop() multiple = false;
+
+  /**
+   * The index of the currently active (focused) option for keyboard navigation.
+   */
+  @State() activeIndex = -1;
+
+  /**
+   * Emitted when the selected value changes.
+   */
+  @Event() postChange: EventEmitter<string | string[]>;
+
+  /**
+   * Emitted when an option receives focus via keyboard navigation.
+   */
+  @Event() postFocus: EventEmitter<{ value: string; index: number }>;
+
+  private root?: Document | ShadowRoot | null;
+
+  private readonly KEYCODES = {
+    UP: 'ArrowUp',
+    DOWN: 'ArrowDown',
+    HOME: 'Home',
+    END: 'End',
+    ENTER: 'Enter',
+    SPACE: ' ',
+  };
+
+  connectedCallback() {
+    this.host.setAttribute('data-version', version);
+    this.root = getRoot(this.host);
+    this.setupAttributes();
+    this.host.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  disconnectedCallback() {
+    this.host.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  componentDidLoad() {
+    // Set initial active index if value is set
+    if (this.value) {
+      const options = this.getOptions();
+      const index = options.findIndex(opt => opt.value === this.value);
+      if (index >= 0) {
+        this.activeIndex = index;
+        this.updateActiveDescendant();
+      }
+    }
+  }
+
+  private setupAttributes() {
+    this.host.setAttribute('role', 'listbox');
+    this.host.setAttribute('id', this.host.id || this.internalId);
+    if (this.label) {
+      this.host.setAttribute('aria-label', this.label);
+    }
+    if (this.multiple) {
+      this.host.setAttribute('aria-multiselectable', 'true');
+    }
+  }
+
+  @Watch('label')
+  updateAriaLabel() {
+    if (this.label) {
+      this.host.setAttribute('aria-label', this.label);
+    } else {
+      this.host.removeAttribute('aria-label');
+    }
+  }
+
+  @Watch('multiple')
+  updateAriaMultiselectable() {
+    if (this.multiple) {
+      this.host.setAttribute('aria-multiselectable', 'true');
+    } else {
+      this.host.removeAttribute('aria-multiselectable');
+    }
+  }
+
+  @Watch('activeIndex')
+  updateActiveDescendant() {
+    const options = this.getOptions();
+    if (this.activeIndex >= 0 && options[this.activeIndex]) {
+      const activeOption = options[this.activeIndex];
+      this.host.setAttribute('aria-activedescendant', activeOption.id);
+    } else {
+      this.host.removeAttribute('aria-activedescendant');
+    }
+  }
+
+  /**
+   * Returns all post-option elements in the listbox.
+   */
+  @Method()
+  async getOptions(): Promise<HTMLPostOptionElement[]> {
+    return this.getOptionsSync();
+  }
+
+  private getOptionsSync(): HTMLPostOptionElement[] {
+    const slot = this.host.shadowRoot?.querySelector('slot');
+    if (!slot) return [];
+
+    const assignedElements = slot.assignedElements({ flatten: true });
+    return assignedElements.filter(
+      (el): el is HTMLPostOptionElement => el.tagName.toLowerCase() === 'post-option'
+    );
+  }
+
+  /**
+   * Sets the active (focused) option by index.
+   */
+  @Method()
+  async setActiveIndex(index: number): Promise<void> {
+    const options = this.getOptionsSync();
+    if (index >= 0 && index < options.length && !options[index].disabled) {
+      this.activeIndex = index;
+      this.postFocus.emit({ value: options[index].value, index });
+    }
+  }
+
+  /**
+   * Selects an option by value.
+   */
+  @Method()
+  async selectValue(value: string): Promise<void> {
+    const options = this.getOptionsSync();
+    const option = options.find(opt => opt.value === value);
+    if (option && !option.disabled) {
+      this.selectOption(option);
+    }
+  }
+
+  /**
+   * Clears the current selection.
+   */
+  @Method()
+  async clearSelection(): Promise<void> {
+    const options = this.getOptionsSync();
+    options.forEach(opt => (opt.selected = false));
+    this.value = undefined;
+    this.postChange.emit(this.multiple ? [] : '');
+  }
+
+  /**
+   * Focuses the first non-disabled option.
+   */
+  @Method()
+  async focusFirst(): Promise<void> {
+    const options = this.getOptionsSync();
+    const firstEnabled = options.findIndex(opt => !opt.disabled);
+    if (firstEnabled >= 0) {
+      await this.setActiveIndex(firstEnabled);
+    }
+  }
+
+  /**
+   * Focuses the last non-disabled option.
+   */
+  @Method()
+  async focusLast(): Promise<void> {
+    const options = this.getOptionsSync();
+    for (let i = options.length - 1; i >= 0; i--) {
+      if (!options[i].disabled) {
+        await this.setActiveIndex(i);
+        break;
+      }
+    }
+  }
+
+  private selectOption(option: HTMLPostOptionElement) {
+    if (option.disabled) return;
+
+    const options = this.getOptionsSync();
+
+    if (this.multiple) {
+      option.selected = !option.selected;
+      const selectedValues = options.filter(opt => opt.selected).map(opt => opt.value);
+      this.value = selectedValues.join(',');
+      this.postChange.emit(selectedValues);
+    } else {
+      // Deselect all others
+      options.forEach(opt => (opt.selected = false));
+      option.selected = true;
+      this.value = option.value;
+      this.postChange.emit(option.value);
+    }
+  }
+
+  @EventFrom('post-option')
+  private handleOptionSelect(event: CustomEvent<string>) {
+    const options = this.getOptionsSync();
+    const option = options.find(opt => opt.value === event.detail);
+    if (option) {
+      this.selectOption(option);
+      // Update active index to selected option
+      const index = options.indexOf(option);
+      if (index >= 0) {
+        this.activeIndex = index;
+      }
+    }
+  }
+
+  private readonly handleKeyDown = (e: KeyboardEvent) => {
+    const options = this.getOptionsSync();
+    if (!options.length) return;
+
+    let newIndex = this.activeIndex;
+    let handled = false;
+
+    switch (e.key) {
+      case this.KEYCODES.UP:
+        e.preventDefault();
+        handled = true;
+        // Find previous non-disabled option
+        for (let i = this.activeIndex - 1; i >= 0; i--) {
+          if (!options[i].disabled) {
+            newIndex = i;
+            break;
+          }
+        }
+        break;
+
+      case this.KEYCODES.DOWN:
+        e.preventDefault();
+        handled = true;
+        // Find next non-disabled option
+        for (let i = this.activeIndex + 1; i < options.length; i++) {
+          if (!options[i].disabled) {
+            newIndex = i;
+            break;
+          }
+        }
+        break;
+
+      case this.KEYCODES.HOME:
+        e.preventDefault();
+        handled = true;
+        // Find first non-disabled option
+        for (let i = 0; i < options.length; i++) {
+          if (!options[i].disabled) {
+            newIndex = i;
+            break;
+          }
+        }
+        break;
+
+      case this.KEYCODES.END:
+        e.preventDefault();
+        handled = true;
+        // Find last non-disabled option
+        for (let i = options.length - 1; i >= 0; i--) {
+          if (!options[i].disabled) {
+            newIndex = i;
+            break;
+          }
+        }
+        break;
+
+      case this.KEYCODES.ENTER:
+      case this.KEYCODES.SPACE:
+        e.preventDefault();
+        handled = true;
+        if (this.activeIndex >= 0 && options[this.activeIndex] && !options[this.activeIndex].disabled) {
+          this.selectOption(options[this.activeIndex]);
+        }
+        break;
+    }
+
+    if (handled && newIndex !== this.activeIndex && newIndex >= 0) {
+      this.setActiveIndex(newIndex);
+    }
+  };
+
+  render() {
+    return (
+      <Host tabindex="0" onPostOptionSelect={this.handleOptionSelect.bind(this)}>
+        <slot></slot>
+      </Host>
+    );
+  }
+}

--- a/packages/components/src/components/post-option/post-option.scss
+++ b/packages/components/src/components/post-option/post-option.scss
@@ -1,0 +1,50 @@
+@use '@swisspost/design-system-styles/core' as post;
+
+post-option {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  padding: post.$size-mini post.$size-regular;
+  gap: post.$size-mini;
+  font-size: post.$font-size-sm;
+  color: post.$gray-80;
+  cursor: pointer;
+  user-select: none;
+  background-color: transparent;
+  border: none;
+  text-align: start;
+  transition:
+    background-color 0.15s ease-in-out,
+    color 0.15s ease-in-out;
+
+  &:hover:not([aria-disabled='true']) {
+    background-color: post.$gray-10;
+  }
+
+  &:focus-visible {
+    outline: post.$size-line solid post.$focus-color;
+    outline-offset: calc(-1 * post.$size-line);
+    border-radius: post.$border-radius;
+  }
+
+  &[aria-selected='true'] {
+    background-color: post.$yellow;
+    font-weight: post.$font-weight-bold;
+
+    &:hover:not([aria-disabled='true']) {
+      background-color: post.$yellow-dark;
+    }
+  }
+
+  &[aria-disabled='true'] {
+    color: post.$gray-40;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  post-icon {
+    width: 1rem;
+    height: 1rem;
+    flex-shrink: 0;
+  }
+}

--- a/packages/components/src/components/post-option/post-option.tsx
+++ b/packages/components/src/components/post-option/post-option.tsx
@@ -14,7 +14,7 @@ let optionId = 0;
 export class PostOption {
   private internalId = `post-option-${optionId++}`;
 
-  @Element() host: HTMLPostOptionElement;
+  @Element() host: HTMLElement;
 
   /**
    * The value of the option. This is what gets submitted when the option is selected.
@@ -38,13 +38,13 @@ export class PostOption {
   @Event() postOptionSelect: EventEmitter<string>;
 
   @Watch('value')
-  validateValue(newValue: string) {
-    checkRequiredAndType(newValue, 'string', 'The `value` property of post-option is required.');
+  validateValue() {
+    checkRequiredAndType(this, 'value', 'string');
   }
 
   connectedCallback() {
     this.host.setAttribute('data-version', version);
-    this.validateValue(this.value);
+    this.validateValue();
     this.setupAttributes();
   }
 

--- a/packages/components/src/components/post-option/post-option.tsx
+++ b/packages/components/src/components/post-option/post-option.tsx
@@ -1,0 +1,94 @@
+import { Component, Element, Event, EventEmitter, Host, h, Prop, Watch } from '@stencil/core';
+import { version } from '@root/package.json';
+import { checkRequiredAndType } from '@/utils';
+
+let optionId = 0;
+
+/**
+ * @slot default - The option label content
+ */
+@Component({
+  tag: 'post-option',
+  styleUrl: 'post-option.scss',
+})
+export class PostOption {
+  private internalId = `post-option-${optionId++}`;
+
+  @Element() host: HTMLPostOptionElement;
+
+  /**
+   * The value of the option. This is what gets submitted when the option is selected.
+   */
+  @Prop() value!: string;
+
+  /**
+   * If `true`, the option is disabled and cannot be selected.
+   */
+  @Prop({ reflect: true }) disabled = false;
+
+  /**
+   * If `true`, the option is currently selected.
+   * This is managed by the parent listbox/autocomplete.
+   */
+  @Prop({ reflect: true, mutable: true }) selected = false;
+
+  /**
+   * Emitted when the option is clicked or selected via keyboard.
+   */
+  @Event() postOptionSelect: EventEmitter<string>;
+
+  @Watch('value')
+  validateValue(newValue: string) {
+    checkRequiredAndType(newValue, 'string', 'The `value` property of post-option is required.');
+  }
+
+  connectedCallback() {
+    this.host.setAttribute('data-version', version);
+    this.validateValue(this.value);
+    this.setupAttributes();
+  }
+
+  private setupAttributes() {
+    // Set ARIA attributes for accessibility
+    this.host.setAttribute('role', 'option');
+    this.host.setAttribute('id', this.host.id || this.internalId);
+    this.updateAriaSelected();
+    this.updateAriaDisabled();
+  }
+
+  @Watch('selected')
+  updateAriaSelected() {
+    this.host.setAttribute('aria-selected', String(this.selected));
+  }
+
+  @Watch('disabled')
+  updateAriaDisabled() {
+    this.host.setAttribute('aria-disabled', String(this.disabled));
+  }
+
+  private handleClick = (event: MouseEvent) => {
+    if (this.disabled) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    this.postOptionSelect.emit(this.value);
+  };
+
+  private handleKeyDown = (event: KeyboardEvent) => {
+    if (this.disabled) return;
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      this.postOptionSelect.emit(this.value);
+    }
+  };
+
+  render() {
+    return (
+      <Host onClick={this.handleClick} onKeyDown={this.handleKeyDown}>
+        <slot></slot>
+      </Host>
+    );
+  }
+}

--- a/packages/components/src/components/post-option/post-option.tsx
+++ b/packages/components/src/components/post-option/post-option.tsx
@@ -19,7 +19,7 @@ export class PostOption {
   /**
    * The value of the option. This is what gets submitted when the option is selected.
    */
-  @Prop() value!: string;
+  @Prop({ reflect: true }) value!: string;
 
   /**
    * If `true`, the option is disabled and cannot be selected.
@@ -30,7 +30,7 @@ export class PostOption {
    * If `true`, the option is currently selected.
    * This is managed by the parent listbox/autocomplete.
    */
-  @Prop({ reflect: true, mutable: true }) selected = false;
+  @Prop({ reflect: true }) selected = false;
 
   /**
    * Emitted when the option is clicked or selected via keyboard.

--- a/packages/components/src/components/post-option/post-option.tsx
+++ b/packages/components/src/components/post-option/post-option.tsx
@@ -14,7 +14,7 @@ let optionId = 0;
 export class PostOption {
   private internalId = `post-option-${optionId++}`;
 
-  @Element() host: HTMLElement;
+  @Element() host: HTMLPostOptionElement;
 
   /**
    * The value of the option. This is what gets submitted when the option is selected.

--- a/packages/documentation/src/stories/components/autocomplete/autocomplete.docs.mdx
+++ b/packages/documentation/src/stories/components/autocomplete/autocomplete.docs.mdx
@@ -1,0 +1,104 @@
+import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
+import meta, * as AutocompleteStories from './autocomplete.stories';
+import PackageTag from '@/shared/package-tag';
+import ComponentsPackageInstall from '@/shared/components-package-install.mdx';
+
+<Meta of={AutocompleteStories} />
+
+<div className="docs-title">
+  # Autocomplete
+
+<link-design of={JSON.stringify(AutocompleteStories)}></link-design>
+
+</div>
+
+<PackageTag meta={meta} />
+
+<div className="lead">
+  An autocomplete component that provides suggestions as the user types, improving form completion efficiency and accuracy.
+</div>
+
+<Canvas sourceState="shown" of={AutocompleteStories.Default} />
+<Controls of={AutocompleteStories.Default} />
+
+<ComponentsPackageInstall component="<post-autocomplete>" />
+
+## Usage
+
+The autocomplete component wraps a native `<input>` element and displays matching options in a dropdown as the user types.
+
+```html
+<post-autocomplete label="Search countries">
+  <input type="text" class="form-control" placeholder="Type to search..." />
+  <div slot="options">
+    <post-option value="switzerland">Switzerland</post-option>
+    <post-option value="germany">Germany</post-option>
+    <post-option value="france">France</post-option>
+  </div>
+</post-autocomplete>
+```
+
+## Accessibility
+
+The autocomplete component implements the WAI-ARIA combobox pattern with the following features:
+
+- The input has `role="combobox"` with `aria-autocomplete="list"`
+- The dropdown listbox is connected via `aria-owns`
+- Keyboard navigation is fully supported (Arrow keys, Enter, Escape, Home, End)
+- Screen reader announcements for the number of available suggestions
+- Focus management ensures proper focus return when closing
+
+## Examples
+
+### Minimum Characters
+
+Use the `min-chars` property to control how many characters must be typed before showing suggestions.
+This is useful for large option lists to avoid overwhelming the user.
+
+<Canvas of={AutocompleteStories.WithMinChars} />
+
+### Auto Highlight
+
+By default, the first matching option is automatically highlighted for quick selection.
+Set `auto-highlight="false"` to disable this behavior.
+
+<Canvas of={AutocompleteStories.NoAutoHighlight} />
+
+### With Icons
+
+Options can include icons or other content to provide additional context.
+
+<Canvas of={AutocompleteStories.WithIcons} />
+
+### Disabled Options
+
+Options can be disabled to prevent selection while still being visible.
+
+<Canvas of={AutocompleteStories.WithDisabledOptions} />
+
+### Form Integration
+
+The autocomplete works with standard form controls and Bootstrap form styling.
+
+<Canvas of={AutocompleteStories.WithFormGroup} />
+
+## Keyboard Navigation
+
+| Key | Action |
+|-----|--------|
+| <kbd>↓</kbd> | Open dropdown / Move to next option |
+| <kbd>↑</kbd> | Move to previous option |
+| <kbd>Enter</kbd> | Select highlighted option |
+| <kbd>Escape</kbd> | Close dropdown |
+| <kbd>Home</kbd> | Jump to first option |
+| <kbd>End</kbd> | Jump to last option |
+| <kbd>Tab</kbd> | Close dropdown and move focus |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| `postSelect` | Fired when an option is selected. Detail contains `{ value, label }` |
+| `postInput` | Fired when the input value changes |
+| `postOpen` | Fired when the dropdown opens |
+| `postClose` | Fired when the dropdown closes |

--- a/packages/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
+++ b/packages/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
@@ -1,0 +1,208 @@
+import { Args, StoryContext, StoryObj } from '@storybook/web-components-vite';
+import { html, nothing } from 'lit';
+import { MetaComponent } from '@root/types';
+
+const SAMPLE_COUNTRIES = [
+  'Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Argentina', 'Armenia',
+  'Australia', 'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados',
+  'Belarus', 'Belgium', 'Belize', 'Benin', 'Bhutan', 'Bolivia', 'Bosnia and Herzegovina',
+  'Botswana', 'Brazil', 'Brunei', 'Bulgaria', 'Burkina Faso', 'Burundi', 'Cambodia',
+  'Cameroon', 'Canada', 'Central African Republic', 'Chad', 'Chile', 'China', 'Colombia',
+  'Costa Rica', 'Croatia', 'Cuba', 'Cyprus', 'Czech Republic', 'Denmark', 'Djibouti',
+  'Dominican Republic', 'Ecuador', 'Egypt', 'El Salvador', 'Estonia', 'Ethiopia',
+  'Finland', 'France', 'Georgia', 'Germany', 'Ghana', 'Greece', 'Guatemala', 'Haiti',
+  'Honduras', 'Hungary', 'Iceland', 'India', 'Indonesia', 'Iran', 'Iraq', 'Ireland',
+  'Israel', 'Italy', 'Jamaica', 'Japan', 'Jordan', 'Kazakhstan', 'Kenya', 'Kuwait',
+  'Latvia', 'Lebanon', 'Liechtenstein', 'Lithuania', 'Luxembourg', 'Madagascar', 'Malaysia',
+  'Malta', 'Mexico', 'Monaco', 'Mongolia', 'Montenegro', 'Morocco', 'Nepal', 'Netherlands',
+  'New Zealand', 'Nicaragua', 'Nigeria', 'North Macedonia', 'Norway', 'Oman', 'Pakistan',
+  'Panama', 'Paraguay', 'Peru', 'Philippines', 'Poland', 'Portugal', 'Qatar', 'Romania',
+  'Russia', 'Saudi Arabia', 'Serbia', 'Singapore', 'Slovakia', 'Slovenia', 'South Africa',
+  'South Korea', 'Spain', 'Sri Lanka', 'Sweden', 'Switzerland', 'Taiwan', 'Thailand',
+  'Tunisia', 'Turkey', 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States',
+  'Uruguay', 'Venezuela', 'Vietnam', 'Yemen', 'Zambia', 'Zimbabwe'
+];
+
+const meta: MetaComponent = {
+  id: 'f8e3a1b2-4c5d-6e7f-8a9b-0c1d2e3f4a5b',
+  title: 'Components/Autocomplete',
+  tags: ['package:WebComponents', 'status:Experimental'],
+  component: 'post-autocomplete',
+  parameters: {
+    badges: [],
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/JIT5AdGYqv6bDRpfBPV8XR/Foundations---Components-Next-Level?node-id=17916-30978&m=dev',
+    },
+  },
+  render: renderAutocomplete,
+  args: {
+    label: 'Search countries',
+    placeholder: 'Type to search...',
+    minChars: 1,
+    autoHighlight: true,
+    placement: 'bottom-start',
+  },
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Accessible label for the autocomplete',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text for the input',
+    },
+    minChars: {
+      control: { type: 'number', min: 0, max: 5 },
+      description: 'Minimum characters before showing suggestions',
+    },
+    autoHighlight: {
+      control: 'boolean',
+      description: 'Automatically highlight the first matching option',
+    },
+    placement: {
+      control: 'select',
+      options: ['bottom-start', 'bottom', 'bottom-end', 'top-start', 'top', 'top-end'],
+      description: 'Dropdown placement relative to the input',
+    },
+  },
+};
+
+function renderAutocomplete(args: Args, context: StoryContext) {
+  return html`
+    <div style="min-height: 400px; padding-top: 50px;">
+      <label for="country-input" class="form-label">Country</label>
+      <post-autocomplete
+        label="${args.label || nothing}"
+        min-chars="${args.minChars}"
+        ?auto-highlight="${args.autoHighlight}"
+        placement="${args.placement || nothing}"
+      >
+        <input
+          id="country-input"
+          type="text"
+          class="form-control"
+          placeholder="${args.placeholder || nothing}"
+          autocomplete="off"
+        />
+        <div slot="options">
+          ${SAMPLE_COUNTRIES.map(
+            country => html`
+              <post-option value="${country}">${country}</post-option>
+            `
+          )}
+        </div>
+      </post-autocomplete>
+    </div>
+  `;
+}
+
+export default meta;
+
+export const Default: StoryObj = {};
+
+export const WithMinChars: StoryObj = {
+  args: {
+    minChars: 3,
+    placeholder: 'Type at least 3 characters...',
+  },
+};
+
+export const NoAutoHighlight: StoryObj = {
+  args: {
+    autoHighlight: false,
+  },
+};
+
+export const WithFormGroup: StoryObj = {
+  render: (args: Args) => html`
+    <div style="min-height: 400px; padding-top: 50px;">
+      <div class="form-floating">
+        <post-autocomplete
+          label="${args.label || nothing}"
+          min-chars="${args.minChars}"
+          ?auto-highlight="${args.autoHighlight}"
+        >
+          <input
+            id="country-floating"
+            type="text"
+            class="form-control"
+            placeholder="${args.placeholder || nothing}"
+            autocomplete="off"
+          />
+          <div slot="options">
+            ${SAMPLE_COUNTRIES.slice(0, 20).map(
+              country => html`
+                <post-option value="${country}">${country}</post-option>
+              `
+            )}
+          </div>
+        </post-autocomplete>
+        <label for="country-floating">Select a country</label>
+      </div>
+    </div>
+  `,
+};
+
+export const WithIcons: StoryObj = {
+  render: (args: Args) => html`
+    <div style="min-height: 400px; padding-top: 50px;">
+      <label for="city-input" class="form-label">City</label>
+      <post-autocomplete label="Search cities" min-chars="1">
+        <input
+          id="city-input"
+          type="text"
+          class="form-control"
+          placeholder="Search for a city..."
+          autocomplete="off"
+        />
+        <div slot="options">
+          <post-option value="zurich">
+            <post-icon aria-hidden="true" name="location"></post-icon>
+            Zürich
+          </post-option>
+          <post-option value="bern">
+            <post-icon aria-hidden="true" name="location"></post-icon>
+            Bern
+          </post-option>
+          <post-option value="geneva">
+            <post-icon aria-hidden="true" name="location"></post-icon>
+            Geneva
+          </post-option>
+          <post-option value="basel">
+            <post-icon aria-hidden="true" name="location"></post-icon>
+            Basel
+          </post-option>
+          <post-option value="lausanne">
+            <post-icon aria-hidden="true" name="location"></post-icon>
+            Lausanne
+          </post-option>
+        </div>
+      </post-autocomplete>
+    </div>
+  `,
+};
+
+export const WithDisabledOptions: StoryObj = {
+  render: (args: Args) => html`
+    <div style="min-height: 400px; padding-top: 50px;">
+      <label for="product-input" class="form-label">Product</label>
+      <post-autocomplete label="Search products" min-chars="0">
+        <input
+          id="product-input"
+          type="text"
+          class="form-control"
+          placeholder="Search for a product..."
+          autocomplete="off"
+        />
+        <div slot="options">
+          <post-option value="laptop">Laptop</post-option>
+          <post-option value="phone" disabled>Phone (Out of stock)</post-option>
+          <post-option value="tablet">Tablet</post-option>
+          <post-option value="monitor" disabled>Monitor (Coming soon)</post-option>
+          <post-option value="keyboard">Keyboard</post-option>
+        </div>
+      </post-autocomplete>
+    </div>
+  `,
+};

--- a/packages/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
+++ b/packages/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
@@ -145,7 +145,7 @@ export const WithFormGroup: StoryObj = {
 };
 
 export const WithIcons: StoryObj = {
-  render: (_args: Args) => html`
+  render: () => html`
     <div style="min-height: 400px; padding-top: 50px;">
       <label for="city-input" class="form-label">City</label>
       <post-autocomplete label="Search cities" min-chars="1">
@@ -184,7 +184,7 @@ export const WithIcons: StoryObj = {
 };
 
 export const WithDisabledOptions: StoryObj = {
-  render: (_args: Args) => html`
+  render: () => html`
     <div style="min-height: 400px; padding-top: 50px;">
       <label for="product-input" class="form-label">Product</label>
       <post-autocomplete label="Search products" min-chars="0">

--- a/packages/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
+++ b/packages/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
@@ -1,4 +1,4 @@
-import { Args, StoryContext, StoryObj } from '@storybook/web-components-vite';
+import { Args, StoryObj } from '@storybook/web-components-vite';
 import { html, nothing } from 'lit';
 import { MetaComponent } from '@root/types';
 
@@ -68,7 +68,7 @@ const meta: MetaComponent = {
   },
 };
 
-function renderAutocomplete(args: Args, context: StoryContext) {
+function renderAutocomplete(args: Args) {
   return html`
     <div style="min-height: 400px; padding-top: 50px;">
       <label for="country-input" class="form-label">Country</label>
@@ -145,7 +145,7 @@ export const WithFormGroup: StoryObj = {
 };
 
 export const WithIcons: StoryObj = {
-  render: (args: Args) => html`
+  render: (_args: Args) => html`
     <div style="min-height: 400px; padding-top: 50px;">
       <label for="city-input" class="form-label">City</label>
       <post-autocomplete label="Search cities" min-chars="1">
@@ -184,7 +184,7 @@ export const WithIcons: StoryObj = {
 };
 
 export const WithDisabledOptions: StoryObj = {
-  render: (args: Args) => html`
+  render: (_args: Args) => html`
     <div style="min-height: 400px; padding-top: 50px;">
       <label for="product-input" class="form-label">Product</label>
       <post-autocomplete label="Search products" min-chars="0">


### PR DESCRIPTION
## ⚠️ DUMMY PR - DO NOT MERGE

**This is a dummy PR to validate the usage of [OpenCode](https://opencode.ai) with Claude Opus 4.5 / GPT-5 for automated code generation.**

The code was generated entirely by AI to test the capabilities of modern LLMs for implementing complex web components.

---

## Summary

Implementation of the Autocomplete feature as specified in #7129:

- **post-option**: Light DOM component for individual selectable options
- **post-listbox**: Shadow DOM component with full keyboard navigation (Arrow keys, Home, End, Enter, Space)
- **post-autocomplete**: Main combobox component integrating with `post-popovercontainer` for dropdown positioning

## Features

- Full ARIA accessibility (combobox pattern with `aria-owns`, `aria-activedescendant`, live regions)
- Keyboard navigation matching WAI-ARIA Combobox pattern
- Filtering options based on input value
- Auto-highlight first matching option
- Min-chars threshold before showing suggestions
- Support for disabled options
- Screen reader announcements

## Files Added

| File | Description |
|------|-------------|
| `post-option.tsx/.scss` | Option component (light DOM) |
| `post-listbox.tsx/.scss` | Listbox component with keyboard nav |
| `post-autocomplete.tsx/.scss` | Main autocomplete combobox |
| `autocomplete.stories.ts` | Storybook stories |
| `autocomplete.docs.mdx` | Documentation |
| `autocomplete.cy.ts` | Cypress E2E tests |

## Testing

- [ ] Build passes
- [ ] Unit tests pass
- [ ] E2E tests pass
- [ ] Storybook renders correctly

---

**Note:** This PR should be closed without merging. It serves only as a validation of AI-assisted development workflows.