### PR TITLE
fix(styles): distinguish completed stepper items

### DIFF
--- a/.changeset/tidy-steppers-finish.md
+++ b/.changeset/tidy-steppers-finish.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-styles': minor
+---
+
+Added an optional `.stepper-item-completed` class so completed steps remain visible when the current step changes.

--- a/packages/documentation/cypress/snapshots/components/stepper.snapshot.ts
+++ b/packages/documentation/cypress/snapshots/components/stepper.snapshot.ts
@@ -2,6 +2,14 @@ describe('Stepper', () => {
   it('default', () => {
     cy.visit('/iframe.html?id=snapshots--stepper');
     cy.get('.stepper', { timeout: 30000 }).should('be.visible');
+    cy.get(".stepper-item-completed[aria-current='step'] > .stepper-link").should($links => {
+      expect($links.length).to.be.greaterThan(0);
+
+      $links.each((_, link) => {
+        expect(getComputedStyle(link, '::before').color).to.equal('rgba(0, 0, 0, 0)');
+        expect(getComputedStyle(link, '::after').maskImage).not.to.equal('none');
+      });
+    });
     cy.percySnapshot('Steppers', { widths: [320, 1440] });
   });
 });

--- a/packages/documentation/src/stories/components/stepper/stepper.docs.mdx
+++ b/packages/documentation/src/stories/components/stepper/stepper.docs.mdx
@@ -38,6 +38,12 @@ import * as StepperStories from './stepper.stories';
 
 ## Examples
 
+### Completed and current step
+
+Add the `.stepper-item-completed` class to every completed `.stepper-item`. Completion is independent of the current step, which continues to use `aria-current="step"`. If a user returns to a completed step, apply both states to show its checkmark while preserving the current-step semantics for assistive technologies.
+
+<Canvas of={StepperStories.CompletedCurrentStep} />
+
 ### Navigational Stepper
 
 You can use a stepper to allow users to navigate to specific steps.

--- a/packages/documentation/src/stories/components/stepper/stepper.stories.ts
+++ b/packages/documentation/src/stories/components/stepper/stepper.stories.ts
@@ -23,6 +23,7 @@ const meta: MetaComponent = {
   },
   args: {
     currentStepNumber: 3,
+    lastCompletedStepNumber: 2,
     navigatableSteps: 'all',
     processName: 'Registration Form',
     steps: defaultSteps,
@@ -55,6 +56,18 @@ const meta: MetaComponent = {
         category: 'General',
       },
     },
