### PR TITLE
fix(styles): remove button link corners on Safari

### DIFF
--- a/.changeset/modern-tools-juggle.md
+++ b/.changeset/modern-tools-juggle.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': patch
+---
+
+Removed visible border on button links on Safari.

--- a/packages/styles/src/components/button.scss
+++ b/packages/styles/src/components/button.scss
@@ -56,11 +56,15 @@ tokens.$default-map: components.$post-button;
 .btn-link {
   text-decoration: tokens.get('link-decoration', elements.$post-link);
   border: 0 none;
-  border-radius: tokens.get('link-border-radius', elements.$post-link);
+  border-radius: 0;
   min-height: 0;
   font-size: inherit;
   font-weight: inherit;
   padding: 0;
+
+  @include utilities.focus-style-custom() {
+    border-radius: tokens.get('link-border-radius', elements.$post-link);
+  }
 
   &:hover {
     color: tokens.get('link-hover-fg', elements.$post-link);


### PR DESCRIPTION
## 📄 Description

This fixes the visible corners on button links in Safari.
To remove the unwanted corners, the button's border-radius is set to 0. However, the focus outline relies on it to render with rounded corners. As a result, the rounded border-radius is applied only while the button is focused, which causes the corners to reappear during the focus state.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
