### PR TITLE
chore(components, styles): use px instead of rem for header styles

### DIFF
--- a/apps/documentation/src/stories/components/tabs/tabs.stories.ts
+++ b/apps/documentation/src/stories/components/tabs/tabs.stories.ts
@@ -343,7 +343,7 @@ function paragraphs(length: number = 6) {
   return Array.from({ length }).map(() => html`<p aria-hidden="true" class="fake-content"></p>`);
 }
 
-function sideNav(story: PartialStoryFn) {
+function header(story: PartialStoryFn) {
   return html`
     <post-header text-menu="Menu">
       <post-logo slot="post-logo" url="/">Homepage</post-logo>
@@ -359,11 +359,33 @@ function sideNav(story: PartialStoryFn) {
         <post-icon name="login"></post-icon>
       </a>
     </post-header>
+    ${story()}
+  `;
+}
+
+function sideNav(story: PartialStoryFn) {
+  return html`
     <post-side-navigation size="large" id="sidenavigation" text-close="Close">
       <nav aria-label="Main navigation">${unsafeHTML(defaultNav)}</nav>
     </post-side-navigation>
 
     <main class="main-container">${story()}</main>
+  `;
+}
+
+function container(story: PartialStoryFn) {
+  return html` <div class="container my-16">${story()}</div> `;
+}
+
+function containerFluid(story: PartialStoryFn) {
+  return html` <div class="container-fluid my-16">${story()}</div> `;
+}
+
+function section(story: PartialStoryFn) {
+  return html`
+    <section class="section palette palette-accent">
+      <div class="container py-64">${story()}</div>
+    </section>
   `;
 }
 
@@ -377,35 +399,30 @@ export const TestBase: StoryObj = {
 
 export const Container: Story = {
   ...TestBase,
-  decorators: [story => html`<div class="container my-16">${story()}</div>`],
+  decorators: [container, header],
 };
 
 export const ContainerFluid: Story = {
   ...TestBase,
-  decorators: [story => html`<div class="container-fluid my-16">${story()}</div>`],
+  decorators: [containerFluid, header],
 };
 
 export const Section: Story = {
   ...TestBase,
-  decorators: [
-    story =>
-      html`<section class="section palette palette-accent">
-        <div class="container py-64">${story()}</div>
-      </section>`,
-  ],
+  decorators: [section, header],
 };
 
 export const ContainerAndSidenav: Story = {
   ...TestBase,
-  decorators: [...(Container.decorators as []), sideNav],
+  decorators: [container, sideNav, header],
 };
 
 export const ContainerFluidAndSidenav: Story = {
   ...TestBase,
-  decorators: [...(ContainerFluid.decorators as []), sideNav],
+  decorators: [containerFluid, sideNav, header],
 };
 
 export const SectionAndSidenav: Story = {
   ...TestBase,
-  decorators: [...(Section.decorators as []), sideNav],
+  decorators: [section, sideNav, header],
 };

--- a/apps/documentation/src/stories/components/tabs/tabs.stories.ts
+++ b/apps/documentation/src/stories/components/tabs/tabs.stories.ts
@@ -1,10 +1,8 @@
-import { defaultNav } from '@root/src/stories/components/side-navigation/nav-content';
-import { MetaComponent } from '@root/types';
 import { StoryObj } from '@storybook/web-components-vite';
-import { html, nothing } from 'lit';
+import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { PartialStoryFn } from 'storybook/internal/types';
+import { MetaComponent } from '@root/types';
 
 const meta: MetaComponent<
   HTMLPostTabsElement & {
@@ -336,93 +334,4 @@ export const ActivePagesItem: Story = {
       </post-tab-item>
     `,
   },
-};
-
-// Temporary
-function paragraphs(length: number = 6) {
-  return Array.from({ length }).map(() => html`<p aria-hidden="true" class="fake-content"></p>`);
-}
-
-function header(story: PartialStoryFn) {
-  return html`
-    <post-header text-menu="Menu">
-      <post-logo slot="post-logo" url="/">Homepage</post-logo>
-      <post-side-navigation-trigger slot="side-nav" for="sidenavigation">
-        <button>
-          <span>Menu</span>
-          <post-icon aria-hidden="true" name="burger"></post-icon>
-        </button>
-      </post-side-navigation-trigger>
-      <p slot="title">[Application Title]</p>
-      <a href="" slot="local-nav">
-        <span>Login</span>
-        <post-icon name="login"></post-icon>
-      </a>
-    </post-header>
-    ${story()}
-  `;
-}
-
-function sideNav(story: PartialStoryFn) {
-  return html`
-    <post-side-navigation size="large" id="sidenavigation" text-close="Close">
-      <nav aria-label="Main navigation">${unsafeHTML(defaultNav)}</nav>
-    </post-side-navigation>
-
-    <main class="main-container">${story()}</main>
-  `;
-}
-
-function container(story: PartialStoryFn) {
-  return html` <div class="container my-16">${story()}</div> `;
-}
-
-function containerFluid(story: PartialStoryFn) {
-  return html` <div class="container-fluid my-16">${story()}</div> `;
-}
-
-function section(story: PartialStoryFn) {
-  return html`
-    <section class="section palette palette-accent">
-      <div class="container py-64">${story()}</div>
-    </section>
-  `;
-}
-
-export const TestBase: StoryObj = {
-  args: {
-    variant: 'Page Tabs',
-    showTabs: true,
-  },
-  render: args => html`${args.showTabs ? renderTabs(args) : nothing}${paragraphs()}`,
-};
-
-export const Container: Story = {
-  ...TestBase,
-  decorators: [container, header],
-};
-
-export const ContainerFluid: Story = {
-  ...TestBase,
-  decorators: [containerFluid, header],
-};
-
-export const Section: Story = {
-  ...TestBase,
-  decorators: [section, header],
-};
-
-export const ContainerAndSidenav: Story = {
-  ...TestBase,
-  decorators: [container, sideNav, header],
-};
-
-export const ContainerFluidAndSidenav: Story = {
-  ...TestBase,
-  decorators: [containerFluid, sideNav, header],
-};
-
-export const SectionAndSidenav: Story = {
-  ...TestBase,
-  decorators: [section, sideNav, header],
 };

--- a/apps/documentation/src/stories/components/tabs/tabs.stories.ts
+++ b/apps/documentation/src/stories/components/tabs/tabs.stories.ts
@@ -354,6 +354,10 @@ function sideNav(story: PartialStoryFn) {
         </button>
       </post-side-navigation-trigger>
       <p slot="title">[Application Title]</p>
+      <a href="" slot="local-nav">
+        <span>Login</span>
+        <post-icon name="login"></post-icon>
+      </a>
     </post-header>
     <post-side-navigation size="large" id="sidenavigation" text-close="Close">
       <nav aria-label="Main navigation">${unsafeHTML(defaultNav)}</nav>

--- a/apps/documentation/src/stories/components/tabs/tabs.stories.ts
+++ b/apps/documentation/src/stories/components/tabs/tabs.stories.ts
@@ -1,8 +1,10 @@
+import { defaultNav } from '@root/src/stories/components/side-navigation/nav-content';
+import { MetaComponent } from '@root/types';
 import { StoryObj } from '@storybook/web-components-vite';
-import { html } from 'lit';
+import { html, nothing } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
-import { MetaComponent } from '@root/types';
+import { PartialStoryFn } from 'storybook/internal/types';
 
 const meta: MetaComponent<
   HTMLPostTabsElement & {
@@ -334,4 +336,72 @@ export const ActivePagesItem: Story = {
       </post-tab-item>
     `,
   },
+};
+
+// Temporary
+function paragraphs(length: number = 6) {
+  return Array.from({ length }).map(() => html`<p aria-hidden="true" class="fake-content"></p>`);
+}
+
+function sideNav(story: PartialStoryFn) {
+  return html`
+    <post-header text-menu="Menu">
+      <post-logo slot="post-logo" url="/">Homepage</post-logo>
+      <post-side-navigation-trigger slot="side-nav" for="sidenavigation">
+        <button>
+          <span>Menu</span>
+          <post-icon aria-hidden="true" name="burger"></post-icon>
+        </button>
+      </post-side-navigation-trigger>
+      <p slot="title">[Application Title]</p>
+    </post-header>
+    <post-side-navigation size="large" id="sidenavigation" text-close="Close">
+      <nav aria-label="Main navigation">${unsafeHTML(defaultNav)}</nav>
+    </post-side-navigation>
+
+    <main class="main-container">${story()}</main>
+  `;
+}
+
+export const TestBase: StoryObj = {
+  args: {
+    variant: 'Page Tabs',
+    showTabs: true,
+  },
+  render: args => html`${args.showTabs ? renderTabs(args) : nothing}${paragraphs()}`,
+};
+
+export const Container: Story = {
+  ...TestBase,
+  decorators: [story => html`<div class="container my-16">${story()}</div>`],
+};
+
+export const ContainerFluid: Story = {
+  ...TestBase,
+  decorators: [story => html`<div class="container-fluid my-16">${story()}</div>`],
+};
+
+export const Section: Story = {
+  ...TestBase,
+  decorators: [
+    story =>
+      html`<section class="section palette palette-accent">
+        <div class="container py-64">${story()}</div>
+      </section>`,
+  ],
+};
+
+export const ContainerAndSidenav: Story = {
+  ...TestBase,
+  decorators: [...(Container.decorators as []), sideNav],
+};
+
+export const ContainerFluidAndSidenav: Story = {
+  ...TestBase,
+  decorators: [...(ContainerFluid.decorators as []), sideNav],
+};
+
+export const SectionAndSidenav: Story = {
+  ...TestBase,
+  decorators: [...(Section.decorators as []), sideNav],
 };

--- a/packages/components/src/components/post-footer/post-footer.scss
+++ b/packages/components/src/components/post-footer/post-footer.scss
@@ -184,7 +184,7 @@ footer {
 .footer-copyright {
   display: flex;
   flex-wrap: wrap;
-  column-gap: 0.5rem;
+  column-gap: 8px;
   font-size: var(--post-footer-copyright-font-size);
 }
 

--- a/packages/components/src/components/post-header/custom-properties.scss
+++ b/packages/components/src/components/post-header/custom-properties.scss
@@ -20,40 +20,40 @@
   );
 
   @include media.only(desktop) {
-    --post-header-gap: 0.5rem;
-    --post-global-header-padding-inline-start: 0.25rem;
-    --post-global-header-padding-inline-end: 0.5rem;
-    --post-local-header-padding-inline-start: 0.75rem;
-    --post-local-header-padding-inline-end: 0.5rem;
+    --post-header-gap: 8px;
+    --post-global-header-padding-inline-start: 4px;
+    --post-global-header-padding-inline-end: 8px;
+    --post-local-header-padding-inline-start: 12px;
+    --post-local-header-padding-inline-end: 8px;
   }
 
   @include media.only(tablet) {
-    --post-header-gap: 0.75rem 0.5rem;
-    --post-global-header-padding-inline-start: 0.25rem;
-    --post-global-header-padding-inline-end: 0.25rem;
-    --post-local-header-padding-inline-start: 0.75rem;
-    --post-local-header-padding-inline-end: 0.25rem;
-    --post-local-header-padding-block: 0.75rem;
-    --post-burger-menu-padding-inline: 2.5rem;
-    --post-burger-menu-body-gap: 2rem;
-    --post-burger-menu-footer-gap: 1.5rem;
+    --post-header-gap: 12px 8px;
+    --post-global-header-padding-inline-start: 4px;
+    --post-global-header-padding-inline-end: 4px;
+    --post-local-header-padding-inline-start: 12px;
+    --post-local-header-padding-inline-end: 4px;
+    --post-local-header-padding-block: 12px;
+    --post-burger-menu-padding-inline: 40px;
+    --post-burger-menu-body-gap: 32px;
+    --post-burger-menu-footer-gap: 24px;
   }
 
   // this is being discussed in Figma
   @include media.only(sm) {
-    --post-burger-menu-padding-inline: 1rem;
+    --post-burger-menu-padding-inline: 16px;
   }
 
   @include media.only(mobile) {
-    --post-header-gap: 0.75rem 0.5rem;
-    --post-global-header-padding-inline-start: 0rem;
-    --post-global-header-padding-inline-end: 0.5rem;
-    --post-local-header-padding-inline-start: 0.5rem;
-    --post-local-header-padding-inline-end: 0.5rem;
-    --post-local-header-padding-block: 0.5rem;
-    --post-burger-menu-padding-inline: 1rem;
-    --post-burger-menu-body-gap: 1.5rem;
-    --post-burger-menu-footer-gap: 1rem;
+    --post-header-gap: 12px 8px;
+    --post-global-header-padding-inline-start: 0px;
+    --post-global-header-padding-inline-end: 8px;
+    --post-local-header-padding-inline-start: 8px;
+    --post-local-header-padding-inline-end: 8px;
+    --post-local-header-padding-block: 8px;
+    --post-burger-menu-padding-inline: 16px;
+    --post-burger-menu-body-gap: 24px;
+    --post-burger-menu-footer-gap: 16px;
   }
 }
 

--- a/packages/components/src/components/post-header/post-header.scss
+++ b/packages/components/src/components/post-header/post-header.scss
@@ -64,7 +64,7 @@ header,
     height: var(--post-logo-height);
     min-height: var(--post-global-header-reduced-height);
     max-height: 100%;
-    margin-inline-end: calc(1.25rem - var(--post-header-gap));
+    margin-inline-end: calc(20px - var(--post-header-gap));
 
     // Offset the logo to ensure visual alignment with the local header content
     margin-inline-start: clamp(
@@ -161,7 +161,7 @@ header,
 
   @include media-mx.only(mobile) {
     @include header-mx.nav-item-icon-only;
-    padding: 0.625rem;
+    padding: 10px;
   }
 
   @include media-mx.only(desktop) {
@@ -204,21 +204,21 @@ header,
 
   .burger-menu-body {
     flex-grow: 1;
-    padding-block: 1.5rem;
+    padding-block: 24px;
     gap: var(--post-burger-menu-body-gap);
   }
 
   .burger-menu-footer {
     background-color: #f0efed;
-    padding-block: 1rem 1.5rem;
+    padding-block: 16px 24px;
     gap: var(--post-burger-menu-footer-gap);
   }
 
   .local-nav {
-    min-height: 3.5rem;
+    min-height: 56px;
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    padding-inline: 0.25rem;
+    padding-inline: 4px;
   }
 }

--- a/packages/components/src/components/post-language-menu/post-language-menu.scss
+++ b/packages/components/src/components/post-language-menu/post-language-menu.scss
@@ -31,6 +31,6 @@ tokens.$default-map: components.$post-button;
 
 .post-language-menu-list {
   display: flex;
-  gap: 0.5rem;
-  margin-top: 1rem;
+  gap: 8px;
+  margin-top: 16px;
 }

--- a/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
+++ b/packages/components/src/components/post-mainnavigation/post-mainnavigation.scss
@@ -27,8 +27,8 @@ nav {
 }
 
 .scroll-control {
-  $icon-size: 1rem;
-  $button-padding: 1rem;
+  $icon-size: 16px;
+  $button-padding: 16px;
   $button-width: $icon-size + 2 * $button-padding;
 
   z-index: 1;

--- a/packages/components/src/components/post-megadropdown/post-megadropdown.scss
+++ b/packages/components/src/components/post-megadropdown/post-megadropdown.scss
@@ -16,7 +16,7 @@
   box-shadow: elevation.$elevation-300;
 
   @include media.only(desktop) {
-    max-height: calc(100vh - var(--post-header-height) - 3rem);
+    max-height: calc(100vh - var(--post-header-height) - 48px);
     background-color: #f0efed;
     z-index: -1;
     inset-block-start: 100%;
@@ -49,7 +49,7 @@
   position: relative;
 
   @include media.only(desktop) {
-    padding: 3rem 2.5rem 2.5rem;
+    padding: 48px 40px 40px;
   }
 
   @include media.max(desktop) {
@@ -59,26 +59,26 @@
       min(var(--post-header-scroll-parent-height, 100dvh), 100dvh) - var(--post-header-height)
     );
     padding-inline: var(--post-burger-menu-padding-inline);
-    padding-block-start: 1.5rem;
+    padding-block-start: 24px;
   }
 
   .megadropdown-content {
     @include media.max(desktop) {
-      padding-block-end: 1.5rem;
+      padding-block-end: 24px;
     }
   }
 }
 
 .megadropdown-title {
-  margin-block: 0 1rem;
+  margin-block: 0 16px;
   font-weight: 950;
 
   @include media.only(tablet) {
-    font-size: 1.25rem;
+    font-size: 20px;
   }
 
   @include media.only(mobile) {
-    font-size: 1.125rem;
+    font-size: 18px;
   }
 }
 
@@ -95,18 +95,18 @@
   }
 
   @include media.only(tablet) {
-    margin-block-end: 2rem;
+    margin-block-end: 32px;
   }
 
   @include media.only(mobile) {
-    margin-block-end: 1.5rem;
+    margin-block-end: 24px;
   }
 }
 
 .close-button {
   position: absolute;
-  inset-block-start: 0.5rem;
-  inset-inline-end: 0.5rem;
+  inset-block-start: 8px;
+  inset-inline-end: 8px;
 
   @include media.max(lg) {
     display: none;

--- a/packages/components/src/components/post-megadropdown/post-megadropdown.scss
+++ b/packages/components/src/components/post-megadropdown/post-megadropdown.scss
@@ -74,11 +74,11 @@
   font-weight: 950;
 
   @include media.only(tablet) {
-    font-size: 20px;
+    font-size: 1.25rem;
   }
 
   @include media.only(mobile) {
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 }
 

--- a/packages/components/src/components/post-menu-item/post-menu-item.scss
+++ b/packages/components/src/components/post-menu-item/post-menu-item.scss
@@ -18,33 +18,33 @@ post-menu-item {
     position: relative;
     display: flex;
     align-items: center;
-    padding: 0.5rem 0.75rem 0.5rem 1rem;
-    gap: 0.75rem;
-    font-size: 0.875rem;
+    padding: 8px 12px 8px 16px;
+    gap: 12px;
+    font-size: 14px;
     color: #050400;
     border-radius: 0;
 
     post-icon {
-      width: 1rem;
-      height: 1rem;
-      margin-block: 0.25rem;
+      width: 16px;
+      height: 16px;
+      margin-block: 4px;
     }
 
     @include media.min(md) {
-      font-size: 1rem;
-      padding-block: 0.75rem;
-      gap: 1rem;
+      font-size: 16px;
+      padding-block: 12px;
+      gap: 16px;
 
       post-icon {
-        width: 1.5rem;
-        height: 1.5rem;
+        width: 24px;
+        height: 24px;
         margin: 0;
       }
     }
 
     @include media.min(lg) {
-      font-size: 1.25rem;
-      padding-block: 0.8125rem;
+      font-size: 20px;
+      padding-block: 13px;
     }
 
     &:focus-visible {

--- a/packages/components/src/components/post-menu-item/post-menu-item.scss
+++ b/packages/components/src/components/post-menu-item/post-menu-item.scss
@@ -20,7 +20,7 @@ post-menu-item {
     align-items: center;
     padding: 8px 12px 8px 16px;
     gap: 12px;
-    font-size: 14px;
+    font-size: 0.875rem;
     color: #050400;
     border-radius: 0;
 
@@ -31,7 +31,7 @@ post-menu-item {
     }
 
     @include media.min(md) {
-      font-size: 16px;
+      font-size: 1rem;
       padding-block: 12px;
       gap: 16px;
 
@@ -43,7 +43,7 @@ post-menu-item {
     }
 
     @include media.min(lg) {
-      font-size: 20px;
+      font-size: 1.25rem;
       padding-block: 13px;
     }
 

--- a/packages/components/src/components/post-menu/post-menu.scss
+++ b/packages/components/src/components/post-menu/post-menu.scss
@@ -8,24 +8,24 @@
 :where([part='post-menu']) {
   display: flex;
   flex-direction: column;
-  padding-block: 0.5rem;
+  padding-block: 8px;
 }
 
 ::slotted([slot='header']) {
-  margin-top: -0.5rem;
-  padding: 1rem;
+  margin-top: -8px;
+  padding: 16px;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 8px;
   border-block-end: 1px solid #050400;
   font-weight: 700;
 
   @include media.max(lg) {
-    padding: 0.75rem 1rem;
+    padding: 12px 16px;
   }
 
   @include media.max(md) {
-    padding: 0.5rem 1rem;
+    padding: 8px 16px;
   }
 }
 

--- a/packages/components/src/components/post-popover/post-popover.scss
+++ b/packages/components/src/components/post-popover/post-popover.scss
@@ -18,13 +18,13 @@
   background-color: var(--post-current-bg);
   display: flex;
   align-items: self-start;
-  padding: 0.5em;
+  padding: 8px;
 
   min-width: 160px;
   max-width: var(--post-popover-max-width, 280px);
 }
 
 .popover-content {
-  padding: 0.5em;
+  padding: 8px;
   flex-grow: 1;
 }

--- a/packages/styles/src/components/header/_custom-properties.scss
+++ b/packages/styles/src/components/header/_custom-properties.scss
@@ -8,16 +8,16 @@
 // ============================================================
 
 :root:has(post-header [slot='main-nav']):not(:has(post-header [slot='title'])) {
-  --post-global-header-expanded-height: 4rem;
-  --post-local-header-reduced-height: 0rem;
-  --post-local-header-expanded-min-height: var(--post-main-navigation-height, 0rem);
+  --post-global-header-expanded-height: 64px;
+  --post-local-header-reduced-height: 0px;
+  --post-local-header-expanded-min-height: var(--post-main-navigation-height, 0px);
 
   @include media.only(desktop) {
-    --post-global-header-expanded-height: 4.5rem;
-    --post-global-header-reduced-height: 1.5rem;
-    --post-local-header-reduced-height: 3.5rem;
+    --post-global-header-expanded-height: 72px;
+    --post-global-header-reduced-height: 24px;
+    --post-local-header-reduced-height: 56px;
     --post-main-navigation-height: var(--post-local-header-reduced-height);
-    --post-logo-reduced-offset: 0.375rem;
+    --post-logo-reduced-offset: 6px;
   }
 }
 
@@ -43,23 +43,23 @@ post-header:has([slot='main-nav']):not(:has([slot='title'])) {
 // ============================================================
 
 :root:has(post-header [slot='main-nav']):has(post-header [slot='title']) {
-  --post-global-header-expanded-height: 4rem;
+  --post-global-header-expanded-height: 64px;
   --post-local-header-reduced-height: var(--post-local-header-expanded-height);
 
   @include media.only(mobile) {
-    --post-local-header-expanded-min-height: 3rem;
+    --post-local-header-expanded-min-height: 48px;
   }
 
   @include media.only(tablet) {
-    --post-local-header-expanded-min-height: 3.5rem;
+    --post-local-header-expanded-min-height: 56px;
   }
 
   @include media.only(desktop) {
-    --post-global-header-expanded-height: 4.5rem;
-    --post-local-header-expanded-min-height: 7rem;
-    --post-global-header-reduced-height: 1.5rem;
-    --post-main-navigation-height: 3.5rem;
-    --post-logo-reduced-offset: 0.375rem;
+    --post-global-header-expanded-height: 72px;
+    --post-local-header-expanded-min-height: 112px;
+    --post-global-header-reduced-height: 24px;
+    --post-main-navigation-height: 56px;
+    --post-logo-reduced-offset: 6px;
   }
 }
 
@@ -83,12 +83,12 @@ post-header:has([slot='main-nav']):has([slot='title']) {
 // ============================================================
 
 :root:has(post-header):not(:has(post-header [slot='main-nav'])) {
-  --post-global-header-expanded-height: 4rem;
-  --post-local-header-expanded-min-height: 3.5rem;
+  --post-global-header-expanded-height: 64px;
+  --post-local-header-expanded-min-height: 56px;
 
   @include media.only(desktop) {
-    --post-global-header-expanded-height: 4.5rem;
-    --post-local-header-expanded-min-height: 4rem;
+    --post-global-header-expanded-height: 72px;
+    --post-local-header-expanded-min-height: 64px;
   }
 }
 
@@ -97,7 +97,7 @@ post-header:has([slot='main-nav']):has([slot='title']) {
 :root:has(post-header):not(:has(post-header [slot='main-nav'])):not(
     :has(post-header [slot='title'])
   ) {
-  --post-local-header-expanded-min-height: 0rem;
+  --post-local-header-expanded-min-height: 0px;
 }
 
 post-header:not(:has([slot='main-nav'])) {
@@ -140,19 +140,19 @@ post-header:not(:has([slot='main-nav'])) {
     :has(post-header > [slot='language-menu'])
   ):not(:has(post-header > [slot='post-login'])) {
   --post-global-header-expanded-height: var(--_post-initial-global-header-height);
-  --post-global-header-reduced-height: 2rem;
+  --post-global-header-reduced-height: 32px;
 
   @include media.only(desktop) {
-    --post-logo-expanded-offset: 0.625rem;
-    --post-logo-reduced-offset: 0.625rem;
+    --post-logo-expanded-offset: 10px;
+    --post-logo-reduced-offset: 10px;
   }
   @include media.only(tablet) {
-    --post-logo-expanded-offset: 0.75rem;
-    --post-logo-reduced-offset: 0.75rem;
+    --post-logo-expanded-offset: 12px;
+    --post-logo-reduced-offset: 12px;
   }
   @include media.only(mobile) {
-    --post-logo-expanded-offset: 0.5rem;
-    --post-logo-reduced-offset: 0.5rem;
+    --post-logo-expanded-offset: 8px;
+    --post-logo-reduced-offset: 8px;
   }
 }
 

--- a/packages/styles/src/components/header/_mixins.scss
+++ b/packages/styles/src/components/header/_mixins.scss
@@ -7,8 +7,8 @@
 
 $interactive-elements-selector: 'a, button, [role="link"], [role="button"]';
 
-$nav-block-padding-inline-start: 0.5rem;
-$nav-block-padding-inline-end: 0.75rem;
+$nav-block-padding-inline-start: 8px;
+$nav-block-padding-inline-end: 12px;
 
 /**
  selects all slotted nav items
@@ -43,9 +43,9 @@ $nav-block-padding-inline-end: 0.75rem;
   border: unset;
   font-weight: unset;
   display: flex;
-  padding: 0.25rem 0.625rem;
-  gap: 0.375rem;
-  font-size: 1rem;
+  padding: 4px 10px;
+  gap: 6px;
+  font-size: 16px;
 
   @include button.button-variant-def('enabled', 'tertiary');
 
@@ -72,9 +72,9 @@ $nav-block-padding-inline-end: 0.75rem;
   width: 100%;
   justify-content: start;
   position: relative;
-  padding: 0.75rem $nav-block-padding-inline-end calc(0.75rem - var(--post-nav-item-border-width))
+  padding: 12px $nav-block-padding-inline-end calc(12px - var(--post-nav-item-border-width))
     $nav-block-padding-inline-start;
-  gap: 1rem;
+  gap: 16px;
   border-radius: 0;
   line-height: 1.5;
   outline-color: currentColor !important;
@@ -119,19 +119,19 @@ $nav-block-padding-inline-end: 0.75rem;
   }
 
   @include media.only(mobile) {
-    padding: calc(0.5rem + 1.5px) $nav-block-padding-inline-end
-      calc(0.5rem + 1.5px - var(--post-nav-item-border-width)) $nav-block-padding-inline-start;
-    gap: 0.5rem;
-    font-size: 0.875rem;
+    padding: calc(8px + 1.5px) $nav-block-padding-inline-end
+      calc(8px + 1.5px - var(--post-nav-item-border-width)) $nav-block-padding-inline-start;
+    gap: 8px;
+    font-size: 14px;
 
     > post-icon {
-      font-size: 1rem;
+      font-size: 16px;
     }
   }
 
   @include media.only(tablet) {
     > post-icon {
-      font-size: 1.5rem;
+      font-size: 24px;
     }
   }
 }
@@ -145,7 +145,7 @@ $nav-block-padding-inline-end: 0.75rem;
   }
 
   > post-icon {
-    font-size: 1.5rem;
+    font-size: 24px;
   }
 }
 

--- a/packages/styles/src/components/header/_mixins.scss
+++ b/packages/styles/src/components/header/_mixins.scss
@@ -45,7 +45,7 @@ $nav-block-padding-inline-end: 12px;
   display: flex;
   padding: 4px 10px;
   gap: 6px;
-  font-size: 16px;
+  font-size: 1rem;
 
   @include button.button-variant-def('enabled', 'tertiary');
 
@@ -122,16 +122,16 @@ $nav-block-padding-inline-end: 12px;
     padding: calc(8px + 1.5px) $nav-block-padding-inline-end
       calc(8px + 1.5px - var(--post-nav-item-border-width)) $nav-block-padding-inline-start;
     gap: 8px;
-    font-size: 14px;
+    font-size: 0.875rem;
 
     > post-icon {
-      font-size: 16px;
+      font-size: 1rem;
     }
   }
 
   @include media.only(tablet) {
     > post-icon {
-      font-size: 24px;
+      font-size: 1.5rem;
     }
   }
 }
@@ -145,7 +145,7 @@ $nav-block-padding-inline-end: 12px;
   }
 
   > post-icon {
-    font-size: 24px;
+    font-size: 1.5rem;
   }
 }
 

--- a/packages/styles/src/components/header/_placeholders.scss
+++ b/packages/styles/src/components/header/_placeholders.scss
@@ -5,7 +5,7 @@
 
 %header-list {
   @include list.list-inline;
-  gap: 0 0.5rem;
+  gap: 0 8px;
   margin: 0;
 
   @include media.max(desktop) {
@@ -27,8 +27,8 @@
   height: 100%;
 
   @include media.only(desktop) {
-    padding: 1rem 0.75rem;
-    gap: 0.5rem;
+    padding: 16px 12px;
+    gap: 8px;
     border-bottom: 0;
   }
 }

--- a/packages/styles/src/components/header/_post-header.scss
+++ b/packages/styles/src/components/header/_post-header.scss
@@ -54,7 +54,7 @@ post-header {
   > :is([slot='global-nav-primary'], [slot='post-login']) {
     @include media.only(mobile) {
       @include interactive-elements {
-        padding: 0.625rem;
+        padding: 10px;
       }
     }
   }
@@ -73,16 +73,16 @@ post-header {
     &:where(ul) {
       @include media.only(tablet) {
         flex-direction: row;
-        margin-block: 1rem;
+        margin-block: 16px;
       }
 
       @include media.only(mobile) {
-        gap: 0.5rem;
+        gap: 8px;
       }
     }
 
     @include interactive-elements {
-      padding-inline: 1rem;
+      padding-inline: 16px;
     }
   }
 
@@ -109,11 +109,11 @@ post-header {
     grid-area: title;
     flex-grow: 1;
     margin: 0;
-    font-size: 1.25rem;
+    font-size: 20px;
     font-weight: 950;
 
     @include media.only(desktop) {
-      font-size: 1.75rem;
+      font-size: 28px;
       line-height: 34px;
     }
   }
@@ -132,13 +132,13 @@ post-header {
 
       @include media.only(mobile) {
         @include nav-item-icon-only;
-        padding: 0.625rem;
+        padding: 10px;
       }
     }
   }
 
   .local-login {
-    margin-block: -0.25rem;
+    margin-block: -4px;
   }
 
   // language menu

--- a/packages/styles/src/components/header/_post-header.scss
+++ b/packages/styles/src/components/header/_post-header.scss
@@ -109,11 +109,11 @@ post-header {
     grid-area: title;
     flex-grow: 1;
     margin: 0;
-    font-size: 20px;
+    font-size: 1.25rem;
     font-weight: 950;
 
     @include media.only(desktop) {
-      font-size: 28px;
+      font-size: 1.75rem;
       line-height: 34px;
     }
   }

--- a/packages/styles/src/components/header/_post-megadropdown.scss
+++ b/packages/styles/src/components/header/_post-megadropdown.scss
@@ -37,7 +37,7 @@ post-megadropdown {
     --post-nav-item-border-width: 2px;
 
     @include media.only(desktop) {
-      font-size: 20px;
+      font-size: 1.25rem;
     }
 
     &:not(#{$interactive-elements-selector}) {
@@ -49,7 +49,7 @@ post-megadropdown {
     margin-block: 0 16px;
 
     @include media.only(desktop) {
-      font-size: 20px;
+      font-size: 1.25rem;
     }
 
     &:first-child {

--- a/packages/styles/src/components/header/_post-megadropdown.scss
+++ b/packages/styles/src/components/header/_post-megadropdown.scss
@@ -37,7 +37,7 @@ post-megadropdown {
     --post-nav-item-border-width: 2px;
 
     @include media.only(desktop) {
-      font-size: 1.25rem;
+      font-size: 20px;
     }
 
     &:not(#{$interactive-elements-selector}) {
@@ -46,14 +46,14 @@ post-megadropdown {
   }
 
   .post-megadropdown-overview {
-    margin-block: 0 1rem;
+    margin-block: 0 16px;
 
     @include media.only(desktop) {
-      font-size: 1.25rem;
+      font-size: 20px;
     }
 
     &:first-child {
-      margin-block-start: -0.5rem;
+      margin-block-start: -8px;
     }
   }
 


### PR DESCRIPTION
## 📄 Description

This PR replaces all rem values by px values in the header so it is easier to align with Figma.

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
