### PR TITLE
feat(appearance): add experimental condensed layout

### DIFF
--- a/apps/documentation/.storybook/addons/styles-switcher/StylesSwitcher.tsx
+++ b/apps/documentation/.storybook/addons/styles-switcher/StylesSwitcher.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { IconButton, WithTooltip } from 'storybook/internal/components';
 
 const THEMES = ['Post', 'Cargo'] as const;
-const APPEARANCE = ['Default', 'Compact'] as const;
+const APPEARANCE = ['Default', 'Compact', 'Condensed'] as const;
 const SCHEMES = ['Light', 'Dark'] as const;
 
 /*

--- a/apps/documentation/src/stories/packages/styles/styles.docs.mdx
+++ b/apps/documentation/src/stories/packages/styles/styles.docs.mdx
@@ -49,6 +49,11 @@ Import one of our stylesheets into your project (for example into your `/src/sty
         <td>everything for internal applications</td>
       </tr>
       <tr>
+        <td>`post-condensed`</td>
+        <td>`css`, `scss`</td>
+        <td>everything for applications with condensed spacing</td>
+      </tr>
+      <tr>
         <td>`basics`</td>
         <td>`css`, `scss`</td>
         <td>atomic styles for font, buttons, lists, etc. (no component styles)</td>

--- a/packages/styles/src/cargo-condensed.scss
+++ b/packages/styles/src/cargo-condensed.scss
@@ -1,0 +1,12 @@
+@use './tokens/schemes-static';
+@use './tokens/schemes';
+@use './tokens/device-condensed';
+@use './tokens/appearance-compact'; /* There is no condensed appearance yet */
+@use './tokens/cargo-theme';
+@use './tokens/palettes';
+@use './icons/signal-icons';
+@use './layout';
+@use './utilities';
+@use './elements';
+@use './components';
+@use './helpers';

--- a/packages/styles/src/post-condensed.scss
+++ b/packages/styles/src/post-condensed.scss
@@ -1,0 +1,12 @@
+@use './tokens/schemes-static';
+@use './tokens/schemes';
+@use './tokens/device-condensed';
+@use './tokens/appearance-compact'; /* There is no condensed appearance yet */
+@use './tokens/post-theme';
+@use './tokens/palettes';
+@use './icons/signal-icons';
+@use './layout';
+@use './utilities';
+@use './elements';
+@use './components';
+@use './helpers';

--- a/packages/styles/src/tokens/_device-condensed.scss
+++ b/packages/styles/src/tokens/_device-condensed.scss
@@ -1,0 +1,9 @@
+@use './temp/device' as device;
+
+@use './core';
+@use './../mixins/tokens';
+
+:root,
+[data-color-scheme] {
+  @include tokens.from(device.$post-mobile);
+}


### PR DESCRIPTION
This is an experimental PR for a condensed appearance. It works the same way as compact: it just renders mobile device tokens only with the effect, that every breakpoint just uses mobile tokens. Simple but effective.

The basic plan would be to release these entry files and label them as beta in the documentation. Applications already on v10 or ones migrating could use or switch to this and we'd get early feedback if we're on the right track here or if more specific styles are necessary. If tweaks can be done through the appearance layer without any other change, even better because we'd have a good basis and use the appearance layer only for the things that really matter.