### PR TITLE
fix(components): prevent page scroll when pressing `Home` key for `post-menu` component

### DIFF
--- a/.changeset/shy-shrimps-pump.md
+++ b/.changeset/shy-shrimps-pump.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Prevented unintended page scroll when pressing `Home` key while navigating the `post-menu` component dropdown with keyboard.

--- a/packages/components/cypress/e2e/menu.cy.ts
+++ b/packages/components/cypress/e2e/menu.cy.ts
@@ -133,3 +133,90 @@ describe('menus', { baseUrl: null, includeShadowDom: true }, () => {
     });
   });
 });
+
+describe('menu keyboard navigation', { baseUrl: null, includeShadowDom: true }, () => {
+  beforeEach(() => {
+    cy.visit('cypress/fixtures/post-menu.test.html');
+    cy.get('post-menu-trigger[data-hydrated]');
+    cy.get('post-menu[data-hydrated]');
+    cy.get('post-menu-trigger[for="menu-one"]').as('trigger');
+    cy.get('post-menu#menu-one').as('menu');
+  });
+
+  it('should open menu with Space key on trigger', () => {
+    cy.get('@trigger').find('button').focus().type(' ');
+    cy.get('@menu').shadow().find('post-popovercontainer').should('not.have.css', 'display', 'none');
+  });
+
+  it('should navigate menu items with Arrow Down', () => {
+    cy.get('@trigger').click();
+    cy.get('@menu').find('button, a').first().as('firstItem');
+    cy.get('@menu').find('button, a').eq(1).as('secondItem');
+
+    cy.get('@firstItem').focus().type('{downarrow}', { force: true });
+    cy.get('@secondItem').should('have.focus');
+  });
+
+  it('should navigate menu items with Arrow Up', () => {
+    cy.get('@trigger').click();
+    cy.get('@menu').find('button, a').first().as('firstItem');
+    cy.get('@menu').find('button, a').last().as('lastItem');
+
+    cy.get('@lastItem').focus().type('{uparrow}', { force: true });
+    cy.get('@firstItem').should('have.focus');
+  });
+
+  it('should move focus to first item with Home key', () => {
+    cy.get('@trigger').click();
+    cy.get('@menu').find('button, a').first().as('firstItem');
+    cy.get('@menu').find('button, a').last().as('lastItem');
+
+    cy.get('@lastItem').focus().type('{home}', { force: true });
+    cy.get('@firstItem').should('have.focus');
+  });
+
+  it('should not scroll page when pressing Home key', () => {
+    cy.window().then(win => {
+      cy.wrap(win.pageYOffset).as('initialScroll');
+    });
+
+    cy.get('@trigger').click();
+    cy.get('@menu').find('button, a').last().focus();
+    cy.get('@menu').find('button, a').last().type('{home}', { force: true });
+
+    cy.window().then(win => {
+      cy.get('@initialScroll').should('equal', win.pageYOffset);
+    });
+  });
+
+  it('should move focus to last item with End key', () => {
+    cy.get('@trigger').click();
+    cy.get('@menu').find('button, a').first().as('firstItem');
+    cy.get('@menu').find('button, a').last().as('lastItem');
+
+    cy.get('@firstItem').focus().type('{end}', { force: true });
+    cy.get('@lastItem').should('have.focus');
+  });
+
+  it('should not scroll page when pressing End key', () => {
+    cy.window().then(win => {
+      cy.wrap(win.pageYOffset).as('initialScroll');
+    });
+
+    cy.get('@trigger').click();
+    cy.get('@menu').find('button, a').first().focus();
+    cy.get('@menu').find('button, a').first().type('{end}', { force: true });
+
+    cy.window().then(win => {
+      cy.get('@initialScroll').should('equal', win.pageYOffset);
+    });
+  });
+
+  it('should close menu with Escape key', () => {
+    cy.get('@trigger').click();
+    cy.get('@menu').shadow().find('post-popovercontainer').should('not.have.css', 'display', 'none');
+
+    cy.get('@menu').find('button, a').first().focus().type('{esc}', { force: true });
+    cy.get('@menu').shadow().find('post-popovercontainer').should('have.css', 'display', 'none');
+  });
+});

--- a/packages/components/src/components/post-menu/post-menu.tsx
+++ b/packages/components/src/components/post-menu/post-menu.tsx
@@ -209,6 +209,7 @@ export class PostMenu {
         currentIndex = (currentIndex + 1) % menuItems.length;
         break;
       case this.KEYCODES.HOME:
+        e.preventDefault();
         currentIndex = 0;
         break;
       case this.KEYCODES.END:


### PR DESCRIPTION
## 📄 Description

This PR prevents page scroll when pressing Home key in post-menu dropdown navigation and adds comprehensive e2e test coverage for keyboard navigation.

## 🚀 Demo

[Menu page](https://preview-7624--swisspost-design-system-next.netlify.app/?path=/docs/8ca2bd70-56e6-4da9-b1fd-4e55388dca88--docs&devModeEnabled=true)

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
