### PR TITLE
chore(docs): hide dialog size and position args for bottom sheet

### DIFF
--- a/apps/documentation/src/stories/components/dialog/dialog.stories.ts
+++ b/apps/documentation/src/stories/components/dialog/dialog.stories.ts
@@ -74,6 +74,7 @@ const meta: Meta = {
       },
       options: ['small', 'medium', 'large'],
       table: { category: 'Variant' },
+      if: { arg: 'variant', neq: 'bottom-sheet' },
     },
     position: {
       name: 'Position',
@@ -84,6 +85,7 @@ const meta: Meta = {
       },
       options: ['top', 'center', 'bottom'],
       table: { category: 'Variant' },
+      if: { arg: 'variant', neq: 'bottom-sheet' },
     },
     animation: {
       name: 'Animation',


### PR DESCRIPTION
## 📄 Description

Hide the size and position arguments on the dialog story when user selects the `bottom-sheet` variant as it does not affect it.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
