### PR TITLE
fix: dev engines definition in the root package.json to unblock mise

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     },
     "packageManager": {
       "name": "pnpm",
-      "version": "10.29.3+sha512.498e1fb4cca5aa06c1dcf2611e6fafc50972ffe7189998c409e90de74566444298ffe43e6cd2acdc775ba1aa7cc5e092a8b7054c811ba8c5770f84693d33d2dc",
+      "version": "10.29.3",
       "onFail": "warn"
     }
   },


### PR DESCRIPTION
## 📄 Description

[mise](https://mise.jdx.dev/) is failing to install pnpm, when its verison is specified with a SHA.

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