+    lastCompletedStepNumber: {
+      name: 'Last Completed Step Number',
+      description:
+        'The number of the last completed step, tracked independently from the current step.',
+      control: {
+        type: 'select',
+      },
+      options: [0, ...Object.keys(defaultSteps).map(key => parseInt(key, 10) + 1)],
+      table: {
+        category: 'General',
+      },
+    },
     processName: {
       name: 'Process Name',
       description:
@@ -78,22 +91,25 @@ function getStepperItem(
   updateStep: (newStep: number, event: Event) => void,
 ) {
   const currentStepIndex = args.currentStepNumber - 1;
-  const isCompletedStep = index < currentStepIndex;
+  const isCompletedStep = index < args.lastCompletedStepNumber;
   const isCurrentStep = index === currentStepIndex;
-  const isNextStep = index > currentStepIndex;
+  const isNextStep = !isCompletedStep && !isCurrentStep;
   const isLink =
-    (isCompletedStep && args.navigatableSteps !== 'none') ||
-    (isNextStep && args.navigatableSteps === 'all');
+    !isCurrentStep &&
+    ((isCompletedStep && args.navigatableSteps !== 'none') ||
+      (isNextStep && args.navigatableSteps === 'all'));
 
-  let status = 'Current';
-  if (isCompletedStep) status = 'Completed';
-  if (isNextStep) status = 'Next';
+  let status = isCompletedStep ? 'Completed' : 'Next';
+  if (isCurrentStep) status = isCompletedStep ? 'Completed current' : 'Current';
 
   const text = html`<span class="visually-hidden">${status} step:</span> ${step}`;
   const title = step !== defaultSteps[index] ? step : undefined;
 
   return html`
-    <li aria-current=${ifDefined(isCurrentStep ? 'step' : undefined)} class="stepper-item">
+    <li
+      aria-current=${ifDefined(isCurrentStep ? 'step' : undefined)}
+      class="stepper-item${isCompletedStep ? ' stepper-item-completed' : ''}"
+    >
       ${isLink
         ? html`
             <a
@@ -148,6 +164,13 @@ export const NavigationalStepper: StoryObj = {
 export const InformationalStepper: StoryObj = {
   args: {
     navigatableSteps: 'none',
+  },
+};
+
+export const CompletedCurrentStep: StoryObj = {
+  args: {
+    currentStepNumber: 2,
+    lastCompletedStepNumber: 3,
   },
 };
 

--- a/packages/styles/src/components/stepper.scss
+++ b/packages/styles/src/components/stepper.scss
@@ -74,10 +74,12 @@
     }
   }
 
-  // current and completed steps are preceded by a yellow segment (except for the first step)
+  // Explicitly completed steps fill both adjacent segments. The aria-current selectors preserve
+  // the legacy behavior that infers completed steps from their position before the current step.
+  &.stepper-item-completed::before,
+  &.stepper-item-completed::after,
   &:not(&[aria-current='step'] ~ *, :first-child)::before,
-  // steps that are not the current step or preceded by a current step are followed by a yellow segment
-    &:not([aria-current='step'], .stepper-item[aria-current='step'] ~ *)::after {
+  &:not([aria-current='step'], .stepper-item[aria-current='step'] ~ *)::after {
     background-color: stepper.$stepper-bar-fill-color;
     z-index: 1;
   }
@@ -148,13 +150,15 @@
     margin-inline-start: auto;
   }
 
-  .stepper-item:not([aria-current='step'], .stepper-item[aria-current='step'] ~ *) > & {
-    color: transparent;
-  }
-
   .stepper-item[aria-current='step'] ~ .stepper-item > & {
     color: stepper.$stepper-indicator-future-color;
     background-color: stepper.$stepper-indicator-future-bg;
+  }
+
+  .stepper-item.stepper-item-completed > &,
+  .stepper-item:not([aria-current='step'], .stepper-item[aria-current='step'] ~ *) > & {
+    color: transparent;
+    background-color: stepper.$stepper-indicator-bg;
   }
 }
 
@@ -189,6 +193,7 @@
   }
 
   // show only for completed steps
+  .stepper-item.stepper-item-completed > &,
   .stepper-item:not([aria-current='step'], .stepper-item[aria-current='step'] ~ *) > & {
     content: '';
   }
@@ -301,6 +306,8 @@
       background-color: CanvasText;
     }
 
+    &.stepper-item-completed::before,
+    &.stepper-item-completed::after,
     &:not(&[aria-current='step'] ~ &, :first-child)::before,
     &:not([aria-current='step']:not(:last-child), &[aria-current='step'] ~ *)::after {
       background-color: Highlight;
@@ -323,6 +330,14 @@
     .stepper-item:not([aria-current='step']) > & {
       &::before {
         color: Canvas;
+        border-color: Canvas;
+        background-color: CanvasText;
+      }
+    }
+
+    .stepper-item.stepper-item-completed > & {
+      &::before {
+        color: transparent;
         border-color: Canvas;
         background-color: CanvasText;
       }


### PR DESCRIPTION
## Summary

- add the optional `.stepper-item-completed` state while preserving the existing `aria-current`-based behavior
- render a checkmark for steps that are both completed and current, including forced-colors styling
- document the independent completed/current states in Storybook and add focused snapshot assertions

## Validation

- `pnpm styles:test`
- `pnpm styles:lint`
- `pnpm --filter design-system-styles... build`
- `pnpm --filter design-system-documentation... build`
- Prettier and ESLint checks for the changed files

Fixes #8383