### PR TITLE
chore(components): add `word-break` mixin to side navigation items

### DIFF
--- a/.changeset/bright-ways-study.md
+++ b/.changeset/bright-ways-study.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-components': patch
+---
+
+Enabled word-break for the side navigation labels.

--- a/packages/components/src/styles/components/post-side-navigation.scss
+++ b/packages/components/src/styles/components/post-side-navigation.scss
@@ -211,7 +211,9 @@ post-side-navigation {
   text-align: start;
   text-decoration: none;
   appearance: none;
-
+  
+  @include utilities.word-break;
+  
   // Split link and button
   &:has(a):has(button) {
     padding-inline-start: 0;


### PR DESCRIPTION
## 📄 Description

This PR fixes the issue of very long words being cut in the side navigation. Currently, any additional text will wrap but the individual words dont break and overflowing chars get hidden.

<img width="331" height="572" alt="image" src="https://github.com/user-attachments/assets/e5498fc1-eb7e-4597-ac34-a84f31d7d8d6" />


## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
