### PR TITLE
fix(components): always show, but dynamically disable pagination controls

### DIFF
--- a/.changeset/pink-shrimps-call.md
+++ b/.changeset/pink-shrimps-call.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Updated the `post-pagination` component to always show, but dynamically disable the navigation control buttons.

--- a/packages/components/cypress/e2e/pagination.cy.ts
+++ b/packages/components/cypress/e2e/pagination.cy.ts
@@ -33,12 +33,12 @@ describe('pagination', () => {
         .should('contain', '1');
     });
 
-    it('should hide previous button on first page', () => {
-      cy.get('.prev-button').should('not.exist');
+    it('should disable previous button on first page', () => {
+      cy.get('.prev-button').should('exist').and('be.disabled');
     });
 
-    it('should show next button on first page', () => {
-      cy.get('@nextButton').should('exist');
+    it('should enable next button on first page', () => {
+      cy.get('@nextButton').should('exist').and('be.enabled');
     });
 
     it('should navigate to next page when next button is clicked', () => {
@@ -188,12 +188,12 @@ describe('pagination', () => {
         });
     });
 
-    it('should hide next button on last page', () => {
-      cy.get('.next-button').should('not.exist');
+    it('should disable next button on last page', () => {
+      cy.get('.next-button').should('exist').and('be.disabled');
     });
 
-    it('should show previous button on last page', () => {
-      cy.get('.prev-button').should('exist');
+    it('should enable previous button on last page', () => {
+      cy.get('.prev-button').should('exist').and('be.enabled');
     });
   });
 
@@ -373,7 +373,7 @@ describe('Accessibility', () => {
   variants.forEach(variant => {
     it(`Has no detectable a11y violations for ${variant.name} variant`, () => {
       cy.getComponent('pagination', PAGINATION_ID, variant.id);
-      cy.checkA11y('#root-inner', undefined, (violations) => {
+      cy.checkA11y('#root-inner', undefined, violations => {
         expect(violations).to.have.length(0);
       });
     });

--- a/packages/components/src/components/post-pagination/post-pagination.tsx
+++ b/packages/components/src/components/post-pagination/post-pagination.tsx
@@ -21,12 +21,37 @@ const MAX_ELLIPSIS_COUNT = 2; // Maximum ellipsis elements
 const GAP_THRESHOLD_FOR_PAGE = 2; // Show page number instead of ellipsis when gap is this value
 const MIDDLE_RANGE_START = 2; // Middle range starts from page 2 (page 1 is always shown separately)
 
+const enum PaginationItemType {
+  Page,
+  Control,
+  Ellipsis,
+}
+
 /**
  * Type-safe pagination item definition using discriminated union.
  */
-type PaginationItem = { type: 'page'; page: number } | { type: 'ellipsis' };
+type PaginationItem =
+  | { type: PaginationItemType.Page; page: number }
+  | { type: PaginationItemType.Control; action: ControlAction; disabled: boolean }
+  | { type: PaginationItemType.Ellipsis };
 
-type SectionType = 'none' | 'page' | 'ellipsis';
+const enum ControlAction {
+  Previous,
+  Next,
+}
+
+interface ControlAttributes {
+  icon: string;
+  label: string;
+  className: string;
+  onClick: () => void;
+}
+
+const enum SectionType {
+  None,
+  Page,
+  Ellipsis,
+}
 
 @Component({
   tag: 'post-pagination',
@@ -297,7 +322,7 @@ export class PostPagination {
   private updatePagesWithValidation() {
     const totalPages = this.getTotalPages();
     this.page = this.clampPageToValidRange(totalPages);
-    this.generatePages(totalPages);
+    this.generateItems(totalPages);
   }
 
   /**
@@ -312,8 +337,8 @@ export class PostPagination {
    * Convert numeric gap to a section type
    */
   private sectionForGap(gap: number): SectionType {
-    if (gap <= 1) return 'none';
-    return gap === GAP_THRESHOLD_FOR_PAGE ? 'page' : 'ellipsis';
+    if (gap <= 1) return SectionType.None;
+    return gap === GAP_THRESHOLD_FOR_PAGE ? SectionType.Page : SectionType.Ellipsis;
   }
 
   /**
@@ -337,8 +362,8 @@ export class PostPagination {
   private computeTotalItems(startPage: number, endPage: number, totalPages: number): number {
     const { leftSection, rightSection } = this.getSections(startPage, endPage, totalPages);
     const middle = Math.max(0, endPage - startPage + 1);
-    const leftCount = leftSection === 'none' ? 0 : 1;
-    const rightCount = rightSection === 'none' ? 0 : 1;
+    const leftCount = leftSection === SectionType.None ? 0 : 1;
+    const rightCount = rightSection === SectionType.None ? 0 : 1;
 
     // Always include first page (1) and last page (totalPages) = EDGE_ITEM_COUNT pages
     // Plus any left/right sections (ellipsis or pages) and middle pages
@@ -351,7 +376,7 @@ export class PostPagination {
   private buildAllPages(totalPages: number): PaginationItem[] {
     const items: PaginationItem[] = [];
     for (let i = 1; i <= totalPages; i++) {
-      items.push({ type: 'page', page: i });
+      items.push({ type: PaginationItemType.Page, page: i });
     }
     return items;
   }
@@ -544,32 +569,32 @@ export class PostPagination {
     const hasMiddlePages = startPage <= endPage;
 
     // First page
-    items.push({ type: 'page', page: 1 });
+    items.push({ type: PaginationItemType.Page, page: 1 });
 
     if (hasMiddlePages) {
       const { leftSection, rightSection } = this.getSections(startPage, endPage, totalPages);
 
       // Left section (ellipsis or page 2)
-      if (leftSection === 'page') {
-        items.push({ type: 'page', page: 2 });
-      } else if (leftSection === 'ellipsis') {
-        items.push({ type: 'ellipsis' });
+      if (leftSection === SectionType.Page) {
+        items.push({ type: PaginationItemType.Page, page: 2 });
+      } else if (leftSection === SectionType.Ellipsis) {
+        items.push({ type: PaginationItemType.Ellipsis });
       }
 
       // Middle pages
       for (let i = startPage; i <= endPage; i++) {
-        items.push({ type: 'page', page: i });
+        items.push({ type: PaginationItemType.Page, page: i });
       }
 
       // Right section (ellipsis or second-to-last page)
-      if (rightSection === 'page') {
-        items.push({ type: 'page', page: totalPages - 1 });
-      } else if (rightSection === 'ellipsis') {
-        items.push({ type: 'ellipsis' });
+      if (rightSection === SectionType.Page) {
+        items.push({ type: PaginationItemType.Page, page: totalPages - 1 });
+      } else if (rightSection === SectionType.Ellipsis) {
+        items.push({ type: PaginationItemType.Ellipsis });
       }
 
       // Last page
-      items.push({ type: 'page', page: totalPages });
+      items.push({ type: PaginationItemType.Page, page: totalPages });
 
       return items;
     }
@@ -581,32 +606,62 @@ export class PostPagination {
    */
   private generateSmallPagination(currentPage: number, totalPages: number): PaginationItem[] {
     if (currentPage === 1 || currentPage === totalPages) {
-      return [{ type: 'page', page: 1 }, { type: 'ellipsis' }, { type: 'page', page: totalPages }];
+      return [
+        { type: PaginationItemType.Page, page: 1 },
+        { type: PaginationItemType.Ellipsis },
+        { type: PaginationItemType.Page, page: totalPages },
+      ];
     }
-    return [{ type: 'ellipsis' }, { type: 'page', page: currentPage }, { type: 'ellipsis' }];
+
+    return [
+      { type: PaginationItemType.Ellipsis },
+      { type: PaginationItemType.Page, page: currentPage },
+      { type: PaginationItemType.Ellipsis },
+    ];
   }
 
   /**
    * Generates the page numbers array with ellipsis based on available space.
    */
-  private generatePages(totalPages: number) {
-    const maxVisible = this.maxVisiblePages;
-    const currentPage = this.page;
-
+  private generatePages(
+    totalPages: number,
+    maxVisible: number,
+    currentPage: number,
+  ): PaginationItem[] {
     if (totalPages <= maxVisible) {
-      this.items = this.buildAllPages(totalPages);
-      return;
+      return this.buildAllPages(totalPages);
     }
 
     // Use simplified logic for small slot counts
     if (maxVisible <= 4) {
-      this.items = this.generateSmallPagination(currentPage, totalPages);
-      return;
+      return this.generateSmallPagination(currentPage, totalPages);
     }
 
     // Use full algorithm for larger slot counts
     const { startPage, endPage } = this.calculatePageRange(currentPage, totalPages, maxVisible);
-    this.items = this.buildPaginationItems(startPage, endPage, totalPages);
+    return this.buildPaginationItems(startPage, endPage, totalPages);
+  }
+
+  /**
+   * Generates the full list of pagination items including controls and pages.
+   */
+  private generateItems(totalPages: number) {
+    const maxVisible = this.maxVisiblePages;
+    const currentPage = this.page;
+
+    this.items = [
+      {
+        type: PaginationItemType.Control,
+        action: ControlAction.Previous,
+        disabled: currentPage <= 1,
+      },
+      ...this.generatePages(totalPages, maxVisible, currentPage),
+      {
+        type: PaginationItemType.Control,
+        action: ControlAction.Next,
+        disabled: currentPage >= totalPages,
+      },
+    ];
   }
 
   /**
@@ -673,11 +728,33 @@ export class PostPagination {
   }
 
   /**
+   * Builds the attributes for a control button based on the action type.
+   */
+  private buildControlAttributes(action: ControlAction): ControlAttributes {
+    switch (action) {
+      case ControlAction.Next:
+        return {
+          icon: 'chevronleftwide',
+          label: this.textPrevious,
+          className: 'prev-button',
+          onClick: () => this.handlePrevious(),
+        };
+      case ControlAction.Previous:
+        return {
+          icon: 'chevronrightwide',
+          label: this.textNext,
+          className: 'next-button',
+          onClick: () => this.handleNext(),
+        };
+    }
+  }
+
+  /**
    * Renders an ellipsis item.
    */
-  private renderEllipsis(key: string) {
+  private renderEllipsis(index: number) {
     return (
-      <li class="pagination-item pagination-ellipsis" key={key} aria-hidden="true">
+      <li class="pagination-item pagination-ellipsis" key={`ellipsis-${index}`} aria-hidden="true">
         <span class="pagination-ellipsis-content">{ELLIPSIS}</span>
       </li>
     );
@@ -710,50 +787,66 @@ export class PostPagination {
   }
 
   /**
-   * Renders a pagination item.
+   * Renders a control button.
    */
-  private renderItem(item: PaginationItem, index: number) {
-    return item.type === 'ellipsis'
-      ? this.renderEllipsis(`ellipsis-${index}`)
-      : this.renderPageButton(item.page);
-  }
+  private renderControlButton(action: ControlAction, disabled: boolean, dummy: boolean) {
+    const attributes = this.buildControlAttributes(action);
 
-  /**
-   * Renders control button (prev/next)
-   */
-  private renderControlButton(
-    iconName: string,
-    isPrev: boolean,
-    label: string,
-    onClick: () => void,
-  ) {
+    if (dummy) {
+      return (
+        <button
+          key="hidden-prev"
+          class="pagination-link pagination-control-button hidden-control-button"
+          disabled
+        >
+          <post-icon name={attributes.icon} aria-hidden="true"></post-icon>
+        </button>
+      );
+    }
+
     return (
       <li class="pagination-item pagination-control">
         <button
           type="button"
-          class={`pagination-control-button btn btn-icon btn-secondary ${isPrev ? 'prev-button' : 'next-button'}`}
-          aria-label={label}
-          onClick={onClick}
-          onKeyDown={e => this.handleKeyDown(e, onClick)}
+          class={`pagination-control-button btn btn-icon btn-secondary ${attributes.className}`}
+          aria-label={attributes.label}
+          onClick={attributes.onClick}
+          onKeyDown={e => this.handleKeyDown(e, attributes.onClick)}
           tabIndex={0}
+          disabled={disabled}
         >
-          <post-icon name={iconName} aria-hidden="true"></post-icon>
-          <span class="visually-hidden">{label}</span>
+          <post-icon name={attributes.icon} aria-hidden="true"></post-icon>
+          <span class="visually-hidden">{attributes.label}</span>
         </button>
       </li>
     );
   }
 
   /**
+   * Renders a pagination item.
+   */
+  private renderItem(item: PaginationItem, index: number) {
+    switch (item.type) {
+      case PaginationItemType.Page:
+        return this.renderPageButton(item.page);
+      case PaginationItemType.Control:
+        return this.renderControlButton(item.action, item.disabled, false);
+      case PaginationItemType.Ellipsis:
+        return this.renderEllipsis(index);
+    }
+  }
+
+  /**
    * Renders minimal hidden items for measurement
    */
-  private renderHiddenItems(totalPages: number, isPrevHidden: boolean, isNextHidden: boolean) {
+  private renderHiddenItems(totalPages: number) {
+    const first = this.items.at(0);
+    const last = this.items.at(totalPages);
+
     return [
-      !isPrevHidden && (
-        <button key="hidden-prev" class="pagination-link pagination-control-button hidden-control-button" disabled>
-          <post-icon name="chevronleftwide" aria-hidden="true"></post-icon>
-        </button>
-      ),
+      first?.type === PaginationItemType.Control &&
+        this.renderControlButton(first.action, true, true),
+
       <button
         key="hidden-page"
         class="pagination-link pagination-control-button hidden-page-button"
@@ -762,14 +855,16 @@ export class PostPagination {
       >
         <span aria-hidden="true">{totalPages}</span>
       </button>,
-      <span key="hidden-ellipsis" class="pagination-ellipsis-content hidden-ellipsis" aria-hidden="true">
+      <span
+        key="hidden-ellipsis"
+        class="pagination-ellipsis-content hidden-ellipsis"
+        aria-hidden="true"
+      >
         {ELLIPSIS}
       </span>,
-      !isNextHidden && (
-        <button key="hidden-next" class="pagination-link pagination-control-button hidden-control-button" disabled>
-          <post-icon name="chevronrightwide" aria-hidden="true"></post-icon>
-        </button>
-      ),
+
+      last?.type === PaginationItemType.Control &&
+        this.renderControlButton(last.action, true, true),
     ];
   }
 
@@ -780,9 +875,6 @@ export class PostPagination {
       return null;
     }
 
-    const isPrevHidden = this.page <= 1;
-    const isNextHidden = this.page >= totalPages;
-
     return (
       <Host slot="post-pagination" data-version={version}>
         <nav
@@ -792,25 +884,12 @@ export class PostPagination {
           ref={el => (this.navRef = el)}
         >
           <ul class="pagination-list" role="list">
-            {/* Previous Button */}
-            {!isPrevHidden &&
-              this.renderControlButton('chevronleftwide', true, this.textPrevious, () =>
-                this.handlePrevious(),
-              )}
-
-            {/* Page Items */}
             {this.items.map((item, index) => this.renderItem(item, index))}
-
-            {/* Next Button */}
-            {!isNextHidden &&
-              this.renderControlButton('chevronrightwide', false, this.textNext, () =>
-                this.handleNext(),
-              )}
           </ul>
 
           {/* Hidden items container for width measurement */}
           <div class="hidden-items" aria-hidden="true" ref={el => (this.hiddenItemsRef = el)}>
-            {this.renderHiddenItems(totalPages, isPrevHidden, isNextHidden)}
+            {this.renderHiddenItems(totalPages)}
           </div>
         </nav>
       </Host>

--- a/packages/components/src/components/post-pagination/post-pagination.tsx
+++ b/packages/components/src/components/post-pagination/post-pagination.tsx
@@ -41,6 +41,7 @@ const enum ControlAction {
 }
 
 interface ControlAttributes {
+  key: string;
   icon: string;
   label: string;
   className: string;
@@ -732,15 +733,17 @@ export class PostPagination {
    */
   private buildControlAttributes(action: ControlAction): ControlAttributes {
     switch (action) {
-      case ControlAction.Next:
+      case ControlAction.Previous:
         return {
+          key: 'prev',
           icon: 'chevronleftwide',
           label: this.textPrevious,
           className: 'prev-button',
           onClick: () => this.handlePrevious(),
         };
-      case ControlAction.Previous:
+      case ControlAction.Next:
         return {
+          key: 'next',
           icon: 'chevronrightwide',
           label: this.textNext,
           className: 'next-button',
@@ -795,7 +798,7 @@ export class PostPagination {
     if (dummy) {
       return (
         <button
-          key="hidden-prev"
+          key={`hidden-${attributes.key}`}
           class="pagination-link pagination-control-button hidden-control-button"
           disabled
         >
@@ -805,7 +808,7 @@ export class PostPagination {
     }
 
     return (
-      <li class="pagination-item pagination-control">
+      <li class="pagination-item pagination-control" key={attributes.key}>
         <button
           type="button"
           class={`pagination-control-button btn btn-icon btn-secondary ${attributes.className}`}
@@ -841,7 +844,7 @@ export class PostPagination {
    */
   private renderHiddenItems(totalPages: number) {
     const first = this.items.at(0);
-    const last = this.items.at(totalPages);
+    const last = this.items.at(-1);
 
     return [
       first?.type === PaginationItemType.Control &&

--- a/packages/components/src/components/post-pagination/post-pagination.tsx
+++ b/packages/components/src/components/post-pagination/post-pagination.tsx
@@ -21,24 +21,15 @@ const MAX_ELLIPSIS_COUNT = 2; // Maximum ellipsis elements
 const GAP_THRESHOLD_FOR_PAGE = 2; // Show page number instead of ellipsis when gap is this value
 const MIDDLE_RANGE_START = 2; // Middle range starts from page 2 (page 1 is always shown separately)
 
-const enum PaginationItemType {
-  Page,
-  Control,
-  Ellipsis,
-}
-
 /**
  * Type-safe pagination item definition using discriminated union.
  */
 type PaginationItem =
-  | { type: PaginationItemType.Page; page: number }
-  | { type: PaginationItemType.Control; action: ControlAction; disabled: boolean }
-  | { type: PaginationItemType.Ellipsis };
+  | { type: 'page'; page: number }
+  | { type: 'control'; action: ControlAction; disabled: boolean }
+  | { type: 'ellipsis' };
 
-const enum ControlAction {
-  Previous,
-  Next,
-}
+type ControlAction = 'previous' | 'next';
 
 interface ControlAttributes {
   key: string;
@@ -48,11 +39,7 @@ interface ControlAttributes {
   onClick: () => void;
 }
 
-const enum SectionType {
-  None,
-  Page,
-  Ellipsis,
-}
+type SectionType = 'none' | 'page' | 'ellipsis';
 
 @Component({
   tag: 'post-pagination',
@@ -338,8 +325,8 @@ export class PostPagination {
    * Convert numeric gap to a section type
    */
   private sectionForGap(gap: number): SectionType {
-    if (gap <= 1) return SectionType.None;
-    return gap === GAP_THRESHOLD_FOR_PAGE ? SectionType.Page : SectionType.Ellipsis;
+    if (gap <= 1) return 'none';
+    return gap === GAP_THRESHOLD_FOR_PAGE ? 'page' : 'ellipsis';
   }
 
   /**
@@ -363,8 +350,8 @@ export class PostPagination {
   private computeTotalItems(startPage: number, endPage: number, totalPages: number): number {
     const { leftSection, rightSection } = this.getSections(startPage, endPage, totalPages);
     const middle = Math.max(0, endPage - startPage + 1);
-    const leftCount = leftSection === SectionType.None ? 0 : 1;
-    const rightCount = rightSection === SectionType.None ? 0 : 1;
+    const leftCount = leftSection === 'none' ? 0 : 1;
+    const rightCount = rightSection === 'none' ? 0 : 1;
 
     // Always include first page (1) and last page (totalPages) = EDGE_ITEM_COUNT pages
     // Plus any left/right sections (ellipsis or pages) and middle pages
@@ -377,7 +364,7 @@ export class PostPagination {
   private buildAllPages(totalPages: number): PaginationItem[] {
     const items: PaginationItem[] = [];
     for (let i = 1; i <= totalPages; i++) {
-      items.push({ type: PaginationItemType.Page, page: i });
+      items.push({ type: 'page', page: i });
     }
     return items;
   }
@@ -570,32 +557,32 @@ export class PostPagination {
     const hasMiddlePages = startPage <= endPage;
 
     // First page
-    items.push({ type: PaginationItemType.Page, page: 1 });
+    items.push({ type: 'page', page: 1 });
 
     if (hasMiddlePages) {
       const { leftSection, rightSection } = this.getSections(startPage, endPage, totalPages);
 
       // Left section (ellipsis or page 2)
-      if (leftSection === SectionType.Page) {
-        items.push({ type: PaginationItemType.Page, page: 2 });
-      } else if (leftSection === SectionType.Ellipsis) {
-        items.push({ type: PaginationItemType.Ellipsis });
+      if (leftSection === 'page') {
+        items.push({ type: 'page', page: 2 });
+      } else if (leftSection === 'ellipsis') {
+        items.push({ type: 'ellipsis' });
       }
 
       // Middle pages
       for (let i = startPage; i <= endPage; i++) {
-        items.push({ type: PaginationItemType.Page, page: i });
+        items.push({ type: 'page', page: i });
       }
 
       // Right section (ellipsis or second-to-last page)
-      if (rightSection === SectionType.Page) {
-        items.push({ type: PaginationItemType.Page, page: totalPages - 1 });
-      } else if (rightSection === SectionType.Ellipsis) {
-        items.push({ type: PaginationItemType.Ellipsis });
+      if (rightSection === 'page') {
+        items.push({ type: 'page', page: totalPages - 1 });
+      } else if (rightSection === 'ellipsis') {
+        items.push({ type: 'ellipsis' });
       }
 
       // Last page
-      items.push({ type: PaginationItemType.Page, page: totalPages });
+      items.push({ type: 'page', page: totalPages });
 
       return items;
     }
@@ -607,18 +594,10 @@ export class PostPagination {
    */
   private generateSmallPagination(currentPage: number, totalPages: number): PaginationItem[] {
     if (currentPage === 1 || currentPage === totalPages) {
-      return [
-        { type: PaginationItemType.Page, page: 1 },
-        { type: PaginationItemType.Ellipsis },
-        { type: PaginationItemType.Page, page: totalPages },
-      ];
+      return [{ type: 'page', page: 1 }, { type: 'ellipsis' }, { type: 'page', page: totalPages }];
     }
 
-    return [
-      { type: PaginationItemType.Ellipsis },
-      { type: PaginationItemType.Page, page: currentPage },
-      { type: PaginationItemType.Ellipsis },
-    ];
+    return [{ type: 'ellipsis' }, { type: 'page', page: currentPage }, { type: 'ellipsis' }];
   }
 
   /**
@@ -652,14 +631,14 @@ export class PostPagination {
 
     this.items = [
       {
-        type: PaginationItemType.Control,
-        action: ControlAction.Previous,
+        type: 'control',
+        action: 'previous',
         disabled: currentPage <= 1,
       },
       ...this.generatePages(totalPages, maxVisible, currentPage),
       {
-        type: PaginationItemType.Control,
-        action: ControlAction.Next,
+        type: 'control',
+        action: 'next',
         disabled: currentPage >= totalPages,
       },
     ];
@@ -733,7 +712,7 @@ export class PostPagination {
    */
   private buildControlAttributes(action: ControlAction): ControlAttributes {
     switch (action) {
-      case ControlAction.Previous:
+      case 'previous':
         return {
           key: 'prev',
           icon: 'chevronleftwide',
@@ -741,7 +720,7 @@ export class PostPagination {
           className: 'prev-button',
           onClick: () => this.handlePrevious(),
         };
-      case ControlAction.Next:
+      case 'next':
         return {
           key: 'next',
           icon: 'chevronrightwide',
@@ -792,20 +771,8 @@ export class PostPagination {
   /**
    * Renders a control button.
    */
-  private renderControlButton(action: ControlAction, disabled: boolean, dummy: boolean) {
+  private renderControlButton(action: ControlAction, disabled: boolean) {
     const attributes = this.buildControlAttributes(action);
-
-    if (dummy) {
-      return (
-        <button
-          key={`hidden-${attributes.key}`}
-          class="pagination-link pagination-control-button hidden-control-button"
-          disabled
-        >
-          <post-icon name={attributes.icon} aria-hidden="true"></post-icon>
-        </button>
-      );
-    }
 
     return (
       <li class="pagination-item pagination-control" key={attributes.key}>
@@ -815,7 +782,7 @@ export class PostPagination {
           aria-label={attributes.label}
           onClick={attributes.onClick}
           onKeyDown={e => this.handleKeyDown(e, attributes.onClick)}
-          tabIndex={0}
+          tabIndex={disabled ? -1 : 0}
           disabled={disabled}
         >
           <post-icon name={attributes.icon} aria-hidden="true"></post-icon>
@@ -830,13 +797,30 @@ export class PostPagination {
    */
   private renderItem(item: PaginationItem, index: number) {
     switch (item.type) {
-      case PaginationItemType.Page:
+      case 'page':
         return this.renderPageButton(item.page);
-      case PaginationItemType.Control:
-        return this.renderControlButton(item.action, item.disabled, false);
-      case PaginationItemType.Ellipsis:
+      case 'control':
+        return this.renderControlButton(item.action, item.disabled);
+      case 'ellipsis':
         return this.renderEllipsis(index);
     }
+  }
+
+  /**
+   * Renders a minimal control button for measurement.
+   */
+  private renderHiddenControlButton(action: ControlAction) {
+    const attributes = this.buildControlAttributes(action);
+
+    return (
+      <button
+        key={`hidden-${attributes.key}`}
+        class="pagination-link pagination-control-button hidden-control-button"
+        disabled
+      >
+        <post-icon name={attributes.icon} aria-hidden="true"></post-icon>
+      </button>
+    );
   }
 
   /**
@@ -847,8 +831,7 @@ export class PostPagination {
     const last = this.items.at(-1);
 
     return [
-      first?.type === PaginationItemType.Control &&
-        this.renderControlButton(first.action, true, true),
+      first?.type === 'control' && this.renderHiddenControlButton(first.action),
 
       <button
         key="hidden-page"
@@ -866,8 +849,7 @@ export class PostPagination {
         {ELLIPSIS}
       </span>,
 
-      last?.type === PaginationItemType.Control &&
-        this.renderControlButton(last.action, true, true),
+      last?.type === 'control' && this.renderHiddenControlButton(last.action),
     ];
   }
 


### PR DESCRIPTION
## 📄 Description

Updated the `post-pagination` component to always show, but dynamically disable the navigation control buttons.

## 🚀 Demo

https://github.com/user-attachments/assets/bcb1993f-32e4-4967-b99d-6c1f2bad7655

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
