### PR TITLE
chore(docs): deprecation notice on button group sizes

### DIFF
--- a/.changeset/cyan-shoes-notice.md
+++ b/.changeset/cyan-shoes-notice.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Added a deprecation notice on the button group sizes.

--- a/packages/documentation/src/stories/components/button-group/button-group.docs.mdx
+++ b/packages/documentation/src/stories/components/button-group/button-group.docs.mdx
@@ -29,6 +29,11 @@ The following examples show the different characteristics of the component. Thes
 
 ### Sizing
 
+<div className="alert alert-md alert-warning">
+  <h2 className="alert-heading">The button group sizes are deprecated</h2>
+  <p>The CSS classes to apply to the buttons will be removed in the next version.</p>
+</div>
+
 You can change the size of buttons belonging to a group using button-sizing classes: `.btn-sm`, `.btn-rg` and `.btn-lg`.
 Just be sure to apply the same class to all buttons contained in the group.
 

--- a/packages/documentation/src/stories/components/button-group/button-group.stories.ts
+++ b/packages/documentation/src/stories/components/button-group/button-group.stories.ts
@@ -25,7 +25,8 @@ const meta: MetaComponent = {
   argTypes: {
     size: {
       name: 'Size',
-      description: 'Sets the size of the button group.',
+      description:
+        'Sets the size of the button group. <span className="mt-mini alert alert-sm alert-warning">Button group sizes are deprecated and will be removed in the next version.</span>',
       control: {
         type: 'select',
         labels: {
@@ -129,17 +130,16 @@ const meta: MetaComponent = {
     },
   },
   decorators: [
-    story =>
-      html`
-        <div
-          @click="${(e: Event) => {
-            const target = e.target as HTMLElement;
-            if (target.tagName === 'A' || target.tagName === 'BUTTON') e.preventDefault();
-          }}"
-        >
-          ${story()}
-        </div>
-      `,
+    story => html`
+      <div
+        @click="${(e: Event) => {
+          const target = e.target as HTMLElement;
+          if (target.tagName === 'A' || target.tagName === 'BUTTON') e.preventDefault();
+        }}"
+      >
+        ${story()}
+      </div>
+    `,
   ],
 };
 


### PR DESCRIPTION
## 📄 Description

Because v10 does not have button size options for the button group, this PR adds a deprecation notice for it on v9.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
