### PR TITLE
fix(components): fix accessibility violations for `<post-date-picker>` component

### DIFF
--- a/.changeset/ready-islands-join.md
+++ b/.changeset/ready-islands-join.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Fixed accessibility violations in the `<post-date-picker>` component.

--- a/packages/components/cypress/e2e/date-picker.cy.ts
+++ b/packages/components/cypress/e2e/date-picker.cy.ts
@@ -42,8 +42,8 @@ describe('date-picker', { includeShadowDom: true }, () => {
         cy.get('@container').find('[role="grid"]').should('exist');
 
         cy.get('@container')
-          .find('.air-datepicker-nav--title button')
-          .should('have.attr', 'aria-label', 'Switch to year view');
+          .find('.air-datepicker-nav--title button .visually-hidden')
+          .should('have.text', ', Switch to year view');
 
         cy.get('@container')
           .find('[data-action="next"] button')

--- a/packages/components/src/components/post-date-picker/post-date-picker.scss
+++ b/packages/components/src/components/post-date-picker/post-date-picker.scss
@@ -150,6 +150,12 @@ $current-day-inset: calc(var(--adp-cell-border-width) * -1);
       row-gap: tokens.get('post-datepicker-grid-gap-block');
       border-radius: tokens.get('post-datepicker-border-radius');
 
+      .a11y-row {
+        display: grid;
+        grid-column: 1/-1;
+        grid-template-columns: subgrid;
+      }
+
       /* View-specific styles */
 
       &.-days- {
@@ -761,4 +767,8 @@ $current-day-inset: calc(var(--adp-cell-border-width) * -1);
       }
     }
   }
+}
+
+.visually-hidden {
+  @include utilities.visuallyhidden;
 }

--- a/packages/components/src/components/post-date-picker/post-date-picker.tsx
+++ b/packages/components/src/components/post-date-picker/post-date-picker.tsx
@@ -229,6 +229,13 @@ export class PostDatePicker {
 
   private static readonly FLYOUT_OFFSET: number = 4;
 
+  // Cells per row for each view
+  private static readonly COLUMNS_BY_VIEW: Record<AirDatepickerViews, number> = {
+    days: 7,
+    months: 4,
+    years: 4,
+  };
+
   private currentViewMonth: number;
   private currentViewYear: number;
   private currentViewType: AirDatepickerViews = 'days';
@@ -370,7 +377,7 @@ export class PostDatePicker {
         break;
     }
 
-    return Array.from(this.dpContainer.querySelectorAll(selector));
+    return Array.from(this.dpContainer.querySelectorAll<HTMLElement>(selector));
   }
 
   private setActiveCell(date: Date, focusOnDate: boolean = true) {
@@ -647,6 +654,34 @@ export class PostDatePicker {
     }
   };
 
