### PR TITLE
chore(docs): move autocomplete back to raw components

### DIFF
--- a/.changeset/public-owls-attack.md
+++ b/.changeset/public-owls-attack.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Removed the "Form Autocomplete" documentation page because the component is not ready for use.

--- a/apps/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
+++ b/apps/documentation/src/stories/components/autocomplete/autocomplete.stories.ts
@@ -1,11 +1,11 @@
+import { spreadArgs } from '@/utils';
+import { MetaComponent } from '@root/types';
 import type { Args, StoryContext, StoryObj } from '@storybook/web-components-vite';
 import { html, TemplateResult } from 'lit';
-import { MetaComponent } from '@root/types';
-import { spreadArgs } from '@/utils';
 
 const meta: MetaComponent = {
   id: '5ef3cb45-86f6-4baf-bdbf-35bd2ddf0f3d',
-  title: 'Components/Form Autocomplete',
+  title: 'Raw Components/Form Autocomplete',
   component: 'post-autocomplete',
   tags: ['package:WebComponents'],
   render: createAutocompleteRenderer(),


### PR DESCRIPTION
## 📄 Description
 
This PR simply moves back the autocomplete docs to the Raw Components so it is no longer publicly available.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
