### PR TITLE
fix: setup-pnpm action

### DIFF
--- a/.github/actions/setup-pnpm/action.yaml
+++ b/.github/actions/setup-pnpm/action.yaml
@@ -45,12 +45,8 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
       with:
-        # If input.pnpm_version is NOT defined,
-        # the action automatically uses the "packageManager" field from the package.json file
-        # If input.pnpm_version is defined, we need to point to another package.json file, without the "packageManager" field,
-        # so we do not end up with a "Multiple versions of pnpm specified" error
-        package_json_file: ${{ inputs.pnpm_version && 'apps/documentation/package.json' || 'package.json' }}
-        version: ${{ inputs.pnpm_version || null }}
+        package_json_file: 'packages/styles/package.json'
+        version: ${{ inputs.pnpm_version || fromJSON(steps.wanted-versions.outputs.result).pnpm }}
 
     - name: Install node
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
   "optionalDependencies": {
     "@web-types/lit": "2.0.0-3"
   },
-  "packageManager": "pnpm@10.29.3",
   "devEngines": {
     "runtime": {
       "name": "node",
@@ -132,6 +131,7 @@
       "onFail": "error"
     }
   },
+  "packageManager": "pnpm@10.29.3",
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [],


### PR DESCRIPTION
## 📄 Description

We'll keep the redundant packageManager field until turborepo supports `devEngines.packageManager`.
I've created a ticket for the cleanup: https://github.com/swisspost/design-system/issues/7764

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
