### PR TITLE
chore(components): fix horizontal scrollbar in breadcrumbs when not necessary

### DIFF
--- a/.changeset/fair-oranges-post.md
+++ b/.changeset/fair-oranges-post.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+> Fixed an unnecessary horizontal scrollbar appearing in the `post-breadcrumbs` concatenated menu.

--- a/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
+++ b/packages/components/src/components/post-popovercontainer/post-popovercontainer.scss
@@ -47,6 +47,7 @@
 
   .popover-scroll {
     max-height: var(--post-popovercontainer-available-height, none);
+    overflow-x: clip;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
## 📄 Description

Fixed the horizontal scrollbar appearing in the post-breadcrumbs concatenated menu, by `overflow-x: clip` on the scrollable area.

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
