### PR TITLE
chore: update CSP for header playground

### DIFF
--- a/packages/internet-header/src/index.html
+++ b/packages/internet-header/src/index.html
@@ -1,9 +1,12 @@
-<!doctype html>
+<!DOCTYPE html>
 <html dir="ltr" lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="connect-src 'self' *.coveo.com *.post.ch" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="connect-src 'self' https://int.post.ch https://www.post.ch https://n.account.post.ch"
+    />
     <title>Common Web Frontend Internet Header</title>
 
     <link rel="stylesheet" href="/build/swisspost-internet-header.css" />


### PR DESCRIPTION
Coveo is not needed anymore and the other hosts can be specified without wildcard.