### PR TITLE
fix(components, styles): inset the focus outline for stacked elements

### DIFF
--- a/.changeset/clever-things-take.md
+++ b/.changeset/clever-things-take.md
@@ -1,0 +1,6 @@
+---
+'@swisspost/design-system-components': patch
+'@swisspost/design-system-styles': patch
+---
+
+Updated the `.list-interactive` class and the `post-accordion-item` component to display the focus outline inside, so that it no longer clashes with neighbouring outlines and borders.

--- a/packages/components/src/components/post-accordion-item/post-accordion-item.scss
+++ b/packages/components/src/components/post-accordion-item/post-accordion-item.scss
@@ -49,16 +49,6 @@ tokens.$default-map: components.$post-accordion;
   border-block-end: tokens.get('accordion-border-bottom-width')
     tokens.get('accordion-border-bottom-style') transparent;
   cursor: pointer;
-  @include utility-mx.focus-style-none;
-
-  @include utility-mx.focus-style('::before') {
-    display: block;
-    content: '';
-    position: absolute;
-    inset: calc(tokens.get('accordion-group-border-top-width') * -1) 0
-      calc(tokens.get('accordion-border-bottom-width') * -1);
-    border-radius: tokens.get('focus-border-radius', helpers.$post-focus);
-  }
 
   slot::slotted(span[slot='header']) {
     flex-grow: 1;
@@ -88,6 +78,8 @@ tokens.$default-map: components.$post-accordion;
   > ::slotted(.text-truncate) {
     display: block;
   }
+
+  @include utility-mx.focus-inline(3px, 3px);
 
   @include utility-mx.high-contrast-mode() {
     &:hover,

--- a/packages/styles/src/components/checkbox.scss
+++ b/packages/styles/src/components/checkbox.scss
@@ -29,6 +29,7 @@ tokens.$default-map: components.$post-checkbox;
   padding-block: tokens.get('checkbox-padding-block-single');
 
   @include forms-mx.form-check-base();
+  @include forms-mx.form-check-focus();
 
   // Grouped
   fieldset > &:not(.form-check-inline):not(:last-of-type) {

--- a/packages/styles/src/components/list-interactive.scss
+++ b/packages/styles/src/components/list-interactive.scss
@@ -28,7 +28,6 @@ tokens.$default-map: components.$post-list;
   padding-block-end: tokens.get('list-item-padding-block-end');
   padding-inline-start: tokens.get('list-item-padding-inline-start');
   padding-inline-end: tokens.get('list-item-padding-inline-end');
-  border-radius: tokens.get('focus-border-radius', helpers.$post-focus); // Used for the focus only
   color: tokens.get('list-item-enabled-fg');
 
   &::after {
@@ -48,7 +47,7 @@ tokens.$default-map: components.$post-list;
     }
   }
 
-  @include utilities-mx.focus-style;
+  @include utilities-mx.focus-inline(3px, calc(3px + tokens.get('list-item-border-width')));
 }
 
 .list-interactive-link,
@@ -90,6 +89,10 @@ tokens.$default-map: components.$post-list;
   .form-check-input {
     flex-shrink: 0;
     margin-block: tokens.get('list-switch-padding-block');
+  }
+
+  > input {
+    @include utilities-mx.focus-style-none;
   }
 }
 

--- a/packages/styles/src/components/radio-button.scss
+++ b/packages/styles/src/components/radio-button.scss
@@ -28,6 +28,7 @@ tokens.$default-map: components.$post-radio-button;
   padding-block: tokens.get('radio-button-padding-block-single');
 
   @include forms-mx.form-check-base();
+  @include forms-mx.form-check-focus();
 
   // Grouped
   fieldset > &:not(.form-check-inline):not(:last-of-type) {

--- a/packages/styles/src/components/switch.scss
+++ b/packages/styles/src/components/switch.scss
@@ -16,6 +16,7 @@ $switch-handle-icon: url("data:image/svg+xml,<svg viewBox='0 0 16 16' xmlns='htt
 
 .form-switch {
   @include forms-mx.form-check-base();
+  @include forms-mx.form-check-focus(':not(.list-interactive-switch)');
 
   .form-check-input {
     appearance: none;

--- a/packages/styles/src/mixins/_forms.scss
+++ b/packages/styles/src/mixins/_forms.scss
@@ -330,14 +330,6 @@
     vertical-align: top;
   }
 
-  &:has(> input:not(:only-child)) {
-    @include utility-mx.focus-style();
-
-    > input {
-      @include utility-mx.focus-style-none();
-    }
-  }
-
   > label {
     transition: color #{animation.$transition-base-timing};
     flex: 1;
@@ -365,6 +357,16 @@
       @include utility-mx.high-contrast-mode() {
         color: GrayText;
       }
+    }
+  }
+}
+
+@mixin form-check-focus($additional-selector: '') {
+  &:has(> input:not(:only-child))#{$additional-selector} {
+    @include utility-mx.focus-style();
+
+    > input {
+      @include utility-mx.focus-style-none();
     }
   }
 }

--- a/packages/styles/src/mixins/_utilities.scss
+++ b/packages/styles/src/mixins/_utilities.scss
@@ -115,6 +115,29 @@
   }
 }
 
+// Draws the focus outline on a pseudo-element instead of on the element itself.
+//
+// Use it on full-width stacked elements where the default outline would clash with neighbouring outlines and borders.
+@mixin focus-inline($top: 0, $bottom: 0, $selector: '::before') {
+  $focus-outline-inverse: calc(
+    tokens.get('focus-outline-width', helpers.$post-focus) +
+      tokens.get('focus-outline-offset', helpers.$post-focus)
+  );
+
+  @include focus-style {
+    @include focus-style-none;
+  }
+
+  @include focus-style($selector) {
+    display: block;
+    content: '';
+    position: absolute;
+    // Inset the pseudo-element instead of adjusting the outline offset to ensure that the outline retains its default appearance.
+    inset: calc(#{$focus-outline-inverse} + #{$top}) 0 calc(#{$focus-outline-inverse} + #{$bottom});
+    border-radius: tokens.get('focus-border-radius', helpers.$post-focus);
+  }
+}
+
 @mixin focus-style-custom($additional-selector: '') {
   // :has(:focus-visible) mimic a focus-visible-within pseudo-class
   &:is(:focus-visible, :has(:focus-visible), .pretend-focus)#{$additional-selector} {


### PR DESCRIPTION
## 📄 Description

The `.list-interactive` class has been updated to display the focus outline inside, so that it no longer clashes with neighbouring outlines and borders.

The same fix has also been applied to the 'post-accordion-item' component to address the same issue and provide a more consistent experience.

## 🚀 Demo

https://github.com/user-attachments/assets/00500d42-fd31-4e54-8008-d043fc7bd906

https://github.com/user-attachments/assets/3c0ca13a-3afd-45c9-a645-3622cbff8a32

https://github.com/user-attachments/assets/298673f8-f0c4-459a-a240-e3228ab28b42

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
