### PR TITLE
chore(docs): add online services header example

### DIFF
--- a/.changeset/big-melons-nail.md
+++ b/.changeset/big-melons-nail.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Documented an example of self-managed header for online services.

--- a/apps/documentation/src/stories/components/header/self-managed/header.docs.mdx
+++ b/apps/documentation/src/stories/components/header/self-managed/header.docs.mdx
@@ -26,7 +26,8 @@ import SampleSessionSubscription from './session-subscription.sample?raw';
 <post-tabs size="large">
   <post-tab-item name="overview">Overview</post-tab-item>
   <post-tab-item name="portal">Post Portal</post-tab-item>
-  <post-tab-item name="microsite">Microsite/Online Services</post-tab-item>
+  <post-tab-item name="microsite">Microsite</post-tab-item>
+  <post-tab-item name="online-service">Online Service</post-tab-item>
   <post-tab-item name="one-pager">One Pager</post-tab-item>
   <post-tab-item name="application">Application</post-tab-item>
 <post-tab-panel for="overview" class="pt-24">
@@ -94,9 +95,17 @@ When a user is authenticated, the user menu is slotted into `post-login`. The se
 
 <post-tab-panel for="microsite" class="pt-24">
 
-The Microsite and Online Services Header is a consistently available interface element that provides a consistent navigation experience across the whole Microsite and Online Services.
+The Microsite Header is a consistently available interface element that provides a consistent navigation experience across the whole Microsite.
 
 <Canvas of={HeaderStories.Microsite} inline="false" />
+
+</post-tab-panel>
+
+<post-tab-panel for="online-service" class="pt-24">
+
+The Online Service Header is a consistently available interface element that provides a consistent navigation experience across the whole Online Service.
+
+<Canvas of={HeaderStories.OnlineService} inline="false" />
 
 </post-tab-panel>
 

--- a/apps/documentation/src/stories/components/header/self-managed/header.stories.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/header.stories.ts
@@ -102,7 +102,6 @@ const meta: MetaComponent = {
       control: {
         type: 'boolean',
       },
-      if: { arg: 'title', eq: '' },
       table: {
         category: 'Content',
       },
@@ -247,6 +246,40 @@ export const Jobs: Story = {
   },
 };
 
