### PR TITLE
fix(klp): use env specific URLs for subscribe call

### DIFF
--- a/.changeset/honest-wombats-pull.md
+++ b/.changeset/honest-wombats-pull.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/design-system-documentation': patch
+---
+
+Updated sample script for self-managed header implementations on which URLs to use when testing on int.

--- a/.changeset/mighty-wings-shave.md
+++ b/.changeset/mighty-wings-shave.md
@@ -1,0 +1,5 @@
+---
+'@swisspost/internet-header': patch
+---
+
+Updated URL mapping for KLP subscribe calls for different environments. Testing on int should no longer cause CORS issues.

--- a/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
@@ -1,5 +1,5 @@
 // Import the KLP URL configuration from the internet-header package
-import { KLP_BASE_URLS, getSessionUrl } from '@swisspost/internet-header/config/klp-urls';
+import { getSessionUrl } from '@swisspost/internet-header/config/klp-urls';
 
 // Get the appropriate URL based on your environment
 const environment = 'prod'; // Change to your environment (int01, int02, etc.)

--- a/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
@@ -1,4 +1,19 @@
-const response = await fetch('https://n.account.post.ch/v1/session/subscribe', {
+// Map environments to their corresponding KLP base URLs
+const KLP_BASE_URLS = {
+  dev01: 'https://n.accountint1.post.ch',
+  dev02: 'https://n.accountint1.post.ch',
+  devs1: 'https://n.accountint1.post.ch',
+  test: 'https://n.accountint1.post.ch',
+  int01: 'https://n.accountint1.post.ch',
+  int02: 'https://n.accountint2.post.ch',
+  prod: 'https://n.account.post.ch',
+};
+
+// Get the appropriate URL based on your environment
+const environment = 'prod'; // Change to your environment (int01, int02, etc.)
+const sessionUrl = `${KLP_BASE_URLS[environment]}/v1/session/subscribe`;
+
+const response = await fetch(sessionUrl, {
   credentials: 'include',
 });
 const json = await response.json();

--- a/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
@@ -1,9 +1,20 @@
-// Import the KLP URL configuration from the internet-header package
-import { getSessionUrl } from '@swisspost/internet-header/config/klp-urls';
+const KLP_SESSION_ENDPOINT = '/v1/session/subscribe';
+const KLP_BASE_URLS = {
+  dev01: 'https://n.accountint1.post.ch',
+  dev02: 'https://n.accountint1.post.ch',
+  devs1: 'https://n.accountint1.post.ch',
+  test: 'https://n.accountint1.post.ch',
+  int01: 'https://n.accountint1.post.ch',
+  int02: 'https://n.accountint2.post.ch',
+  prod: 'https://n.account.post.ch',
+} as const;
+
+const getSessionUrl = (environment: keyof typeof KLP_BASE_URLS): string =>
+  `${KLP_BASE_URLS[environment]}${KLP_SESSION_ENDPOINT}`;
 
 // Get the appropriate URL based on your environment
 const environment = 'prod'; // Change to your environment (int01, int02, etc.)
-const sessionUrl = getSessionUrl(environment as any);
+const sessionUrl = getSessionUrl(environment);
 
 const response = await fetch(sessionUrl, {
   credentials: 'include',

--- a/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
+++ b/apps/documentation/src/stories/components/header/self-managed/session-subscription.sample.ts
@@ -1,17 +1,9 @@
-// Map environments to their corresponding KLP base URLs
-const KLP_BASE_URLS = {
-  dev01: 'https://n.accountint1.post.ch',
-  dev02: 'https://n.accountint1.post.ch',
-  devs1: 'https://n.accountint1.post.ch',
-  test: 'https://n.accountint1.post.ch',
-  int01: 'https://n.accountint1.post.ch',
-  int02: 'https://n.accountint2.post.ch',
-  prod: 'https://n.account.post.ch',
-};
+// Import the KLP URL configuration from the internet-header package
+import { KLP_BASE_URLS, getSessionUrl } from '@swisspost/internet-header/config/klp-urls';
 
 // Get the appropriate URL based on your environment
 const environment = 'prod'; // Change to your environment (int01, int02, etc.)
-const sessionUrl = `${KLP_BASE_URLS[environment]}/v1/session/subscribe`;
+const sessionUrl = getSessionUrl(environment as any);
 
 const response = await fetch(sessionUrl, {
   credentials: 'include',

--- a/packages/internet-header/src/components/post-internet-header/post-internet-header.spec.ts
+++ b/packages/internet-header/src/components/post-internet-header/post-internet-header.spec.ts
@@ -1,23 +1,5 @@
 import { Environment } from '@/models/general.model';
-
-// Define the KLP URL mapping constants the same way they are in the component
-const KLP_SESSION_ENDPOINT = '/v1/session/subscribe';
-
-const KLP_BASE_URLS: Record<Environment, string> = {
-  dev01: 'https://n.accountint1.post.ch',
-  dev02: 'https://n.accountint1.post.ch',
-  devs1: 'https://n.accountint1.post.ch',
-  test: 'https://n.accountint1.post.ch',
-  int01: 'https://n.accountint1.post.ch',
-  int02: 'https://n.accountint2.post.ch',
-  prod: 'https://n.account.post.ch',
-};
-
-// Helper function to get session URL (same logic as component)
-const getSessionUrl = (environment: Environment): string => {
-  const baseUrl = KLP_BASE_URLS[environment];
-  return `${baseUrl}${KLP_SESSION_ENDPOINT}`;
-};
+import { KLP_BASE_URLS, KLP_SESSION_ENDPOINT, getSessionUrl } from '@/config/klp-urls';
 
 describe('KLP Session URL Configuration', () => {
   // Mock fetch globally

--- a/packages/internet-header/src/components/post-internet-header/post-internet-header.spec.ts
+++ b/packages/internet-header/src/components/post-internet-header/post-internet-header.spec.ts
@@ -85,48 +85,26 @@ describe('KLP Session URL Configuration', () => {
   });
 
   describe('Fetch call verification with URLs', () => {
-    it('should call fetch with prod URL when environment is prod', async () => {
-      const mockFetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ data: {} }),
-      });
-      global.fetch = mockFetch;
+    const fetchCallTestCases: Array<[Environment, string]> = [
+      ['prod', 'https://n.account.post.ch/v1/session/subscribe'],
+      ['int02', 'https://n.accountint2.post.ch/v1/session/subscribe'],
+      ['int01', 'https://n.accountint1.post.ch/v1/session/subscribe'],
+    ];
 
-      const url = getSessionUrl('prod');
-      await mockFetch(url, { credentials: 'include' });
+    fetchCallTestCases.forEach(([environment, expectedUrl]) => {
+      it(`should call fetch with ${environment} URL when environment is ${environment}`, async () => {
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ data: {} }),
+        });
+        global.fetch = mockFetch;
 
-      expect(mockFetch).toHaveBeenCalledWith('https://n.account.post.ch/v1/session/subscribe', {
-        credentials: 'include',
-      });
-    });
+        const url = getSessionUrl(environment);
+        await mockFetch(url, { credentials: 'include' });
 
-    it('should call fetch with int02 URL when environment is int02', async () => {
-      const mockFetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ data: {} }),
-      });
-      global.fetch = mockFetch;
-
-      const url = getSessionUrl('int02');
-      await mockFetch(url, { credentials: 'include' });
-
-      expect(mockFetch).toHaveBeenCalledWith('https://n.accountint2.post.ch/v1/session/subscribe', {
-        credentials: 'include',
-      });
-    });
-
-    it('should call fetch with int01 URL when environment is int01', async () => {
-      const mockFetch = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({ data: {} }),
-      });
-      global.fetch = mockFetch;
-
-      const url = getSessionUrl('int01');
-      await mockFetch(url, { credentials: 'include' });
-
-      expect(mockFetch).toHaveBeenCalledWith('https://n.accountint1.post.ch/v1/session/subscribe', {
-        credentials: 'include',
+        expect(mockFetch).toHaveBeenCalledWith(expectedUrl, {
+          credentials: 'include',
+        });
       });
     });
   });