+  // ARIA requires role="grid" to own role="row", and role="row" to own role="gridcell"
+  // AirDatepicker renders cells flat, so we wrap them in row divs to satisfy that
+  private wrapCellsInRows(body: Element) {
+    this.gridObserver?.disconnect();
+
+    body.querySelectorAll(':scope > [role="row"]').forEach(row => {
+      while (row.firstChild) body.insertBefore(row.firstChild, row);
+      row.remove();
+    });
+
+    const cells = Array.from(body.children).filter(el =>
+      el.classList.contains('air-datepicker-cell'),
+    );
+    const columns = PostDatePicker.COLUMNS_BY_VIEW[this.currentViewType];
+
+    for (let i = 0; i < cells.length; i += columns) {
+      const row = document.createElement('div');
+      row.setAttribute('role', 'row');
+      row.classList.add('a11y-row');
+      body.insertBefore(row, cells[i]);
+      for (let j = i; j < i + columns && j < cells.length; j++) {
+        row.appendChild(cells[j]);
+      }
+    }
+
+    this.gridObserver.observe(body, { childList: true, subtree: false });
+  }
+
   private enhanceAccessibility(focusOnDate: boolean = true) {
     let body = this.dpContainer.querySelector('.air-datepicker-body--cells');
 
@@ -658,6 +693,7 @@ export class PostDatePicker {
     if (!body) return;
 
     body.setAttribute('role', 'grid');
+    this.wrapCellsInRows(body);
 
     this.getCells().forEach(c => {
       c.setAttribute('aria-selected', c.classList.contains('-selected-') ? 'true' : 'false');
@@ -863,8 +899,8 @@ export class PostDatePicker {
     if (this.dpContainer) {
       const options: AirDatepickerOptions<HTMLDivElement> = {
         navTitles: {
-          days: `<button aria-label="${this.textSwitchYear}"><strong>MMMM yyyy</strong><post-icon name="chevrondown"></post-icon></button>`,
-          months: `<button aria-label="${this.textSwitchYear}"><strong>yyyy</strong><post-icon name="chevrondown"></post-icon></button>`,
+          days: `<button><strong>MMMM yyyy</strong><span class="visually-hidden">, ${this.textSwitchYear}</span><post-icon name="chevrondown"></post-icon></button>`,
+          months: `<button><strong>yyyy</strong><span class="visually-hidden">, ${this.textSwitchYear}</span><post-icon name="chevrondown"></post-icon></button>`,
         },
         prevHtml: '<button><post-icon name="chevronleft" ></post-icon></button>',
         nextHtml: '<button><post-icon name="chevronright" ></post-icon></button>',

--- a/packages/components/src/components/post-date-picker/post-date-picker.tsx
+++ b/packages/components/src/components/post-date-picker/post-date-picker.tsx
@@ -675,7 +675,7 @@ export class PostDatePicker {
       row.classList.add('a11y-row');
       body.insertBefore(row, cells[i]);
       for (let j = i; j < i + columns && j < cells.length; j++) {
-        row.appendChild(cells[j]);
+        row.append(cells[j]);
       }
     }
 

--- a/packages/components/src/components/post-date-picker/post-date-picker.tsx
+++ b/packages/components/src/components/post-date-picker/post-date-picker.tsx
@@ -473,6 +473,8 @@ export class PostDatePicker {
 
   private skipOnSelectCount = 0;
   private skipFocusOnNextRender = false;
+  // Date the keyboard is navigating to, used to keep focus correct when the grid redraws
+  private pendingFocusDate: Date | null = null;
 
   private handleInputBlur = () => {
     if (this.range) {
@@ -643,11 +645,19 @@ export class PostDatePicker {
       current.getMonth() !== newDate.getMonth() || current.getFullYear() !== newDate.getFullYear();
 
     if (monthChanged) {
+      this.pendingFocusDate = newDate;
       this.skipFocusOnNextRender = false;
       this.dpInstance.setViewDate(newDate);
 
       requestAnimationFrame(() => {
         this.setActiveCell(newDate, true);
+
+        // Clear it a frame later, in case the grid redraws itself twice
+        requestAnimationFrame(() => {
+          if (this.pendingFocusDate === newDate) {
+            this.pendingFocusDate = null;
+          }
+        });
       });
     } else {
       this.setActiveCell(newDate, true);
@@ -707,7 +717,10 @@ export class PostDatePicker {
 
     const dates = this.getIsoDates();
     const selectedDate = dates[0] ? isoToDate(dates[0]) : null;
-    this.setActiveCell(selectedDate || this.today, focusOnDate);
+    // Focus the keyboard's target date if there is one, else the selected date, else today
+    const dateToFocus = this.pendingFocusDate || selectedDate || this.today;
+
+    this.setActiveCell(dateToFocus, focusOnDate);
   }
 
   /**


### PR DESCRIPTION
## 📄 Description

Fixes two accessibility violations in `<post-date-picker>`, flagged independently by axe DevTools, ARC Toolkit, and Siteimprove:

1. **Grid cells missing required `row` context** : AirDatepicker renders calendar cells as a flat list, so `role="gridcell"` had no `role="row"` ancestor between it and the `role="grid"` container. Scanners correctly flagged this as invalid ARIA structure.
2. **Label in Name mismatch (WCAG 2.5.3)**:  the nav title button's `aria-label` fully replaced its accessible name (e.g. visible "July 2026" vs. announced "Switch to year view"), so voice-control users saying the visible label couldn't activate the button.
3. A third violation was also flagged on this component ("Form field missing a label," on the slotted `<input>`), that one is out of scope here and is being addressed separately in #8054.


## How

- Added `wrapCellsInRows()`, which groups the flat cell list into `role="row"` wrapper divs, keeping the required `grid > row > gridcell` hierarchy intact. Uses CSS `subgrid`
- `gridObserver` disconnects before `wrapCellsInRows()` mutates the DOM and reconnects after, so the observer doesn't react to its own change
- Replaced the nav title's `aria-label` with a `.visually-hidden` span appended after the visible text, so the accessible name now contains the visible label plus the extra context, instead of replacing it.

## Testing

- Verified with ARC Toolkit / axe DevTools that both violations are resolved on days/months/years views.
- Manually confirmed no visual regression (subgrid inherits the parent's column tracks, so cell layout is unchanged).
- Manually confirmed keyboard navigation (arrows, month/view switching) still works correctly with the new row wrappers in place.

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
