### PR TITLE
Fix: <post-icon> page in Storybook throws error for missing name prop whenever any prop is changed

### DIFF
--- a/.changeset/eight-clocks-create.md
+++ b/.changeset/eight-clocks-create.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Filter `null` and `undefined` from attributes to be removed

--- a/.changeset/eight-clocks-create.md
+++ b/.changeset/eight-clocks-create.md
@@ -2,4 +2,4 @@
 '@swisspost/design-system-documentation': patch
 ---
 
-Filter `null` and `undefined` from attributes to be removed
+Prevent unchanged Storybook attributes from being temporarily removed when controls update.

--- a/apps/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
+++ b/apps/documentation/src/stories/foundations/icons/search/search-icons.blocks.tsx
@@ -491,7 +491,7 @@ export class Search extends React.Component {
       <div className="container" data-iconset={this.form.set.current}>
         <div className="search-form">{this.searchForm()}</div>
         <div className="search-results">
-          <a href="#results-top" aria-hidden="true" tabindex="-1"></a>
+          <a href="#results-top" aria-hidden="true" tabIndex={-1}></a>
           {this.paging()}
           {this.resultsList()}
           {this.paging()}

--- a/apps/documentation/src/utils/spread-args.ts
+++ b/apps/documentation/src/utils/spread-args.ts
@@ -42,13 +42,6 @@ export class SpreadArgsDirective<T extends HTMLElement> extends AsyncDirective {
     });
 
     // remove previously set attributes
-    // console.log('prevAttrs', this.prevAttrs);
-    // console.log('attrs', attrs);
-    // console.log('all keys', Object.keys(this.prevAttrs));
-    // console.log(
-    //   'filter attrs with key',
-    //   Object.keys(this.prevAttrs).filter(key => attrs[key]),
-    // );
     Object.keys(this.prevAttrs)
       .filter(attrKey => attrs[attrKey] === null || attrs[attrKey] === undefined)
       .forEach(attrKey => element.removeAttribute(attrKey));

--- a/apps/documentation/src/utils/spread-args.ts
+++ b/apps/documentation/src/utils/spread-args.ts
@@ -42,7 +42,16 @@ export class SpreadArgsDirective<T extends HTMLElement> extends AsyncDirective {
     });
 
     // remove previously set attributes
-    Object.keys(this.prevAttrs).forEach(attrKey => element.removeAttribute(attrKey));
+    // console.log('prevAttrs', this.prevAttrs);
+    // console.log('attrs', attrs);
+    // console.log('all keys', Object.keys(this.prevAttrs));
+    // console.log(
+    //   'filter attrs with key',
+    //   Object.keys(this.prevAttrs).filter(key => attrs[key]),
+    // );
+    Object.keys(this.prevAttrs)
+      .filter(attrKey => attrs[attrKey] === null || attrs[attrKey] === undefined)
+      .forEach(attrKey => element.removeAttribute(attrKey));
 
     // set new attributes
     Object.entries(attrs)


### PR DESCRIPTION
## 📄 Description

Fixed missing name prop, when changing prop. Filtered `null` and `undefined` values

## 🚀 Demo

If applicable, please add a screenshot or video to illustrate the changes

<img width="1920" height="1080" alt="screen-capture (1)" src="https://github.com/user-attachments/assets/a944554f-a297-47f8-8b4c-a1d6349f2ef2" />

---

## 🔮 Design review

- [ ] Design review done
- [ ] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes

Closes #6369 