### PR TITLE
fix(workflow): update an incompatible action, causing a duplicate auth header error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,19 +156,19 @@ jobs:
 
       - name: Check if changset-release/main Branch exists
         id: changeset-branch-exists
-        uses: GuillaumeFalourd/branch-exists@b59b6e80d7a9718439df11e733e26d4f88ffefd3
+        uses: GuillaumeFalourd/branch-exists@650358876c774d6ccbd581b5553eb636dab79a97
         with:
           branch: changeset-release/main
 
       - name: Check if release/v* Branch exists
         id: release-branch-exists
-        uses: GuillaumeFalourd/branch-exists@b59b6e80d7a9718439df11e733e26d4f88ffefd3
+        uses: GuillaumeFalourd/branch-exists@650358876c774d6ccbd581b5553eb636dab79a97
         with:
           branch: ${{ fromJSON(steps.release-data-pre.outputs.result).branchName }}
 
       - name: Check if changeset-release/release/v* Branch exists
         id: release-changeset-branch-exists
-        uses: GuillaumeFalourd/branch-exists@b59b6e80d7a9718439df11e733e26d4f88ffefd3
+        uses: GuillaumeFalourd/branch-exists@650358876c774d6ccbd581b5553eb636dab79a97
         with:
           branch: changeset-release/${{ fromJSON(steps.release-data-pre.outputs.result).branchName }}
 


### PR DESCRIPTION
## 📄 Description

We're using the `actions/checkout@v6` in our workflows, while `GuillaumeFalourd/branch-exists` is using `actions/checkout@v4` internally. This causes an error in the workflow run:

<img width="664" height="96" alt="image" src="https://github.com/user-attachments/assets/4b5fdce7-303b-41cf-ad15-1a2e58a574b0" />

The newest version of `GuillaumeFalourd/branch-exists` fixes this, by aligning to the latest `actions/checkout@v6` version.

---

## 🔮 Design review

- [x] No design review needed