### PR TITLE
fix(components-angular): ignore cors errors in playwright tests

### DIFF
--- a/packages/components-angular/package.json
+++ b/packages/components-angular/package.json
@@ -21,6 +21,7 @@
     "e2e": "playwright test",
     "e2e:ci": "playwright test",
     "e2e:watch": "playwright test --ui",
+    "unit": "echo 'No unit tests for components-angular'",
     "playwright:install": "playwright install --with-deps chromium",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",

--- a/packages/components-angular/projects/consumer-app/playwright/support/component-error-filter.ts
+++ b/packages/components-angular/projects/consumer-app/playwright/support/component-error-filter.ts
@@ -1,5 +1,9 @@
 import { Page, ConsoleMessage } from '@playwright/test';
 
+const IGNORE_ERROR_PATTERNS = [
+  /has been blocked by cors policy/i,
+];
+
 type CapturedError = {
   message: string;
   source: 'console' | 'pageerror';
@@ -62,19 +66,31 @@ export function setupComponentErrorCapture(page: Page, componentNames: string[])
 
   /**
    * Adds an error to the captured errors array if it passes all filters.
-   * Applies relevance checking.
+   * Applies relevance checking and ignore pattern filtering.
    *
    * @param message - The error message to capture
    * @param source - The source of the error ('console' or 'pageerror')
    * @param stack - Optional stack trace for the error
    */
   function pushError(message: string, source: CapturedError['source'], stack?: string): void {
-    // Skip errors unrelated to our components
-    if (!isRelevant(message)) return;
+    // Skip ignored errors and errors unrelated to our components
+    if (isIgnoredError(message) || !isRelevant(message)) return;
 
     const entry: CapturedError = { message, source, stack, timestamp: Date.now() };
     captured.push(entry);
     errors.push(message);
+  }
+
+  /**
+   * Checks if an error message matches known patterns that should be ignored.
+   * Currently filters out hydration-related errors, CORS errors, and other non-critical messages.
+   *
+   * @param text - Error message to check against ignore patterns
+   * @returns True if the error should be ignored, false otherwise
+   */
+  function isIgnoredError(text: string): boolean {
+    // Check if error message matches any known patterns that should be ignored
+    return IGNORE_ERROR_PATTERNS.some(pattern => pattern.test(text));
   }
 
   /**

--- a/packages/components-angular/projects/consumer-app/playwright/support/component-error-filter.ts
+++ b/packages/components-angular/projects/consumer-app/playwright/support/component-error-filter.ts
@@ -83,7 +83,7 @@ export function setupComponentErrorCapture(page: Page, componentNames: string[])
 
   /**
    * Checks if an error message matches known patterns that should be ignored.
-   * Currently filters out hydration-related errors, CORS errors, and other non-critical messages.
+   * Currently filters out CORS/network errors and other non-critical messages.
    *
    * @param text - Error message to check against ignore patterns
    * @returns True if the error should be ignored, false otherwise


### PR DESCRIPTION
## 📄 Description

CORS errors are network-level noise that have nothing to do with component behaviour and were causing the should not have console errors test to fail in CI.

Added an **IGNORE_ERROR_PATTERNS**, the same approach already used in integration-next https://github.com/swisspost/design-system/pull/7587.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