+export const OnlineService: Story = {
+  ...getIframeParameters(550),
+  args: {
+    title: '[Online Service]',
+    globalNavPrimary: false,
+    globalNavSecondary: false,
+    localNav: true,
+    targetGroup: false,
+    isLoggedIn: true,
+  },
+  render: (args: Args) => {
+    const renderHeader = getHeaderRenderer({
+      renderLocalNav: () => html`
+        <!-- Local navigation -->
+        <ul slot="local-nav">
+          <li>
+            <a href="#">
+              <span>Local action</span>
+              <post-icon aria-hidden="true" name="component"></post-icon>
+            </a>
+          </li>
+          <li>
+            <a class="btn-primary" href="#">
+              <span>Close</span>
+              <post-icon aria-hidden="true" name="closex"></post-icon>
+            </a>
+          </li>
+        </ul>
+      `,
+    });
+    return renderHeader(args);
+  },
+};
+
 export const Microsite: Story = {
   ...getIframeParameters(550),
   args: {
@@ -268,8 +301,8 @@ export const OnePager: Story = {
     globalNavSecondary: false,
     globalNavPrimary: false,
     localNav: false,
-    postLogin: false,
     targetGroup: false,
+    postLogin: false,
   },
 };
 

--- a/apps/documentation/src/stories/components/header/self-managed/renderers/index.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/renderers/index.ts
@@ -6,7 +6,7 @@ export * from './language-menu';
 export * from './login-link';
 export * from './logo';
 export * from './main-navigation';
-export * from './microsite-controls';
+export * from './local-nav';
 export * from './side-navigation';
 export * from './title';
 export * from './user-menu';

--- a/apps/documentation/src/stories/components/header/self-managed/renderers/local-nav.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/renderers/local-nav.ts
@@ -1,10 +1,10 @@
 import { Args } from '@storybook/web-components-vite';
 import { html, nothing } from 'lit';
-import { renderUserMenu } from './user-menu';
 import { getSubComponentRenderers } from '../utils/get-sub-component-renderers';
 import { isApplicationHeader } from '../utils/is-application-header';
+import { renderUserMenu } from './user-menu';
 
-export function renderMicrositeControls(args: Args) {
+export function renderLocalNav(args: Args) {
   const { renderLanguageMenu } = getSubComponentRenderers({});
 
   const loginButton = html`

--- a/apps/documentation/src/stories/components/header/self-managed/utils/get-slotted-content.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/utils/get-slotted-content.ts
@@ -1,8 +1,6 @@
-import { renderJobControls } from '../renderers';
 import { Args } from '@storybook/web-components-vite';
 import { nothing } from 'lit';
 import { getSubComponentRenderers, SubComponentRenderers } from './get-sub-component-renderers';
-import { hasGlobalLogin } from './has-global-login';
 import { isApplicationHeader } from './is-application-header';
 
 export function getSlottedContent(args: Args, customRenderers: SubComponentRenderers = {}) {
@@ -16,7 +14,8 @@ export function getSlottedContent(args: Args, customRenderers: SubComponentRende
     renderLoginLink,
     renderTitle,
     renderSideNavTrigger,
-    renderMicrositeControls,
+    renderLocalNav,
+    renderJobControls,
     renderMainnavigation,
   } = getSubComponentRenderers(customRenderers);
 
@@ -32,17 +31,16 @@ export function getSlottedContent(args: Args, customRenderers: SubComponentRende
     args.languageMenu && !isApplicationHeader(args) ? renderLanguageMenu() : nothing;
 
   const login = args.isLoggedIn ? renderUserMenu() : renderLoginLink();
-  const globalLogin = hasGlobalLogin(args) ? login : nothing;
+  const globalLogin = args.postLogin && !args.jobs ? login : nothing;
 
   const title = args.title !== '' ? renderTitle(args) : nothing;
 
   const sideNavTrigger = args.sideNav && args.title !== '' ? renderSideNavTrigger() : nothing;
 
-  const micrositeControls = args.localNav && !args.jobs ? renderMicrositeControls(args) : nothing;
+  const localNav = args.localNav ? renderLocalNav(args) : nothing;
+  const localControls = args.jobs ? renderJobControls() : localNav;
 
   const mainNavSlot = args.mainNav ? renderMainnavigation() : nothing;
-
-  const jobControls = args.jobs ? renderJobControls() : nothing;
 
   return [
     logo,
@@ -53,8 +51,7 @@ export function getSlottedContent(args: Args, customRenderers: SubComponentRende
     globalLogin,
     title,
     sideNavTrigger,
-    micrositeControls,
+    localControls,
     mainNavSlot,
-    jobControls,
   ];
 }

--- a/apps/documentation/src/stories/components/header/self-managed/utils/has-global-login.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/utils/has-global-login.ts
@@ -1,5 +1,0 @@
-import { Args } from '@storybook/web-components-vite';
-
-export function hasGlobalLogin(args: Args): boolean {
-  return !args.title && !args.jobs && args.postLogin;
-}

--- a/apps/documentation/src/stories/components/header/self-managed/utils/index.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/utils/index.ts
@@ -1,4 +1,3 @@
 export * from './get-slotted-content';
 export * from './get-sub-component-renderers';
-export * from './has-global-login';
 export * from './is-application-header';

--- a/packages/components/src/components/post-header/custom-properties.scss
+++ b/packages/components/src/components/post-header/custom-properties.scss
@@ -28,7 +28,7 @@
   }
 
   @include media.only(tablet) {
-    --post-header-gap: 0.75rem 0.25rem;
+    --post-header-gap: 0.75rem 0.5rem;
     --post-global-header-padding-inline-start: 0.25rem;
     --post-global-header-padding-inline-end: 0.25rem;
     --post-local-header-padding-inline-start: 0.75rem;
@@ -45,7 +45,7 @@
   }
 
   @include media.only(mobile) {
-    --post-header-gap: 0.75rem 0.25rem;
+    --post-header-gap: 0.75rem 0.5rem;
     --post-global-header-padding-inline-start: 0rem;
     --post-global-header-padding-inline-end: 0.5rem;
     --post-local-header-padding-inline-start: 0.5rem;

--- a/packages/styles/src/components/header/_post-header.scss
+++ b/packages/styles/src/components/header/_post-header.scss
@@ -66,12 +66,6 @@ post-header {
     &:where(ul) {
       align-items: center;
     }
-
-    @include media.only(mobile) {
-      @include interactive-elements {
-        padding: 0.25rem 0.75rem;
-      }
-    }
   }
 
   // audience


### PR DESCRIPTION
## 📄 Description

This PR adds an self-managed header example with a close button for the online services.

## 🚀 Demo

https://preview-8335--swisspost-design-system.netlify.app/iframe.html?globals=&viewMode=story&id=27a2e64d-55ba-492d-ab79-5f7c5e818498--online-service

---

## 🔮 Design review

- [x] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