@@ -149,15 +127,7 @@ describe('KLP Session URL Configuration', () => {
   });
 
   describe('URL format validation', () => {
-    const testCases: Environment[] = [
-      'prod',
-      'int02',
-      'int01',
-      'test',
-      'devs1',
-      'dev02',
-      'dev01',
-    ];
+    const testCases: Environment[] = ['prod', 'int02', 'int01', 'test', 'devs1', 'dev02', 'dev01'];
 
     testCases.forEach(environment => {
       it(`should generate valid URL for ${environment}`, () => {
@@ -179,4 +149,3 @@ describe('KLP Session URL Configuration', () => {
     });
   });
 });
-

--- a/packages/internet-header/src/components/post-internet-header/post-internet-header.spec.ts
+++ b/packages/internet-header/src/components/post-internet-header/post-internet-header.spec.ts
@@ -1,0 +1,200 @@
+import { Environment } from '@/models/general.model';
+
+// Define the KLP URL mapping constants the same way they are in the component
+const KLP_SESSION_ENDPOINT = '/v1/session/subscribe';
+
+const KLP_BASE_URLS: Record<Environment, string> = {
+  dev01: 'https://n.accountint1.post.ch',
+  dev02: 'https://n.accountint1.post.ch',
+  devs1: 'https://n.accountint1.post.ch',
+  test: 'https://n.accountint1.post.ch',
+  int01: 'https://n.accountint1.post.ch',
+  int02: 'https://n.accountint2.post.ch',
+  prod: 'https://n.account.post.ch',
+};
+
+// Helper function to get session URL (same logic as component)
+const getSessionUrl = (environment: Environment): string => {
+  const baseUrl = KLP_BASE_URLS[environment];
+  return `${baseUrl}${KLP_SESSION_ENDPOINT}`;
+};
+
+describe('KLP Session URL Configuration', () => {
+  // Mock fetch globally
+  global.fetch = jest.fn();
+
+  beforeEach(() => {
+    (fetch as jest.Mock).mockClear();
+    (fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: { name: 'Test User', email: 'test@example.com' } }),
+    });
+  });
+
+  describe('getSessionUrl - URL construction for all environments', () => {
+    const testCases: Array<[Environment, string]> = [
+      ['prod', 'https://n.account.post.ch/v1/session/subscribe'],
+      ['int02', 'https://n.accountint2.post.ch/v1/session/subscribe'],
+      ['int01', 'https://n.accountint1.post.ch/v1/session/subscribe'],
+      ['test', 'https://n.accountint1.post.ch/v1/session/subscribe'],
+      ['devs1', 'https://n.accountint1.post.ch/v1/session/subscribe'],
+      ['dev02', 'https://n.accountint1.post.ch/v1/session/subscribe'],
+      ['dev01', 'https://n.accountint1.post.ch/v1/session/subscribe'],
+    ];
+
+    testCases.forEach(([environment, expectedUrl]) => {
+      it(`should construct correct URL for ${environment} environment`, () => {
+        const sessionUrl = getSessionUrl(environment);
+        expect(sessionUrl).toBe(expectedUrl);
+      });
+    });
+  });
+
+  describe('KLP Base URL Mapping', () => {
+    it('should have entries for all environment types', () => {
+      const expectedEnvironments: Environment[] = [
+        'prod',
+        'int02',
+        'int01',
+        'test',
+        'devs1',
+        'dev02',
+        'dev01',
+      ];
+
+      expectedEnvironments.forEach(env => {
+        expect(KLP_BASE_URLS[env]).toBeDefined();
+        expect(typeof KLP_BASE_URLS[env]).toBe('string');
+        expect(KLP_BASE_URLS[env]).toMatch(/^https:\/\/n\.account/);
+      });
+    });
+
+    it('should map development environments to int1 endpoint', () => {
+      const devEnvironments: Environment[] = ['dev01', 'dev02', 'devs1', 'test'];
+
+      devEnvironments.forEach(env => {
+        expect(KLP_BASE_URLS[env]).toBe('https://n.accountint1.post.ch');
+      });
+    });
+
+    it('should map int01 to int1 endpoint', () => {
+      expect(KLP_BASE_URLS['int01']).toBe('https://n.accountint1.post.ch');
+    });
+
+    it('should map int02 to int2 endpoint', () => {
+      expect(KLP_BASE_URLS['int02']).toBe('https://n.accountint2.post.ch');
+    });
+
+    it('should map prod to production endpoint', () => {
+      expect(KLP_BASE_URLS['prod']).toBe('https://n.account.post.ch');
+    });
+  });
+
+  describe('Session endpoint consistency', () => {
+    it('should use correct endpoint path', () => {
+      expect(KLP_SESSION_ENDPOINT).toBe('/v1/session/subscribe');
+    });
+
+    it('should construct full URL by combining base URL and endpoint', () => {
+      const baseUrl = 'https://n.accountint2.post.ch';
+      const fullUrl = `${baseUrl}${KLP_SESSION_ENDPOINT}`;
+      expect(fullUrl).toBe('https://n.accountint2.post.ch/v1/session/subscribe');
+    });
+  });
+
+  describe('Fetch call verification with URLs', () => {
+    it('should call fetch with prod URL when environment is prod', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+      global.fetch = mockFetch;
+
+      const url = getSessionUrl('prod');
+      await mockFetch(url, { credentials: 'include' });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://n.account.post.ch/v1/session/subscribe', {
+        credentials: 'include',
+      });
+    });
+
+    it('should call fetch with int02 URL when environment is int02', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+      global.fetch = mockFetch;
+
+      const url = getSessionUrl('int02');
+      await mockFetch(url, { credentials: 'include' });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://n.accountint2.post.ch/v1/session/subscribe', {
+        credentials: 'include',
+      });
+    });
+
+    it('should call fetch with int01 URL when environment is int01', async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+      global.fetch = mockFetch;
+
+      const url = getSessionUrl('int01');
+      await mockFetch(url, { credentials: 'include' });
+
+      expect(mockFetch).toHaveBeenCalledWith('https://n.accountint1.post.ch/v1/session/subscribe', {
+        credentials: 'include',
+      });
+    });
+  });
+
+  describe('CORS handling for different environments', () => {
+    it('should use correct domain for CORS policy in prod', () => {
+      const url = getSessionUrl('prod');
+      expect(url).toContain('https://n.account.post.ch');
+    });
+
+    it('should use correct domain for CORS policy in int2', () => {
+      const url = getSessionUrl('int02');
+      expect(url).toContain('https://n.accountint2.post.ch');
+    });
+
+    it('should use correct domain for CORS policy in int1', () => {
+      const url = getSessionUrl('int01');
+      expect(url).toContain('https://n.accountint1.post.ch');
+    });
+  });
+
+  describe('URL format validation', () => {
+    const testCases: Environment[] = [
+      'prod',
+      'int02',
+      'int01',
+      'test',
+      'devs1',
+      'dev02',
+      'dev01',
+    ];
+
+    testCases.forEach(environment => {
+      it(`should generate valid URL for ${environment}`, () => {
+        const url = getSessionUrl(environment);
+
+        // URL should be valid
+        expect(() => new URL(url)).not.toThrow();
+
+        // URL should have correct protocol
+        expect(url).toMatch(/^https:\/\//);
+
+        // URL should contain the session endpoint
+        expect(url).toContain('/v1/session/subscribe');
+
+        // URL should not have query parameters or fragments in the base
+        expect(url).not.toContain('?');
+        expect(url).not.toContain('#');
+      });
+    });
+  });
+});
+

