### PR TITLE
fix(styles): fix calendar icon color on Safari/iOS for `post-date-picker` component

### DIFF
--- a/.changeset/breezy-badgers-dig.md
+++ b/.changeset/breezy-badgers-dig.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed the calendar toggle button icon appearing blue on Safari/iOS in the `post-date-picker`.

--- a/packages/components/src/components/post-date-picker/post-date-picker.scss
+++ b/packages/components/src/components/post-date-picker/post-date-picker.scss
@@ -690,6 +690,7 @@ tokens.$default-map: components.$post-datepicker;
     @include form-input-mx.input-btn();
     // Safari applies its system accent color to buttons; reset it explicitly
     -webkit-appearance: none;
+    appearance: none;
     color: tokens.get('post-datepicker-grid-day-cell-element-color-enabled-fg');
     outline-offset: 4px;
     right: tokens.get('search-position-inline-end-icon', components.$post-search-input);

--- a/packages/components/src/components/post-date-picker/post-date-picker.scss
+++ b/packages/components/src/components/post-date-picker/post-date-picker.scss
@@ -688,6 +688,9 @@ tokens.$default-map: components.$post-datepicker;
 
   button {
     @include form-input-mx.input-btn();
+    // Safari applies its system accent color to buttons; reset it explicitly
+    -webkit-appearance: none;
+    color: tokens.get('post-datepicker-grid-day-cell-element-color-enabled-fg');
     outline-offset: 4px;
     right: tokens.get('search-position-inline-end-icon', components.$post-search-input);
 


### PR DESCRIPTION
## 📄 Description

This PR fixes the calendar toggle button icon appearing blue on **Safari/iOS**. The root cause was Safari's default button styling leaking its system accent color into the post-icon mask, which uses currentColor to render. By adding `appearance: none` and `-webkit-appearance: none` alongside an `explicit color token`, the button no longer picks up Safari's accent color and the icon renders correctly across all browsers.

## 🚀 Preview link

https://preview-7486--swisspost-design-system-next.netlify.app/?path=/docs/eb77cd02-48b2-42e1-a3e4-cd8a973d431e--docs&devModeEnabled=true
---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
