### PR TITLE
fix(docs): fix code ql parsing issues in `date-picker-disable.sample.ts`

### DIFF
--- a/.changeset/puny-phones-grin.md
+++ b/.changeset/puny-phones-grin.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Fixed incorrect `cellConfig` callback signature in the `<post-date-picker>` disable-dates documentation sample.

--- a/apps/documentation/src/stories/components/datepicker/date-picker-disable.sample.ts
+++ b/apps/documentation/src/stories/components/datepicker/date-picker-disable.sample.ts
@@ -1,7 +1,7 @@
 window.addEventListener('DOMContentLoaded', () => {
   const datePicker: HTMLPostDatePickerElement = document.querySelector('post-date-picker');
 
-  datePicker.cellConfig = ({ date: Date, cellType: 'day' | 'month' | 'year' }) => {
+  datePicker.cellConfig = ({ date, cellType }: { date: Date; cellType: 'day' | 'month' | 'year' }) => {
     if (cellType === 'day' && date.getDay() === 0) {
       return { disabled: true };
     }

--- a/apps/documentation/src/stories/components/datepicker/date-picker-disable.sample.ts
+++ b/apps/documentation/src/stories/components/datepicker/date-picker-disable.sample.ts
@@ -1,7 +1,7 @@
 window.addEventListener('DOMContentLoaded', () => {
   const datePicker: HTMLPostDatePickerElement = document.querySelector('post-date-picker');
 
-  datePicker.cellConfig = ({ date, cellType }: { date: Date; cellType: 'day' | 'month' | 'year' }) => {
+  datePicker.cellConfig = (date: Date, cellType: 'day' | 'month' | 'year') => {
     if (cellType === 'day' && date.getDay() === 0) {
       return { disabled: true };
     }


### PR DESCRIPTION
## 📄 Description
This PR fixes a CodeQL parse error reported in code scanning, caused by invalid destructuring syntax in `date-picker-disable.sample.ts`.
 
## Context
Original ticket (#5888) listed 8 files with CodeQL parse errors (the link attached to the ticket displays "The logs have expired"). Checked the current [Code scanning alerts](https://github.com/swisspost/design-system/security/code-scanning/tools/CodeQL/status/configurations/automatic/13b4667cf1b1b63f3e04c795be76152eb27d810bce6dd440c1b9b26b570367bd) list and it displays only one **"Could not process some files due to syntax errors"** warning.
 
## Problem
 
```ts
datePicker.cellConfig = ({ date: Date, cellType: 'day' | 'month' | 'year' }) => {
```
 
`date: Date` is parsed as a destructuring rename, not a type annotation, and `cellType: 'day' | 'month' | 'year'` isn't valid there either a union type can't be a rename target.

 ## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