--- a/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
+++ b/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
@@ -19,7 +19,17 @@ import {
 } from '@stencil/core';
 import '@swisspost/design-system-components';
 
-const SESSION_URL = 'https://n.account.post.ch/v1/session/subscribe';
+const KLP_SESSION_ENDPOINT = '/v1/session/subscribe';
+
+const KLP_BASE_URLS: Record<Environment, string> = {
+  dev01: 'https://n.accountint1.post.ch',
+  dev02: 'https://n.accountint1.post.ch',
+  devs1: 'https://n.accountint1.post.ch',
+  test: 'https://n.accountint1.post.ch',
+  int01: 'https://n.accountint1.post.ch',
+  int02: 'https://n.accountint2.post.ch',
+  prod: 'https://n.account.post.ch',
+};
 
 @Component({
   tag: 'swisspost-internet-header',
@@ -177,7 +187,8 @@ export class PostInternetHeader {
 
   private async fetchUserData(): Promise<void> {
     try {
-      const response = await fetch(SESSION_URL, {
+      const sessionUrl = this.getSessionUrl();
+      const response = await fetch(sessionUrl, {
         credentials: 'include',
       });
 
@@ -188,6 +199,11 @@ export class PostInternetHeader {
     } catch {
       // In case of an error, we assume the user is not logged in and do nothing
     }
+  }
+
+  private getSessionUrl(): string {
+    const baseUrl = KLP_BASE_URLS[this.environment];
+    return `${baseUrl}${KLP_SESSION_ENDPOINT}`;
   }
 
   // Fetch and store the localized config, defaulting to the `language` prop if none is passed

--- a/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
+++ b/packages/internet-header/src/components/post-internet-header/post-internet-header.tsx
@@ -6,6 +6,7 @@ import { IconLinkConfig, LinkConfig } from '@/models/shared.model';
 import { getAlternateLinks, observeAlternateLinks } from '@/services/alternate-link.service';
 import { getLocalizedConfig, isValidProjectId } from '@/services/config.service';
 import { getActiveLink } from '@/services/route.service';
+import { getSessionUrl } from '@/config/klp-urls';
 import { version } from '@root/package.json';
 import {
   Component,
@@ -18,18 +19,6 @@ import {
   Watch,
 } from '@stencil/core';
 import '@swisspost/design-system-components';
-
-const KLP_SESSION_ENDPOINT = '/v1/session/subscribe';
-
-const KLP_BASE_URLS: Record<Environment, string> = {
-  dev01: 'https://n.accountint1.post.ch',
-  dev02: 'https://n.accountint1.post.ch',
-  devs1: 'https://n.accountint1.post.ch',
-  test: 'https://n.accountint1.post.ch',
-  int01: 'https://n.accountint1.post.ch',
-  int02: 'https://n.accountint2.post.ch',
-  prod: 'https://n.account.post.ch',
-};
 
 @Component({
   tag: 'swisspost-internet-header',
@@ -187,7 +176,7 @@ export class PostInternetHeader {
 
   private async fetchUserData(): Promise<void> {
     try {
-      const sessionUrl = this.getSessionUrl();
+      const sessionUrl = getSessionUrl(this.environment);
       const response = await fetch(sessionUrl, {
         credentials: 'include',
       });
@@ -199,11 +188,6 @@ export class PostInternetHeader {
     } catch {
       // In case of an error, we assume the user is not logged in and do nothing
     }
-  }
-
-  private getSessionUrl(): string {
-    const baseUrl = KLP_BASE_URLS[this.environment];
-    return `${baseUrl}${KLP_SESSION_ENDPOINT}`;
   }
 
   // Fetch and store the localized config, defaulting to the `language` prop if none is passed

--- a/packages/internet-header/src/config/klp-urls.ts
+++ b/packages/internet-header/src/config/klp-urls.ts
@@ -1,0 +1,37 @@
+import { Environment } from '@/models/general.model';
+
+/**
+ * KLP (Swiss Post Login) session API endpoint path
+ */
+export const KLP_SESSION_ENDPOINT = '/v1/session/subscribe';
+
+/**
+ * KLP base URL mapping for different environments
+ * Maps each environment to its corresponding KLP authentication service URL
+ *
+ * Environment | Base URL
+ * -- | --
+ * PROD | https://n.account.post.ch
+ * INT2 | https://n.accountint2.post.ch
+ * INT1 | https://n.accountint1.post.ch
+ * dev01, dev02, devs1, test | https://n.accountint1.post.ch
+ */
+export const KLP_BASE_URLS: Record<Environment, string> = {
+  dev01: 'https://n.accountint1.post.ch',
+  dev02: 'https://n.accountint1.post.ch',
+  devs1: 'https://n.accountint1.post.ch',
+  test: 'https://n.accountint1.post.ch',
+  int01: 'https://n.accountint1.post.ch',
+  int02: 'https://n.accountint2.post.ch',
+  prod: 'https://n.account.post.ch',
+};
+
+/**
+ * Constructs the full session URL for a given environment
+ * @param environment - The target environment
+ * @returns The full KLP session subscription URL
+ */
+export const getSessionUrl = (environment: Environment): string => {
+  const baseUrl = KLP_BASE_URLS[environment];
+  return `${baseUrl}${KLP_SESSION_ENDPOINT}`;
+};


### PR DESCRIPTION
## 📄 Description

Updated URL mapping for KLP subscribe calls to take environment into account.

---

## 🔮 Design review

- [ ] Design review done
- [X] No design review needed

## 🧪 Visual regression tests

- [ ] Visual changes detected and approved _(Check this box if VRT fails and changes are intentional)_

## 📝 Checklist

- ✅ My code follows the style guidelines of this project
- 🛠️ I have performed a self-review of my own code
- 📄 I have made corresponding changes to the documentation
- ⚠️ My changes generate no new warnings or errors
- 🧪 I have added tests that prove my fix is effective or that my feature works
- ✔️ New and existing unit tests pass locally with my changes
