### PR TITLE
chore: add worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ yarn.lock
 
 # Log files
 .pnpm-debug.log
-lerna-debug.log
 
 # System Files
 .DS_Store
@@ -35,3 +34,6 @@ styles/stylelint-report.txt
 
 # Intellij IDEA
 .idea
+
+# Git worktrees
+.worktrees


### PR DESCRIPTION
## 📄 Description

The `.worktrees` folder can be used to store Git worktrees, allowing devs to develop on multiple branches in parallel.

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
