### PR TITLE
chore(angular): remove `provideAnimationsAsync` usage from angular integration app

### DIFF
--- a/apps/integration-angular/src/app/app.config.ts
+++ b/apps/integration-angular/src/app/app.config.ts
@@ -4,8 +4,6 @@ import { providePostComponents } from '@swisspost/design-system-components-angul
 import { providePrimeNG } from 'primeng/config';
 import { swissPostPreset } from '@swisspost/design-system-styles-primeng';
 
-
-
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
   {

--- a/apps/integration-angular/src/app/app.config.ts
+++ b/apps/integration-angular/src/app/app.config.ts
@@ -4,8 +4,7 @@ import { providePostComponents } from '@swisspost/design-system-components-angul
 import { providePrimeNG } from 'primeng/config';
 import { swissPostPreset } from '@swisspost/design-system-styles-primeng';
 
-// Remove once PrimeNG migrates away from AnimationBuilder (Angular v23 removal)
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+
 
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -26,6 +25,5 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     providePostComponents(),
     providePrimeNG({ theme: { preset: swissPostPreset } }),
-    provideAnimationsAsync(),
   ],
 };


### PR DESCRIPTION
## 📄 Description

This PR removes the usage of `provideAnimationsAsync` from the Angular app and eliminates the dependency on `@angular/animations` that was only required for it. (Tested Primeng and seems to work fine without it.)

This also fixes the E2E failure introduced by pnpm 11 update, which no longer installs the optional peer dependency providing `@angular/animations/browser`.

Tested this PR by merging it to the [failing one](https://github.com/swisspost/design-system/pull/8220) and now it passes.

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
