### PR TITLE
chore(workflow): add step in the release workflow to check if all packages exist on npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,12 @@ jobs:
       - name: Test publish step
         run: pnpm -r publish --dry-run
 
+      - name: Check release packages exist on npm
+        run: |
+          trap 'rm -f changesets.json' EXIT
+          pnpm changeset status --output=changesets.json
+          node .github/workflows/scripts/check-packages-on-npm.mjs
+
       # The changeset action will behave differently based on whether there are
       # new changesets on the github.ref branch:
       #

--- a/.github/workflows/scripts/check-packages-on-npm.mjs
+++ b/.github/workflows/scripts/check-packages-on-npm.mjs
@@ -1,0 +1,34 @@
+// This script checks if the packages about to be released are available on npm
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+
+// Read the changesets.json file and parse it into an object
+const changesets = JSON.parse(fs.readFileSync('changesets.json', 'utf8'));
+
+// Get the list of releases from the changesets object
+const releases = changesets.releases ?? [];
+const missingPackages = [];
+
+// Check if each package exists on npm and log an error for the missing ones
+for (const release of releases) {
+  try {
+    execFileSync('pnpm', ['view', release.name, '--registry=https://registry.npmjs.org'], {
+      stdio: 'ignore',
+    });
+
+    console.log(`Package exists on npm: ${release.name}`);
+  } catch {
+    missingPackages.push(release.name);
+  }
+}
+
+if (missingPackages.length > 0) {
+  for (const packageName of missingPackages) {
+    console.error(
+      `::error::Package ${packageName} does not exist on npmjs.org. Create it manually and configure trusted publishing before releasing.`,
+    );
+  }
+
+  process.exit(1);
+}


### PR DESCRIPTION
## 📄 Description

Added a step  in the release workflow (after dry-run) that creates the `changesets.json` and runs a script that checks if each included package already exists on npm. Tested locally with a fake `changesets.json`.

---

## 🔮 Design review

- [ ] Design review done
- [x] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
