### PR TITLE
feat(copilot): add automatic copilot reviews to new prs

### DIFF
--- a/.github/copilot-reviews.yml
+++ b/.github/copilot-reviews.yml
@@ -1,0 +1,22 @@
+# .github/copilot-reviews.yml
+
+# Automatically request Copilot review on new PRs
+reviews:
+  auto_review: true
+
+  # Limit auto-review to specific paths (optional)
+  path_filters:
+    include:
+      - 'src/**'
+      - 'apps/**'
+      - 'packages/**'
+    exclude:
+      - '**/*.md'
+      - '**/*.json'
+      - '**/test/**'
+
+  # Custom coding guidelines for Copilot to check against
+  # NOTE: Copilot code review automatically uses your `copilot-instructions.md` as context when reviewing PRs.
+  # coding_guidelines:
+  #   - title: 'topic'
+  #     description: 'instruction'


### PR DESCRIPTION
## 📄 Description

GitHub Copilot code review (the ability to request Copilot as a reviewer on pull requests) is available for all public repositories on GitHub, regardless of plan.

**Details**

- Public repos: Copilot review is free and available to all users
- Private repos: Requires a GitHub Copilot Enterprise or Copilot Business subscription
- You can request Copilot as a reviewer on any PR, just like a human reviewer
- You can also set up coding guidelines to customize what Copilot checks for

Let's test that with this pr 😜 

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
