### PR TITLE
fix: olis mail mapping

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+.mailmap
+Oliver Schürch <oli@skaos.ch> Oliver Schürch <oliver.schuerch@post.ch>


### PR DESCRIPTION
For a long time I used my companies email address in the personal account used to commit on this repo.
After migrating to github enterprise company wise, I had to use and verify this email address in my company account to get access to the enterprise repos. Therefore I had to remove it from my personal github account. This resulted in the loss of historical data and stats showing up as if I'm just a hobbyist, not a core team member 😆.

Now there are the following possibilities:

Option | What it does | GitHub attribution fixed? | Feasibility
:- | :- | :- | :-
.mailmap | Fixes display in git log, git shortlog | No | Yes
History rewrite (git filter-repo) | Changes commits and hashes | Yes, but destructive | No
Contact GitHub Support | Might manually unlink the email from the company account | Possibly, but not guaranteed and depends on company policy | Yes

This PR is the attempt to fix my accounts history stats, without re-writing the repos history.